### PR TITLE
Add cross-platform MarkdownCte + cross-platform CTE rendering test infrastructure

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Claude Code on the web SessionStart hook for winprint.
+#
+# Installs the toolchain a fresh remote (Linux) container needs to build
+# WinPrint.Core and run WinPrint.Core.UnitTests:
+#   - the .NET 10 SDK (not preinstalled in web sessions)
+#   - libgdiplus (System.Drawing.Common P/Invokes it; required by parts of the
+#     test suite — note the cross-platform CTE rendering tests do NOT need it)
+#   - the repo's local dotnet tools (JetBrains 'jb' for code-style checks)
+#   - a warm NuGet restore (cached into the container image after this runs)
+#
+# Idempotent and non-interactive. Runs only in remote sessions.
+set -euo pipefail
+
+# Only run in Claude Code on the web (remote) environments. Local machines
+# already have their own toolchain.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+DOTNET_DIR="$HOME/.dotnet"
+
+# 1. .NET 10 SDK ------------------------------------------------------------
+if ! "$DOTNET_DIR/dotnet" --version >/dev/null 2>&1 && ! command -v dotnet >/dev/null 2>&1; then
+  echo "[session-start] Installing .NET 10 SDK..."
+  curl -sSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh
+  bash /tmp/dotnet-install.sh --channel 10.0 --install-dir "$DOTNET_DIR"
+fi
+
+# Persist dotnet on PATH for the rest of the session.
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  echo "export PATH=\"$DOTNET_DIR:\$PATH\"" >> "$CLAUDE_ENV_FILE"
+  echo "export DOTNET_CLI_TELEMETRY_OPTOUT=1" >> "$CLAUDE_ENV_FILE"
+fi
+export PATH="$DOTNET_DIR:$PATH"
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+
+# 2. libgdiplus -------------------------------------------------------------
+# Best-effort: don't fail the whole session if the package can't be installed.
+if ! ldconfig -p 2>/dev/null | grep -q libgdiplus; then
+  echo "[session-start] Installing libgdiplus..."
+  if command -v apt-get >/dev/null 2>&1; then
+    (apt-get update -y && apt-get install -y libgdiplus) \
+      || (command -v sudo >/dev/null 2>&1 && sudo apt-get update -y && sudo apt-get install -y libgdiplus) \
+      || echo "[session-start] WARNING: could not install libgdiplus; some System.Drawing tests may fail."
+  fi
+fi
+
+# 3. Local dotnet tools (jb / ReSharper command line) -----------------------
+dotnet tool restore || echo "[session-start] WARNING: 'dotnet tool restore' failed; 'jb' style checks may be unavailable."
+
+# 4. Warm the NuGet restore cache -------------------------------------------
+dotnet restore src/WinPrint.Core/WinPrint.Core.csproj
+dotnet restore tests/WinPrint.Core.UnitTests/WinPrint.Core.UnitTests.csproj
+
+echo "[session-start] winprint web session ready: .NET $(dotnet --version)"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -27,6 +27,14 @@ dotnet_style_namespace_match_folder = false
 # IDE0160: Convert to block scoped namespace
 dotnet_diagnostic.IDE0160.severity = silent
 
+# IDE0005 / ReSharper redundant-using: this solution multi-targets net10.0 and net10.0-windows
+# with #if WINDOWS code, so some usings are legitimately used on only one TFM and look "unused"
+# on the other. We intentionally keep them inline and do NOT optimize usings during cleanup, so
+# silence the unused-using diagnostic (it would otherwise break the build under
+# TreatWarningsAsErrors and show as a spurious editor suggestion).
+dotnet_diagnostic.IDE0005.severity = none
+resharper_redundant_using_directive_highlighting = none
+
 # Always use braces - no single-line if/else/for/while/using
 csharp_prefer_braces = true:warning
 
@@ -38,33 +46,33 @@ csharp_style_var_for_built_in_types = false:suggestion
 csharp_style_var_when_type_is_apparent = true:suggestion
 csharp_style_var_elsewhere = false:suggestion
 
-# Prefer pattern matching and modern C# idioms
-csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
-csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
-csharp_style_prefer_not_pattern = true:suggestion
-csharp_style_prefer_switch_expression = true:suggestion
+# Prefer pattern matching and modern C# idioms (enforced)
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_prefer_not_pattern = true:warning
+csharp_style_prefer_switch_expression = true:warning
 
-# Prefer target-typed new
-csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
+# Prefer target-typed new (enforced)
+csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
 
-# Prefer collection expressions
-dotnet_style_prefer_collection_expression = true:suggestion
+# Prefer collection expressions (enforced)
+dotnet_style_prefer_collection_expression = true:warning
 
-# Space before parentheses in calls/declarations: `Method (arg)`, `new ()`, `if (x)`
-csharp_space_between_method_call_name_and_opening_parenthesis = true
-csharp_space_between_method_declaration_name_and_open_parenthesis = true
+# Standard C#: no space before parentheses in calls/declarations (`Method(arg)`, `new()`),
+# but keep a space after control-flow keywords (`if (x)`, `while (x)`).
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
 csharp_space_after_keywords_in_control_flow_statements = true
 
-# ReSharper-specific space rules - dotnet format reads the csharp_space_* keys above, but
-# ReSharper has additional knobs. These keep ReSharper's code-cleanup output aligned with
-# clet's house style (space before parens).
-resharper_space_before_new_parentheses = true
-resharper_space_before_method_call_parentheses = true
-resharper_space_before_method_parentheses = true
-resharper_space_before_empty_method_call_parentheses = true
-resharper_space_before_empty_method_parentheses = true
-resharper_space_before_typeof_parentheses = true
-resharper_space_before_default_parentheses = true
-resharper_space_before_checked_parentheses = true
-resharper_space_before_sizeof_parentheses = true
-resharper_space_before_nameof_parentheses = true
+# ReSharper space knobs - dotnet format reads the csharp_space_* keys above, but ReSharper has
+# additional knobs. Kept in sync with the standard no-space-before-parens style above.
+resharper_space_before_new_parentheses = false
+resharper_space_before_method_call_parentheses = false
+resharper_space_before_method_parentheses = false
+resharper_space_before_empty_method_call_parentheses = false
+resharper_space_before_empty_method_parentheses = false
+resharper_space_before_typeof_parentheses = false
+resharper_space_before_default_parentheses = false
+resharper_space_before_checked_parentheses = false
+resharper_space_before_sizeof_parentheses = false
+resharper_space_before_nameof_parentheses = false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,12 @@ jobs:
       - name: Verify code style
         shell: bash
         run: |
-          dotnet jb cleanupcode src/WinPrint.slnx --no-build --verbosity=WARN
+          # WinPrintCleanup is a custom profile (in WinPrint.slnx.DotSettings) = Full Cleanup minus
+          # "Optimize usings"/"Shorten references"/"Reorder members". Those fight this solution's
+          # multi-TFM #if WINDOWS conditional usings (hoisting them out of #if and breaking the other
+          # TFM). MainPage.xaml.cs is excluded because jb's var->explicit on its #if WINDOWS WinUI code
+          # keeps pulling Microsoft.UI usings to the top; dotnet format still applies spacing there.
+          dotnet jb cleanupcode src/WinPrint.slnx --no-build --profile="WinPrintCleanup" --exclude="**/MainPage.xaml.cs" --verbosity=WARN
           dotnet format src/WinPrint.slnx --no-restore
           git diff --exit-code
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,3 +74,32 @@ double with a deterministic fixed-pitch measurement model — so the full
   `PrintMarginsRegressionTests` (P/Invokes `USER32.dll`), and the Pygments/date-macro
   tests (external tooling / filesystem). The cross-platform `CteRenderingTests` and
   `MarkdownCteTests` pass on Linux.
+
+## Native AOT roadmap (tracked — NOT yet implemented)
+Goal: ship **`WinPrint.cli` as Native AOT** with **`WinPrint.Core` AOT/trim-compatible**.
+`WinPrint.WinForms` and `WinPrint.Maui` are **out of scope** — neither supports Native AOT.
+
+Decisions made (record of intent; revisit when work actually starts):
+- **Status: track only for now.** No AOT code changes yet. When starting, the first step is a
+  *spike*: set `<IsAotCompatible>true</IsAotCompatible>` on Core + `<PublishAot>true</PublishAot>`
+  on the CLI, build, and collect the trim/AOT analyzer warnings into an inventory to size the work.
+- **Target = cross-platform AOT** (Windows/Linux/macOS), not Windows-only. This requires a
+  **non-`System.Drawing` measurement backend** (e.g. SkiaSharp) plugged into the existing
+  `IGraphicsContext`/`MeasurementContext` seam — `System.Drawing` stays the Windows default.
+- **DI: drop MvvmLight `SimpleIoc`** (`ModelLocator`/`ServiceLocator`) in favor of **manual
+  construction**. MvvmLight is unmaintained and not trim-annotated.
+- **CLI arg parsing stays on `Terminal.Gui.Cli`** (vet Terminal.Gui itself for AOT/trim).
+- **`Macros.cs`: rewrite with a hand-rolled resolver**, removing **`System.Linq.Dynamic.Core`**
+  (runtime expression compiling — the one hard AOT blocker). May narrow exotic macro syntax to
+  what's actually used.
+- **JSON: move to source-generated `System.Text.Json`** (`JsonSerializerContext`); also replace
+  the reflection-based `Microsoft.Extensions.Configuration` `.Bind()` path.
+- **Update-check: redesign from the ground up and remove `Octokit`** (reflection/JSON-heavy).
+- **`CommandLineParser`: remove if unused** (verify no real callers, then drop the package).
+
+Other known AOT work (fall out of the spike):
+- `ModelBase.CopyPropertiesFrom` + `TypeDescriptor.GetProperties` / `GetType().GetProperties()` —
+  annotate with `[DynamicallyAccessedMembers]` or replace with generated/explicit copies.
+- CTE discovery (`GetTypes()` + `Activator.CreateInstance` in `ContentTypeEngineBase`) — root the
+  engine types or replace reflection with an explicit registry.
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# winprint — agent notes
+
+Cross-platform source/document printing engine. .NET 10. The Markdown work and the
+cross-platform CTE rendering refactor are described below because the "why" isn't
+obvious from the code alone.
+
+## Projects
+- `src/WinPrint.Core` — engine. **Multi-targets `net10.0` and `net10.0-windows`.** The
+  `WINDOWS` constant is defined for the `-windows` TFM only.
+- `src/WinPrint.cli` — CLI.
+- `src/WinPrint.WinForms` — Windows print UI.
+- `src/WinPrint.Maui` — MAUI app (Windows/MacCatalyst; needs the `maui` workload — does
+  **not** build on Linux).
+- `tests/WinPrint.Core.UnitTests` — xUnit. Targets `net10.0-windows` but most tests run
+  on Linux too (see below).
+- Solution: `src/WinPrint.slnx`.
+
+## Build & test
+```bash
+dotnet build src/WinPrint.Core/WinPrint.Core.csproj          # builds both TFMs
+dotnet test  tests/WinPrint.Core.UnitTests/WinPrint.Core.UnitTests.csproj
+dotnet test  ... --filter "FullyQualifiedName~CteRenderingTests"   # single class
+```
+CI (`.github/workflows/ci.yml`) runs on **windows-latest**, installs the `maui`
+workload, builds `WinPrint.slnx`, then enforces a **style gate**:
+`dotnet jb cleanupcode` + `dotnet format` with `git diff --exit-code`. Run those
+before pushing if you touched many files. Code-style analyzers also enforce
+**one top-level type per file** (WPA0001) and **no nested types** (WPA0002).
+
+## Remote (Claude Code on the web) environment
+Fresh Linux containers have no toolchain. `.claude/hooks/session-start.sh` (registered
+in `.claude/settings.json`) installs the .NET 10 SDK, `libgdiplus`, the local `jb` tool,
+and warms NuGet restore. `global.json` pins .NET 10. The hook runs only when
+`CLAUDE_CODE_REMOTE=true`.
+
+## Content Type Engines (CTEs)
+CTEs live in `src/WinPrint.Core/ContentTypeEngines` and derive from
+`ContentTypeEngineBase`. They are discovered by reflection via `SupportedContentTypes`
+(`CreateContentTypeEngine`), **not** by the static `Create()` factories (which have no
+production callers). Engines:
+- `TextCte` (`text/plain`), `MarkdownCte` (`text/x-markdown`, subclasses `TextCte` and
+  flattens Markdown via Markdig), `TextMateCte` (syntax highlighting; the default),
+  `AnsiCte`/`HtmlCte` (stubs after their native deps were removed).
+
+### Cross-platform rendering — the key design
+`System.Drawing.Common` is **Windows-only** (it P/Invokes GDI+/`gdiplus.dll`, absent on
+Linux). To keep the engines cross-platform, **all drawing and measurement goes through
+the `IGraphicsContext` abstraction** (`src/WinPrint.Core/Abstractions`), never
+`System.Drawing` directly:
+- `PaintPage(IGraphicsContext, ...)` paints through the abstraction.
+- `RenderAsync` reflow/measurement uses `ContentTypeEngineBase.ResolveMeasurementContext`,
+  which returns the injected `MeasurementContext` if set, else builds the Windows default
+  (`WindowsMeasurementContext`, the only Windows-gated CTE file).
+- `ContentTypeEngineBase.StringFormat` (a `System.Drawing` object) is **lazily**
+  initialized so the type can load without GDI+ (e.g. the Windows-targeted test assembly
+  running on Linux).
+- `System.Drawing.Color`/`ColorTranslator` are managed (no GDI+) and are fine on any OS.
+
+`TextCte`, `MarkdownCte`, and `TextMateCte` are no longer Windows-gated. Tests inject a
+`RecordingGraphicsContext` (in `tests/.../TestSupport`) — a GDI+-free `IGraphicsContext`
+double with a deterministic fixed-pitch measurement model — so the full
+`SetDocument → RenderAsync → PaintPage` pipeline is verified cross-platform
+(`CteRenderingTests`).
+
+## Important caveats
+- **Markdig is fully cross-platform** — it was never the platform constraint; the old
+  Windows gating was due to `System.Drawing` in the render path.
+- **The Windows `System.Drawing` measurement path is verified by CI (windows-latest),
+  not on Linux.** This container can't load GDI+, so the production measurement math is
+  preserved by construction and guarded by the older `TextCteTests`/`TextMateCteTests`
+  which run on Windows CI.
+- On Linux a handful of tests fail for **environment** reasons unrelated to logic: the
+  older CTE render tests that construct real `System.Drawing` objects in test code,
+  `PrintMarginsRegressionTests` (P/Invokes `USER32.dll`), and the Pygments/date-macro
+  tests (external tooling / filesystem). The cross-platform `CteRenderingTests` and
+  `MarkdownCteTests` pass on Linux.

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestMinor",
+    "allowPrerelease": false
+  }
+}

--- a/src/WinPrint.Core/Abstractions/GraphicsColor.cs
+++ b/src/WinPrint.Core/Abstractions/GraphicsColor.cs
@@ -7,7 +7,7 @@ public struct GraphicsColor
     public byte G { get; }
     public byte B { get; }
 
-    public GraphicsColor (byte a, byte r, byte g, byte b)
+    public GraphicsColor(byte a, byte r, byte g, byte b)
     {
         A = a;
         R = r;
@@ -15,13 +15,13 @@ public struct GraphicsColor
         B = b;
     }
 
-    public static GraphicsColor FromArgb (byte a, byte r, byte g, byte b)
+    public static GraphicsColor FromArgb(byte a, byte r, byte g, byte b)
     {
-        return new GraphicsColor (a, r, g, b);
+        return new GraphicsColor(a, r, g, b);
     }
 
-    public static GraphicsColor FromRgb (byte r, byte g, byte b)
+    public static GraphicsColor FromRgb(byte r, byte g, byte b)
     {
-        return new GraphicsColor (255, r, g, b);
+        return new GraphicsColor(255, r, g, b);
     }
 }

--- a/src/WinPrint.Core/Abstractions/GraphicsPointF.cs
+++ b/src/WinPrint.Core/Abstractions/GraphicsPointF.cs
@@ -5,7 +5,7 @@ public struct GraphicsPointF
     public float X { get; }
     public float Y { get; }
 
-    public GraphicsPointF (float x, float y)
+    public GraphicsPointF(float x, float y)
     {
         X = x;
         Y = y;

--- a/src/WinPrint.Core/Abstractions/GraphicsRectF.cs
+++ b/src/WinPrint.Core/Abstractions/GraphicsRectF.cs
@@ -12,7 +12,7 @@ public struct GraphicsRectF
     public float Right => X + Width;
     public float Bottom => Y + Height;
 
-    public GraphicsRectF (float x, float y, float width, float height)
+    public GraphicsRectF(float x, float y, float width, float height)
     {
         X = x;
         Y = y;

--- a/src/WinPrint.Core/Abstractions/GraphicsSizeF.cs
+++ b/src/WinPrint.Core/Abstractions/GraphicsSizeF.cs
@@ -5,7 +5,7 @@ public struct GraphicsSizeF
     public float Width { get; }
     public float Height { get; }
 
-    public GraphicsSizeF (float width, float height)
+    public GraphicsSizeF(float width, float height)
     {
         Width = width;
         Height = height;

--- a/src/WinPrint.Core/Abstractions/IGraphicsContext.cs
+++ b/src/WinPrint.Core/Abstractions/IGraphicsContext.cs
@@ -14,37 +14,37 @@ public interface IGraphicsContext
     IGraphicsPen GrayPen { get; }
     IGraphicsPen RedPen { get; }
 
-    IGraphicsState Save ();
-    void Restore (IGraphicsState state);
+    IGraphicsState Save();
+    void Restore(IGraphicsState state);
 
-    void TranslateTransform (float dx, float dy);
-    void ScaleTransform (float sx, float sy);
+    void TranslateTransform(float dx, float dy);
+    void ScaleTransform(float sx, float sy);
 
-    void SetClip (GraphicsRectF rect);
-    void ExcludeClip (GraphicsRectF rect);
-    void ResetClip ();
+    void SetClip(GraphicsRectF rect);
+    void ExcludeClip(GraphicsRectF rect);
+    void ResetClip();
 
-    void SetTextRenderingMode (GraphicsTextRenderingMode mode);
+    void SetTextRenderingMode(GraphicsTextRenderingMode mode);
 
-    IGraphicsFont CreateFont (string family, float size, GraphicsFontStyle style, GraphicsFontUnit unit);
-    IGraphicsBrush CreateSolidBrush (GraphicsColor color);
-    IGraphicsPen CreatePen (GraphicsColor color, float width = 1f);
+    IGraphicsFont CreateFont(string family, float size, GraphicsFontStyle style, GraphicsFontUnit unit);
+    IGraphicsBrush CreateSolidBrush(GraphicsColor color);
+    IGraphicsPen CreatePen(GraphicsColor color, float width = 1f);
 
-    GraphicsSizeF MeasureString (string text, IGraphicsFont font);
-    GraphicsSizeF MeasureString (string text, IGraphicsFont font, int width, GraphicsStringFormat format);
+    GraphicsSizeF MeasureString(string text, IGraphicsFont font);
+    GraphicsSizeF MeasureString(string text, IGraphicsFont font, int width, GraphicsStringFormat format);
 
-    GraphicsSizeF MeasureString (string text, IGraphicsFont font, GraphicsSizeF proposedSize,
+    GraphicsSizeF MeasureString(string text, IGraphicsFont font, GraphicsSizeF proposedSize,
         GraphicsStringFormat format, out int charsFitted, out int linesFilled);
 
-    void DrawString (string text, IGraphicsFont font, IGraphicsBrush brush, float x, float y,
+    void DrawString(string text, IGraphicsFont font, IGraphicsBrush brush, float x, float y,
         GraphicsStringFormat? format = null);
 
-    void DrawString (string text, IGraphicsFont font, IGraphicsBrush brush, GraphicsRectF rect,
+    void DrawString(string text, IGraphicsFont font, IGraphicsBrush brush, GraphicsRectF rect,
         GraphicsStringFormat? format = null);
 
-    void DrawLine (IGraphicsPen pen, float x1, float y1, float x2, float y2);
-    void DrawLine (IGraphicsPen pen, GraphicsPointF start, GraphicsPointF end);
-    void DrawRectangle (IGraphicsPen pen, float x, float y, float width, float height);
-    void FillRectangle (IGraphicsBrush brush, GraphicsRectF rect);
-    void FillRectangle (IGraphicsBrush brush, float x, float y, float width, float height);
+    void DrawLine(IGraphicsPen pen, float x1, float y1, float x2, float y2);
+    void DrawLine(IGraphicsPen pen, GraphicsPointF start, GraphicsPointF end);
+    void DrawRectangle(IGraphicsPen pen, float x, float y, float width, float height);
+    void FillRectangle(IGraphicsBrush brush, GraphicsRectF rect);
+    void FillRectangle(IGraphicsBrush brush, float x, float y, float width, float height);
 }

--- a/src/WinPrint.Core/Abstractions/IGraphicsFont.cs
+++ b/src/WinPrint.Core/Abstractions/IGraphicsFont.cs
@@ -5,5 +5,5 @@ public interface IGraphicsFont : IGraphicsResource
     /// <summary>
     ///     Returns the line height (line spacing) of this font, in pixels, for the given vertical DPI.
     /// </summary>
-    float GetHeight (float dpi);
+    float GetHeight(float dpi);
 }

--- a/src/WinPrint.Core/Abstractions/IGraphicsFont.cs
+++ b/src/WinPrint.Core/Abstractions/IGraphicsFont.cs
@@ -2,4 +2,8 @@ namespace WinPrint.Core.Abstractions;
 
 public interface IGraphicsFont : IGraphicsResource
 {
+    /// <summary>
+    ///     Returns the line height (line spacing) of this font, in pixels, for the given vertical DPI.
+    /// </summary>
+    float GetHeight (float dpi);
 }

--- a/src/WinPrint.Core/Abstractions/IPrintJob.cs
+++ b/src/WinPrint.Core/Abstractions/IPrintJob.cs
@@ -4,7 +4,7 @@ namespace WinPrint.Core.Abstractions;
 
 public interface IPrintJob : IDisposable
 {
-    void Begin ();
-    void PrintPage (int pageNumber, Action<IGraphicsContext, int> renderPage);
-    void End ();
+    void Begin();
+    void PrintPage(int pageNumber, Action<IGraphicsContext, int> renderPage);
+    void End();
 }

--- a/src/WinPrint.Core/Abstractions/IPrintService.cs
+++ b/src/WinPrint.Core/Abstractions/IPrintService.cs
@@ -4,8 +4,8 @@ namespace WinPrint.Core.Abstractions;
 
 public interface IPrintService
 {
-    IReadOnlyList<PrinterInfo> GetAvailablePrinters ();
-    PrintPageSetup GetDefaultPageSetup (string? printerName = null);
-    PrintPageSetup ShowPrintDialog (PrintDialogOptions options, PrintPageSetup currentSetup);
-    IPrintJob CreateJob (PrintPageSetup pageSetup, string documentName);
+    IReadOnlyList<PrinterInfo> GetAvailablePrinters();
+    PrintPageSetup GetDefaultPageSetup(string? printerName = null);
+    PrintPageSetup ShowPrintDialog(PrintDialogOptions options, PrintPageSetup currentSetup);
+    IPrintJob CreateJob(PrintPageSetup pageSetup, string documentName);
 }

--- a/src/WinPrint.Core/Abstractions/PrintMargins.cs
+++ b/src/WinPrint.Core/Abstractions/PrintMargins.cs
@@ -8,9 +8,11 @@ namespace WinPrint.Core.Abstractions;
 /// </summary>
 public class PrintMargins : ICloneable
 {
-    public PrintMargins () : this (0, 0, 0, 0) { }
+    public PrintMargins() : this(0, 0, 0, 0)
+    {
+    }
 
-    public PrintMargins (int left, int right, int top, int bottom)
+    public PrintMargins(int left, int right, int top, int bottom)
     {
         Left = left;
         Right = right;
@@ -23,9 +25,12 @@ public class PrintMargins : ICloneable
     public int Top { get; set; }
     public int Bottom { get; set; }
 
-    public object Clone () => new PrintMargins (Left, Right, Top, Bottom);
+    public object Clone()
+    {
+        return new PrintMargins(Left, Right, Top, Bottom);
+    }
 
-    public override bool Equals (object? obj)
+    public override bool Equals(object? obj)
     {
         if (obj is PrintMargins other)
         {
@@ -35,7 +40,13 @@ public class PrintMargins : ICloneable
         return false;
     }
 
-    public override int GetHashCode () => HashCode.Combine (Left, Right, Top, Bottom);
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Left, Right, Top, Bottom);
+    }
 
-    public override string ToString () => $"[PrintMargins Left={Left} Right={Right} Top={Top} Bottom={Bottom}]";
+    public override string ToString()
+    {
+        return $"[PrintMargins Left={Left} Right={Right} Top={Top} Bottom={Bottom}]";
+    }
 }

--- a/src/WinPrint.Core/Abstractions/PrintResolution.cs
+++ b/src/WinPrint.Core/Abstractions/PrintResolution.cs
@@ -6,9 +6,11 @@ namespace WinPrint.Core.Abstractions;
 /// </summary>
 public sealed class PrintResolution
 {
-    public PrintResolution () : this (300, 300) { }
+    public PrintResolution() : this(300, 300)
+    {
+    }
 
-    public PrintResolution (int x, int y)
+    public PrintResolution(int x, int y)
     {
         X = x;
         Y = y;
@@ -17,5 +19,8 @@ public sealed class PrintResolution
     public int X { get; set; }
     public int Y { get; set; }
 
-    public override string ToString () => $"{X}x{Y} DPI";
+    public override string ToString()
+    {
+        return $"{X}x{Y} DPI";
+    }
 }

--- a/src/WinPrint.Core/Abstractions/SystemDrawingAdapters.cs
+++ b/src/WinPrint.Core/Abstractions/SystemDrawingAdapters.cs
@@ -5,7 +5,7 @@ namespace WinPrint.Core.Abstractions;
 
 public static class SystemDrawingAdapters
 {
-    public static GraphicsFontStyle ToGraphicsFontStyle (ModelFontStyle style)
+    public static GraphicsFontStyle ToGraphicsFontStyle(ModelFontStyle style)
     {
         GraphicsFontStyle result = GraphicsFontStyle.Regular;
         if ((style & ModelFontStyle.Bold) == ModelFontStyle.Bold)
@@ -31,8 +31,8 @@ public static class SystemDrawingAdapters
         return result;
     }
 
-    public static GraphicsColor ToGraphicsColor (Color color)
+    public static GraphicsColor ToGraphicsColor(Color color)
     {
-        return GraphicsColor.FromArgb (color.A, color.R, color.G, color.B);
+        return GraphicsColor.FromArgb(color.A, color.R, color.G, color.B);
     }
 }

--- a/src/WinPrint.Core/Abstractions/SystemDrawingBrush.cs
+++ b/src/WinPrint.Core/Abstractions/SystemDrawingBrush.cs
@@ -7,19 +7,19 @@ internal sealed class SystemDrawingBrush : IGraphicsBrush
 {
     private readonly bool _ownsNative;
 
-    public SystemDrawingBrush (Brush brush, bool ownsNative = true)
+    public SystemDrawingBrush(Brush brush, bool ownsNative = true)
     {
-        Brush = brush ?? throw new ArgumentNullException (nameof (brush));
+        Brush = brush ?? throw new ArgumentNullException(nameof(brush));
         _ownsNative = ownsNative;
     }
 
     public Brush Brush { get; }
 
-    public void Dispose ()
+    public void Dispose()
     {
         if (_ownsNative)
         {
-            Brush.Dispose ();
+            Brush.Dispose();
         }
     }
 }

--- a/src/WinPrint.Core/Abstractions/SystemDrawingFont.cs
+++ b/src/WinPrint.Core/Abstractions/SystemDrawingFont.cs
@@ -7,24 +7,24 @@ internal sealed class SystemDrawingFont : IGraphicsFont
 {
     private readonly bool _ownsNative;
 
-    public SystemDrawingFont (Font font, bool ownsNative = true)
+    public SystemDrawingFont(Font font, bool ownsNative = true)
     {
-        Font = font ?? throw new ArgumentNullException (nameof (font));
+        Font = font ?? throw new ArgumentNullException(nameof(font));
         _ownsNative = ownsNative;
     }
 
     public Font Font { get; }
 
-    public float GetHeight (float dpi)
+    public float GetHeight(float dpi)
     {
-        return Font.GetHeight (dpi);
+        return Font.GetHeight(dpi);
     }
 
-    public void Dispose ()
+    public void Dispose()
     {
         if (_ownsNative)
         {
-            Font.Dispose ();
+            Font.Dispose();
         }
     }
 }

--- a/src/WinPrint.Core/Abstractions/SystemDrawingFont.cs
+++ b/src/WinPrint.Core/Abstractions/SystemDrawingFont.cs
@@ -15,6 +15,11 @@ internal sealed class SystemDrawingFont : IGraphicsFont
 
     public Font Font { get; }
 
+    public float GetHeight (float dpi)
+    {
+        return Font.GetHeight (dpi);
+    }
+
     public void Dispose ()
     {
         if (_ownsNative)

--- a/src/WinPrint.Core/Abstractions/SystemDrawingGraphicsContext.cs
+++ b/src/WinPrint.Core/Abstractions/SystemDrawingGraphicsContext.cs
@@ -6,16 +6,16 @@ namespace WinPrint.Core.Abstractions;
 
 public sealed class SystemDrawingGraphicsContext : IGraphicsContext
 {
-    private static readonly IGraphicsBrush _blackBrush = new SystemDrawingBrush (Brushes.Black, false);
-    private static readonly IGraphicsBrush _grayBrush = new SystemDrawingBrush (Brushes.Gray, false);
-    private static readonly IGraphicsBrush _darkGrayBrush = new SystemDrawingBrush (Brushes.DarkGray, false);
-    private static readonly IGraphicsPen _blackPen = new SystemDrawingPen (Pens.Black, false);
-    private static readonly IGraphicsPen _grayPen = new SystemDrawingPen (Pens.Gray, false);
-    private static readonly IGraphicsPen _redPen = new SystemDrawingPen (Pens.Red, false);
+    private static readonly IGraphicsBrush _blackBrush = new SystemDrawingBrush(Brushes.Black, false);
+    private static readonly IGraphicsBrush _grayBrush = new SystemDrawingBrush(Brushes.Gray, false);
+    private static readonly IGraphicsBrush _darkGrayBrush = new SystemDrawingBrush(Brushes.DarkGray, false);
+    private static readonly IGraphicsPen _blackPen = new SystemDrawingPen(Pens.Black, false);
+    private static readonly IGraphicsPen _grayPen = new SystemDrawingPen(Pens.Gray, false);
+    private static readonly IGraphicsPen _redPen = new SystemDrawingPen(Pens.Red, false);
 
-    public SystemDrawingGraphicsContext (Graphics graphics)
+    public SystemDrawingGraphicsContext(Graphics graphics)
     {
-        Graphics = graphics ?? throw new ArgumentNullException (nameof (graphics));
+        Graphics = graphics ?? throw new ArgumentNullException(nameof(graphics));
     }
 
     public Graphics Graphics { get; }
@@ -31,228 +31,220 @@ public sealed class SystemDrawingGraphicsContext : IGraphicsContext
     public IGraphicsPen GrayPen => _grayPen;
     public IGraphicsPen RedPen => _redPen;
 
-    public IGraphicsState Save ()
+    public IGraphicsState Save()
     {
-        return new SystemDrawingState (Graphics.Save ());
+        return new SystemDrawingState(Graphics.Save());
     }
 
-    public void Restore (IGraphicsState state)
+    public void Restore(IGraphicsState state)
     {
-        if (!(state is SystemDrawingState systemState))
+        if (state is not SystemDrawingState systemState)
         {
-            throw new ArgumentException ("Invalid graphics state for SystemDrawingGraphicsContext.", nameof (state));
+            throw new ArgumentException("Invalid graphics state for SystemDrawingGraphicsContext.", nameof(state));
         }
 
-        Graphics.Restore (systemState.State);
+        Graphics.Restore(systemState.State);
     }
 
-    public void TranslateTransform (float dx, float dy)
+    public void TranslateTransform(float dx, float dy)
     {
-        Graphics.TranslateTransform (dx, dy);
+        Graphics.TranslateTransform(dx, dy);
     }
 
-    public void ScaleTransform (float sx, float sy)
+    public void ScaleTransform(float sx, float sy)
     {
-        Graphics.ScaleTransform (sx, sy);
+        Graphics.ScaleTransform(sx, sy);
     }
 
-    public void SetClip (GraphicsRectF rect)
+    public void SetClip(GraphicsRectF rect)
     {
-        Graphics.SetClip (ToRectangleF (rect));
+        Graphics.SetClip(ToRectangleF(rect));
     }
 
-    public void ExcludeClip (GraphicsRectF rect)
+    public void ExcludeClip(GraphicsRectF rect)
     {
-        using var clipRegion = new Region (ToRectangleF (rect));
-        Graphics.ExcludeClip (clipRegion);
+        using var clipRegion = new Region(ToRectangleF(rect));
+        Graphics.ExcludeClip(clipRegion);
     }
 
-    public void ResetClip ()
+    public void ResetClip()
     {
-        Graphics.ResetClip ();
+        Graphics.ResetClip();
     }
 
-    public void SetTextRenderingMode (GraphicsTextRenderingMode mode)
+    public void SetTextRenderingMode(GraphicsTextRenderingMode mode)
     {
-        switch (mode)
+        Graphics.TextRenderingHint = mode switch
         {
-            case GraphicsTextRenderingMode.ClearTypeGridFit:
-                Graphics.TextRenderingHint = TextRenderingHint.ClearTypeGridFit;
-                break;
-            default:
-                Graphics.TextRenderingHint = TextRenderingHint.SystemDefault;
-                break;
-        }
+            GraphicsTextRenderingMode.ClearTypeGridFit => TextRenderingHint.ClearTypeGridFit,
+            _ => TextRenderingHint.SystemDefault,
+        };
     }
 
-    public IGraphicsFont CreateFont (string family, float size, GraphicsFontStyle style, GraphicsFontUnit unit)
+    public IGraphicsFont CreateFont(string family, float size, GraphicsFontStyle style, GraphicsFontUnit unit)
     {
         GraphicsUnit graphicsUnit = unit == GraphicsFontUnit.Pixel ? GraphicsUnit.Pixel : GraphicsUnit.Point;
-        FontStyle nativeStyle = ToSystemFontStyle (style);
-        return new SystemDrawingFont (new Font (family, size, nativeStyle, graphicsUnit));
+        FontStyle nativeStyle = ToSystemFontStyle(style);
+        return new SystemDrawingFont(new Font(family, size, nativeStyle, graphicsUnit));
     }
 
-    public IGraphicsBrush CreateSolidBrush (GraphicsColor color)
+    public IGraphicsBrush CreateSolidBrush(GraphicsColor color)
     {
-        return new SystemDrawingBrush (new SolidBrush (Color.FromArgb (color.A, color.R, color.G, color.B)));
+        return new SystemDrawingBrush(new SolidBrush(Color.FromArgb(color.A, color.R, color.G, color.B)));
     }
 
-    public IGraphicsPen CreatePen (GraphicsColor color, float width = 1f)
+    public IGraphicsPen CreatePen(GraphicsColor color, float width = 1f)
     {
-        return new SystemDrawingPen (new Pen (Color.FromArgb (color.A, color.R, color.G, color.B), width));
+        return new SystemDrawingPen(new Pen(Color.FromArgb(color.A, color.R, color.G, color.B), width));
     }
 
-    public GraphicsSizeF MeasureString (string text, IGraphicsFont font)
+    public GraphicsSizeF MeasureString(string text, IGraphicsFont font)
     {
-        Font nativeFont = GetFont (font);
-        SizeF size = Graphics.MeasureString (text, nativeFont);
-        return new GraphicsSizeF (size.Width, size.Height);
+        Font nativeFont = GetFont(font);
+        SizeF size = Graphics.MeasureString(text, nativeFont);
+        return new GraphicsSizeF(size.Width, size.Height);
     }
 
-    public GraphicsSizeF MeasureString (string text, IGraphicsFont font, int width, GraphicsStringFormat format)
+    public GraphicsSizeF MeasureString(string text, IGraphicsFont font, int width, GraphicsStringFormat format)
     {
-        Font nativeFont = GetFont (font);
-        using StringFormat nativeFormat = ToSystemStringFormat (format);
-        SizeF size = Graphics.MeasureString (text, nativeFont, width, nativeFormat);
-        return new GraphicsSizeF (size.Width, size.Height);
+        Font nativeFont = GetFont(font);
+        using StringFormat nativeFormat = ToSystemStringFormat(format);
+        SizeF size = Graphics.MeasureString(text, nativeFont, width, nativeFormat);
+        return new GraphicsSizeF(size.Width, size.Height);
     }
 
-    public GraphicsSizeF MeasureString (string text, IGraphicsFont font, GraphicsSizeF proposedSize,
+    public GraphicsSizeF MeasureString(string text, IGraphicsFont font, GraphicsSizeF proposedSize,
         GraphicsStringFormat format, out int charsFitted, out int linesFilled)
     {
-        Font nativeFont = GetFont (font);
-        using StringFormat nativeFormat = ToSystemStringFormat (format);
-        SizeF size = Graphics.MeasureString (text, nativeFont, new SizeF (proposedSize.Width, proposedSize.Height),
+        Font nativeFont = GetFont(font);
+        using StringFormat nativeFormat = ToSystemStringFormat(format);
+        SizeF size = Graphics.MeasureString(text, nativeFont, new SizeF(proposedSize.Width, proposedSize.Height),
             nativeFormat, out charsFitted, out linesFilled);
-        return new GraphicsSizeF (size.Width, size.Height);
+        return new GraphicsSizeF(size.Width, size.Height);
     }
 
-    public void DrawString (string text, IGraphicsFont font, IGraphicsBrush brush, float x, float y,
+    public void DrawString(string text, IGraphicsFont font, IGraphicsBrush brush, float x, float y,
         GraphicsStringFormat? format = null)
     {
-        Font nativeFont = GetFont (font);
-        Brush nativeBrush = GetBrush (brush);
-        using StringFormat nativeFormat = ToSystemStringFormat (format);
-        Graphics.DrawString (text, nativeFont, nativeBrush, x, y, nativeFormat);
+        Font nativeFont = GetFont(font);
+        Brush nativeBrush = GetBrush(brush);
+        using StringFormat nativeFormat = ToSystemStringFormat(format);
+        Graphics.DrawString(text, nativeFont, nativeBrush, x, y, nativeFormat);
     }
 
-    public void DrawString (string text, IGraphicsFont font, IGraphicsBrush brush, GraphicsRectF rect,
+    public void DrawString(string text, IGraphicsFont font, IGraphicsBrush brush, GraphicsRectF rect,
         GraphicsStringFormat? format = null)
     {
-        Font nativeFont = GetFont (font);
-        Brush nativeBrush = GetBrush (brush);
-        using StringFormat nativeFormat = ToSystemStringFormat (format);
-        Graphics.DrawString (text, nativeFont, nativeBrush, ToRectangleF (rect), nativeFormat);
+        Font nativeFont = GetFont(font);
+        Brush nativeBrush = GetBrush(brush);
+        using StringFormat nativeFormat = ToSystemStringFormat(format);
+        Graphics.DrawString(text, nativeFont, nativeBrush, ToRectangleF(rect), nativeFormat);
     }
 
-    public void DrawLine (IGraphicsPen pen, float x1, float y1, float x2, float y2)
+    public void DrawLine(IGraphicsPen pen, float x1, float y1, float x2, float y2)
     {
-        Graphics.DrawLine (GetPen (pen), x1, y1, x2, y2);
+        Graphics.DrawLine(GetPen(pen), x1, y1, x2, y2);
     }
 
-    public void DrawLine (IGraphicsPen pen, GraphicsPointF start, GraphicsPointF end)
+    public void DrawLine(IGraphicsPen pen, GraphicsPointF start, GraphicsPointF end)
     {
-        Graphics.DrawLine (GetPen (pen), start.X, start.Y, end.X, end.Y);
+        Graphics.DrawLine(GetPen(pen), start.X, start.Y, end.X, end.Y);
     }
 
-    public void DrawRectangle (IGraphicsPen pen, float x, float y, float width, float height)
+    public void DrawRectangle(IGraphicsPen pen, float x, float y, float width, float height)
     {
-        Graphics.DrawRectangle (GetPen (pen), x, y, width, height);
+        Graphics.DrawRectangle(GetPen(pen), x, y, width, height);
     }
 
-    public void FillRectangle (IGraphicsBrush brush, GraphicsRectF rect)
+    public void FillRectangle(IGraphicsBrush brush, GraphicsRectF rect)
     {
-        Graphics.FillRectangle (GetBrush (brush), rect.X, rect.Y, rect.Width, rect.Height);
+        Graphics.FillRectangle(GetBrush(brush), rect.X, rect.Y, rect.Width, rect.Height);
     }
 
-    public void FillRectangle (IGraphicsBrush brush, float x, float y, float width, float height)
+    public void FillRectangle(IGraphicsBrush brush, float x, float y, float width, float height)
     {
-        Graphics.FillRectangle (GetBrush (brush), x, y, width, height);
+        Graphics.FillRectangle(GetBrush(brush), x, y, width, height);
     }
 
-    public static GraphicsRectF FromRectangleF (RectangleF rect)
+    public static GraphicsRectF FromRectangleF(RectangleF rect)
     {
-        return new GraphicsRectF (rect.X, rect.Y, rect.Width, rect.Height);
+        return new GraphicsRectF(rect.X, rect.Y, rect.Width, rect.Height);
     }
 
-    public static RectangleF ToRectangleF (GraphicsRectF rect)
+    public static RectangleF ToRectangleF(GraphicsRectF rect)
     {
-        return new RectangleF (rect.X, rect.Y, rect.Width, rect.Height);
+        return new RectangleF(rect.X, rect.Y, rect.Width, rect.Height);
     }
 
-    private static Font GetFont (IGraphicsFont font)
+    private static Font GetFont(IGraphicsFont font)
     {
-        if (!(font is SystemDrawingFont systemFont))
+        if (font is not SystemDrawingFont systemFont)
         {
-            throw new ArgumentException ("Graphics font is not compatible with SystemDrawingGraphicsContext.",
-                nameof (font));
+            throw new ArgumentException("Graphics font is not compatible with SystemDrawingGraphicsContext.",
+                nameof(font));
         }
 
         return systemFont.Font;
     }
 
-    private static Brush GetBrush (IGraphicsBrush brush)
+    private static Brush GetBrush(IGraphicsBrush brush)
     {
-        if (!(brush is SystemDrawingBrush systemBrush))
+        if (brush is not SystemDrawingBrush systemBrush)
         {
-            throw new ArgumentException ("Graphics brush is not compatible with SystemDrawingGraphicsContext.",
-                nameof (brush));
+            throw new ArgumentException("Graphics brush is not compatible with SystemDrawingGraphicsContext.",
+                nameof(brush));
         }
 
         return systemBrush.Brush;
     }
 
-    private static Pen GetPen (IGraphicsPen pen)
+    private static Pen GetPen(IGraphicsPen pen)
     {
-        if (!(pen is SystemDrawingPen systemPen))
+        if (pen is not SystemDrawingPen systemPen)
         {
-            throw new ArgumentException ("Graphics pen is not compatible with SystemDrawingGraphicsContext.",
-                nameof (pen));
+            throw new ArgumentException("Graphics pen is not compatible with SystemDrawingGraphicsContext.",
+                nameof(pen));
         }
 
         return systemPen.Pen;
     }
 
-    private static StringFormat ToSystemStringFormat (GraphicsStringFormat? format)
+    private static StringFormat ToSystemStringFormat(GraphicsStringFormat? format)
     {
         if (format == null)
         {
-            return new StringFormat (StringFormat.GenericDefault);
+            return new StringFormat(StringFormat.GenericDefault);
         }
 
-        var systemFormat = new StringFormat (StringFormat.GenericTypographic)
+        var systemFormat = new StringFormat(StringFormat.GenericTypographic)
         {
-            Alignment = ToStringAlignment (format.Alignment),
-            LineAlignment = ToStringAlignment (format.LineAlignment),
-            Trimming = ToStringTrimming (format.Trimming),
-            FormatFlags = ToStringFormatFlags (format.FormatFlags)
+            Alignment = ToStringAlignment(format.Alignment),
+            LineAlignment = ToStringAlignment(format.LineAlignment),
+            Trimming = ToStringTrimming(format.Trimming),
+            FormatFlags = ToStringFormatFlags(format.FormatFlags)
         };
         return systemFormat;
     }
 
-    private static StringAlignment ToStringAlignment (GraphicsTextAlignment alignment)
+    private static StringAlignment ToStringAlignment(GraphicsTextAlignment alignment)
     {
-        switch (alignment)
+        return alignment switch
         {
-            case GraphicsTextAlignment.Center:
-                return StringAlignment.Center;
-            case GraphicsTextAlignment.Far:
-                return StringAlignment.Far;
-            default:
-                return StringAlignment.Near;
-        }
+            GraphicsTextAlignment.Center => StringAlignment.Center,
+            GraphicsTextAlignment.Far => StringAlignment.Far,
+            _ => StringAlignment.Near,
+        };
     }
 
-    private static StringTrimming ToStringTrimming (GraphicsStringTrimming trimming)
+    private static StringTrimming ToStringTrimming(GraphicsStringTrimming trimming)
     {
-        switch (trimming)
+        return trimming switch
         {
-            default:
-                return StringTrimming.None;
-        }
+            _ => StringTrimming.None,
+        };
     }
 
-    private static StringFormatFlags ToStringFormatFlags (GraphicsStringFormatFlags flags)
+    private static StringFormatFlags ToStringFormatFlags(GraphicsStringFormatFlags flags)
     {
         StringFormatFlags result = 0;
         if ((flags & GraphicsStringFormatFlags.NoClip) == GraphicsStringFormatFlags.NoClip)
@@ -284,7 +276,7 @@ public sealed class SystemDrawingGraphicsContext : IGraphicsContext
         return result;
     }
 
-    private static FontStyle ToSystemFontStyle (GraphicsFontStyle style)
+    private static FontStyle ToSystemFontStyle(GraphicsFontStyle style)
     {
         FontStyle result = FontStyle.Regular;
         if ((style & GraphicsFontStyle.Bold) == GraphicsFontStyle.Bold)

--- a/src/WinPrint.Core/Abstractions/SystemDrawingPen.cs
+++ b/src/WinPrint.Core/Abstractions/SystemDrawingPen.cs
@@ -7,19 +7,19 @@ internal sealed class SystemDrawingPen : IGraphicsPen
 {
     private readonly bool _ownsNative;
 
-    public SystemDrawingPen (Pen pen, bool ownsNative = true)
+    public SystemDrawingPen(Pen pen, bool ownsNative = true)
     {
-        Pen = pen ?? throw new ArgumentNullException (nameof (pen));
+        Pen = pen ?? throw new ArgumentNullException(nameof(pen));
         _ownsNative = ownsNative;
     }
 
     public Pen Pen { get; }
 
-    public void Dispose ()
+    public void Dispose()
     {
         if (_ownsNative)
         {
-            Pen.Dispose ();
+            Pen.Dispose();
         }
     }
 }

--- a/src/WinPrint.Core/Abstractions/SystemDrawingState.cs
+++ b/src/WinPrint.Core/Abstractions/SystemDrawingState.cs
@@ -4,7 +4,7 @@ namespace WinPrint.Core.Abstractions;
 
 internal sealed class SystemDrawingState : IGraphicsState
 {
-    public SystemDrawingState (GraphicsState state)
+    public SystemDrawingState(GraphicsState state)
     {
         State = state;
     }

--- a/src/WinPrint.Core/ContentTypeEngines/AnsiCte.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/AnsiCte.cs
@@ -26,20 +26,20 @@ public class AnsiCte : ContentTypeEngineBase, IDisposable
 
     public override string[] SupportedContentTypes => _supportedContentTypes;
 
-    public void Dispose ()
+    public void Dispose()
     {
-        Dispose (true);
-        GC.SuppressFinalize (this);
+        Dispose(true);
+        GC.SuppressFinalize(this);
     }
 
-    public static AnsiCte Create ()
+    public static AnsiCte Create()
     {
-        var engine = new AnsiCte ();
-        engine.CopyPropertiesFrom (ModelLocator.Current.Settings.AnsiContentTypeEngineSettings);
+        var engine = new AnsiCte();
+        engine.CopyPropertiesFrom(ModelLocator.Current.Settings.AnsiContentTypeEngineSettings);
         return engine;
     }
 
-    private void Dispose (bool disposing)
+    private void Dispose(bool disposing)
     {
         if (_disposed)
         {
@@ -49,20 +49,20 @@ public class AnsiCte : ContentTypeEngineBase, IDisposable
         _disposed = true;
     }
 
-    public override async Task<bool> SetDocumentAsync (string doc)
+    public override async Task<bool> SetDocumentAsync(string doc)
     {
         Document = doc;
-        return await Task.FromResult (true);
+        return await Task.FromResult(true);
     }
 
-    public override async Task<int> RenderAsync (PrintResolution? printerResolution,
+    public override async Task<int> RenderAsync(PrintResolution? printerResolution,
         EventHandler<string>? reflowProgress)
     {
-        LogService.TraceMessage ("AnsiCte is a stub - libvt100 submodule removed.");
-        return await Task.FromResult (0);
+        LogService.TraceMessage("AnsiCte is a stub - libvt100 submodule removed.");
+        return await Task.FromResult(0);
     }
 
-    public override void PaintPage (IGraphicsContext g, int pageNum)
+    public override void PaintPage(IGraphicsContext g, int pageNum)
     {
         // Stub: libvt100 submodule removed
     }

--- a/src/WinPrint.Core/ContentTypeEngines/ContentTypeEngineBase.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/ContentTypeEngineBase.cs
@@ -41,8 +41,8 @@ public abstract class ContentTypeEngineBase : ModelBase, INotifyPropertyChanged
     ///     this lets the type be loaded on a host without GDI+ (e.g. Linux CI running the Windows-targeted test
     ///     assembly) as long as this member is not actually used.
     /// </summary>
-    private static readonly Lazy<StringFormat> _stringFormat = new (() =>
-        new StringFormat (StringFormat.GenericTypographic)
+    private static readonly Lazy<StringFormat> _stringFormat = new(() =>
+        new StringFormat(StringFormat.GenericTypographic)
         {
             FormatFlags = StringFormatFlags.NoClip |
                           StringFormatFlags.LineLimit |
@@ -57,7 +57,7 @@ public abstract class ContentTypeEngineBase : ModelBase, INotifyPropertyChanged
     public static StringFormat StringFormat => _stringFormat.Value;
 #endif
 
-    public static readonly GraphicsStringFormat GraphicsStringFormat = new ()
+    public static readonly GraphicsStringFormat GraphicsStringFormat = new()
     {
         FormatFlags = GraphicsStringFormatFlags.NoClip |
                       GraphicsStringFormatFlags.LineLimit |
@@ -105,7 +105,7 @@ public abstract class ContentTypeEngineBase : ModelBase, INotifyPropertyChanged
     public ContentSettings? ContentSettings
     {
         get => _contentSettings;
-        set => SetField (ref _contentSettings, value);
+        set => SetField(ref _contentSettings, value);
     }
 
     /// <summary>
@@ -117,7 +117,7 @@ public abstract class ContentTypeEngineBase : ModelBase, INotifyPropertyChanged
         get => _document;
         set =>
             //LogService.TraceMessage($"Document is {document.Length} chars.");
-            SetField (ref _document, value);
+            SetField(ref _document, value);
     }
 
     /// <summary>
@@ -127,48 +127,48 @@ public abstract class ContentTypeEngineBase : ModelBase, INotifyPropertyChanged
     public Encoding? Encoding
     {
         get => _encoding;
-        set => SetField (ref _encoding, value);
+        set => SetField(ref _encoding, value);
     }
 
     public new event PropertyChangedEventHandler? PropertyChanged;
 
-    protected new void OnPropertyChanged ([CallerMemberName] string? propertyName = null)
+    protected new void OnPropertyChanged([CallerMemberName] string? propertyName = null)
     {
-        PropertyChanged?.Invoke (this, new PropertyChangedEventArgs (propertyName));
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
 
-    protected new bool SetField<T> (ref T field, T value, [CallerMemberName] string? propertyName = null)
+    protected new bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
     {
-        if (EqualityComparer<T>.Default.Equals (field, value))
+        if (EqualityComparer<T>.Default.Equals(field, value))
         {
             return false;
         }
 
         field = value;
-        OnPropertyChanged (propertyName);
-        OnSettingsChanged (true);
+        OnPropertyChanged(propertyName);
+        OnSettingsChanged(true);
         return true;
     }
 
     // if bool is true, reflow. Otherwise, just paint
     public event EventHandler<bool>? SettingsChanged;
 
-    protected void OnSettingsChanged (bool reflow)
+    protected void OnSettingsChanged(bool reflow)
     {
-        SettingsChanged?.Invoke (this, reflow);
+        SettingsChanged?.Invoke(this, reflow);
     }
 
     /// <summary>
     ///     https://stackoverflow.com/questions/5411694/get-all-inherited-classes-of-an-abstract-class
     /// </summary>
-    public static ICollection<ContentTypeEngineBase> GetDerivedClassesCollection ()
+    public static ICollection<ContentTypeEngineBase> GetDerivedClassesCollection()
     {
-        var objects = new List<ContentTypeEngineBase> ();
-        foreach (Type type in typeof (ContentTypeEngineBase).Assembly.GetTypes ()
-                     .Where (myType =>
-                         myType.IsClass && !myType.IsAbstract && myType.IsSubclassOf (typeof (ContentTypeEngineBase))))
+        var objects = new List<ContentTypeEngineBase>();
+        foreach (Type type in typeof(ContentTypeEngineBase).Assembly.GetTypes()
+                     .Where(myType =>
+                         myType.IsClass && !myType.IsAbstract && myType.IsSubclassOf(typeof(ContentTypeEngineBase))))
         {
-            objects.Add ((ContentTypeEngineBase)Activator.CreateInstance (type)!);
+            objects.Add((ContentTypeEngineBase)Activator.CreateInstance(type)!);
         }
 
         return objects;
@@ -181,7 +181,7 @@ public abstract class ContentTypeEngineBase : ModelBase, INotifyPropertyChanged
     ///     receives the object that must be disposed once reflow completes (null when the caller-supplied
     ///     context is returned).
     /// </summary>
-    protected IGraphicsContext ResolveMeasurementContext (int dpiX, int dpiY, out IDisposable? owner)
+    protected IGraphicsContext ResolveMeasurementContext(int dpiX, int dpiY, out IDisposable? owner)
     {
         if (MeasurementContext is not null)
         {
@@ -190,13 +190,13 @@ public abstract class ContentTypeEngineBase : ModelBase, INotifyPropertyChanged
         }
 
 #if WINDOWS
-        var windowsContext = new WindowsMeasurementContext (dpiX, dpiY);
+        var windowsContext = new WindowsMeasurementContext(dpiX, dpiY);
         owner = windowsContext;
         return windowsContext.Context;
 #else
         owner = null;
-        throw new InvalidOperationException (
-            $"{GetType ().Name}.RenderAsync requires a MeasurementContext to be set on non-Windows platforms.");
+        throw new InvalidOperationException(
+            $"{GetType().Name}.RenderAsync requires a MeasurementContext to be set on non-Windows platforms.");
 #endif
     }
 
@@ -207,15 +207,15 @@ public abstract class ContentTypeEngineBase : ModelBase, INotifyPropertyChanged
     /// <param name="printerResolution"></param>
     /// <param name="reflowProgress"></param>
     /// <returns>Number of sheets.</returns>
-    public virtual async Task<int> RenderAsync (PrintResolution? printerResolution,
+    public virtual async Task<int> RenderAsync(PrintResolution? printerResolution,
         EventHandler<string>? reflowProgress)
     {
         if (Document == null)
         {
-            throw new InvalidOperationException ("Document can't be null for Render");
+            throw new InvalidOperationException("Document can't be null for Render");
         }
 
-        return await Task.FromResult (0);
+        return await Task.FromResult(0);
     }
 
     /// <summary>
@@ -223,35 +223,35 @@ public abstract class ContentTypeEngineBase : ModelBase, INotifyPropertyChanged
     /// </summary>
     /// <param name="g">Graphics context with 0,0 being the origin of the Page</param>
     /// <param name="pageNum">Page number to print</param>
-    public abstract void PaintPage (IGraphicsContext g, int pageNum);
+    public abstract void PaintPage(IGraphicsContext g, int pageNum);
 
     /// <summary>
     ///     Creates the appropriate Content Type Engine instance given a content type string.
     /// </summary>
     /// <param name="contentType"></param>
     /// <returns>ContentEngine, ContentType, Language</returns>
-    public static (ContentTypeEngineBase? cte, string languageId, string language) CreateContentTypeEngine (
+    public static (ContentTypeEngineBase? cte, string languageId, string language) CreateContentTypeEngine(
         string? contentType)
     {
-        LogService.TraceMessage ();
+        LogService.TraceMessage();
 
-        contentType = string.IsNullOrEmpty (contentType)
+        contentType = string.IsNullOrEmpty(contentType)
             ? ModelLocator.Current.Settings.DefaultContentType
             : contentType;
-        Debug.Assert (ModelLocator.Current.FileTypeMapping != null);
-        Debug.Assert (ModelLocator.Current.FileTypeMapping.ContentTypes != null);
+        Debug.Assert(ModelLocator.Current.FileTypeMapping != null);
+        Debug.Assert(ModelLocator.Current.FileTypeMapping.ContentTypes != null);
 
         // If contentType matches one of our CTE Names, this will succeed.
-        ContentTypeEngineBase? cte = GetDerivedClassesCollection ()
-            .FirstOrDefault (c => contentType.Equals (c.GetType ().Name, StringComparison.OrdinalIgnoreCase));
+        ContentTypeEngineBase? cte = GetDerivedClassesCollection()
+            .FirstOrDefault(c => contentType.Equals(c.GetType().Name, StringComparison.OrdinalIgnoreCase));
         string language = string.Empty;
         string languageId = string.Empty;
 
         if (cte != null)
         {
             languageId = cte.SupportedContentTypes[0];
-            language = ModelLocator.Current.FileTypeMapping.ContentTypes.FirstOrDefault (lang =>
-                lang.Id.Equals (languageId, StringComparison.OrdinalIgnoreCase))?.Title ?? languageId;
+            language = ModelLocator.Current.FileTypeMapping.ContentTypes.FirstOrDefault(lang =>
+                lang.Id.Equals(languageId, StringComparison.OrdinalIgnoreCase))?.Title ?? languageId;
             return (cte, languageId, language);
         }
 
@@ -270,12 +270,12 @@ public abstract class ContentTypeEngineBase : ModelBase, INotifyPropertyChanged
         // Is it a file extension? (*.an)
 
         ContentType? extension = ModelLocator.Current.FileTypeMapping.ContentTypes
-            .FirstOrDefault (l => l.Extensions.Any (i =>
-                CultureInfo.CurrentCulture.CompareInfo.Compare (i, contentType, CompareOptions.IgnoreCase) == 0));
-        if (extension != null && !string.IsNullOrEmpty (extension.Id))
+            .FirstOrDefault(l => l.Extensions.Any(i =>
+                CultureInfo.CurrentCulture.CompareInfo.Compare(i, contentType, CompareOptions.IgnoreCase) == 0));
+        if (extension != null && !string.IsNullOrEmpty(extension.Id))
         {
             // Is Id directly supported by a Cte?
-            cte = GetDerivedClassesCollection ().FirstOrDefault (c => c.SupportedContentTypes.Contains (extension.Id));
+            cte = GetDerivedClassesCollection().FirstOrDefault(c => c.SupportedContentTypes.Contains(extension.Id));
             if (cte != null)
             {
                 return (cte, extension.Id, extension.Title);
@@ -288,8 +288,8 @@ public abstract class ContentTypeEngineBase : ModelBase, INotifyPropertyChanged
         else
         {
             // Is it a content type (Landuage.Id)? (text/ansi)
-            ContentType? lang = ModelLocator.Current.FileTypeMapping.ContentTypes.FirstOrDefault (l =>
-                l.Id.Equals (contentType, StringComparison.OrdinalIgnoreCase));
+            ContentType? lang = ModelLocator.Current.FileTypeMapping.ContentTypes.FirstOrDefault(l =>
+                l.Id.Equals(contentType, StringComparison.OrdinalIgnoreCase));
             if (lang != null)
             {
                 languageId = lang.Id;
@@ -297,8 +297,8 @@ public abstract class ContentTypeEngineBase : ModelBase, INotifyPropertyChanged
             }
 
             // Is it a language Title?
-            lang = ModelLocator.Current.FileTypeMapping.ContentTypes.FirstOrDefault (l =>
-                l.Title.Equals (contentType, StringComparison.OrdinalIgnoreCase));
+            lang = ModelLocator.Current.FileTypeMapping.ContentTypes.FirstOrDefault(l =>
+                l.Title.Equals(contentType, StringComparison.OrdinalIgnoreCase));
             if (lang != null)
             {
                 languageId = lang.Id;
@@ -307,7 +307,7 @@ public abstract class ContentTypeEngineBase : ModelBase, INotifyPropertyChanged
 
             // Is it a language name found in a Language alias? (ansi)
             lang = ModelLocator.Current.FileTypeMapping.ContentTypes
-                .FirstOrDefault (l => l.Aliases.Any (i => CultureInfo.CurrentCulture.CompareInfo.Compare (i,
+                .FirstOrDefault(l => l.Aliases.Any(i => CultureInfo.CurrentCulture.CompareInfo.Compare(i,
                     contentType,
                     CompareOptions.IgnoreCase) == 0));
             if (lang != null)
@@ -316,24 +316,24 @@ public abstract class ContentTypeEngineBase : ModelBase, INotifyPropertyChanged
                 language = lang.Title;
             }
 
-            if (!string.IsNullOrEmpty (language) && !string.IsNullOrEmpty (languageId))
+            if (!string.IsNullOrEmpty(language) && !string.IsNullOrEmpty(languageId))
             {
                 // Is the Id supported directly (e.g. text/html is supported directly by HtmlCte) 
                 // If supported by multiple, pick the default.
                 string id = languageId;
-                IEnumerable<ContentTypeEngineBase> ctes = GetDerivedClassesCollection ()
-                    .Where (c => c.SupportedContentTypes.Contains (id.ToLower ()));
-                ContentTypeEngineBase[] contentTypeEngineBases = ctes as ContentTypeEngineBase[] ?? ctes.ToArray ();
-                cte = contentTypeEngineBases.Count () > 1
-                    ? contentTypeEngineBases.First (c =>
-                        c.GetType ().Name == ModelLocator.Current.Settings.DefaultCteClassName)
-                    : contentTypeEngineBases.FirstOrDefault ();
+                IEnumerable<ContentTypeEngineBase> ctes = GetDerivedClassesCollection()
+                    .Where(c => c.SupportedContentTypes.Contains(id.ToLower()));
+                ContentTypeEngineBase[] contentTypeEngineBases = ctes as ContentTypeEngineBase[] ?? [.. ctes];
+                cte = contentTypeEngineBases.Count() > 1
+                    ? contentTypeEngineBases.First(c =>
+                        c.GetType().Name == ModelLocator.Current.Settings.DefaultCteClassName)
+                    : contentTypeEngineBases.FirstOrDefault();
 
                 if (cte != null)
                 {
                     return (cte, languageId,
-                        ModelLocator.Current.FileTypeMapping.ContentTypes.FirstOrDefault (l =>
-                            l.Id.Equals (languageId, StringComparison.OrdinalIgnoreCase))!.Title);
+                        ModelLocator.Current.FileTypeMapping.ContentTypes.FirstOrDefault(l =>
+                            l.Id.Equals(languageId, StringComparison.OrdinalIgnoreCase))!.Title);
                 }
 
                 // It is a language. Needs to be Syntax Highlighted. Use the default Syntax Highlighter CTE
@@ -342,21 +342,21 @@ public abstract class ContentTypeEngineBase : ModelBase, INotifyPropertyChanged
             }
         }
 
-        if (string.IsNullOrEmpty (languageId))
+        if (string.IsNullOrEmpty(languageId))
         {
             // Didn't find a content type so use default CTE
-            cte = GetDerivedClassesCollection ().FirstOrDefault (c =>
-                c.SupportedContentTypes.Contains (ModelLocator.Current.Settings.DefaultContentType));
+            cte = GetDerivedClassesCollection().FirstOrDefault(c =>
+                c.SupportedContentTypes.Contains(ModelLocator.Current.Settings.DefaultContentType));
             languageId = cte?.SupportedContentTypes[0] ?? ModelLocator.Current.Settings.DefaultContentType;
             language = ModelLocator.Current.FileTypeMapping.ContentTypes
-                .FirstOrDefault (l => l.Id.Equals (languageId, StringComparison.OrdinalIgnoreCase))
+                .FirstOrDefault(l => l.Id.Equals(languageId, StringComparison.OrdinalIgnoreCase))
                 ?.Title ?? languageId;
         }
         else
         {
             // It is a language. Needs to be Syntax Highlighted. Use the default Syntax Highlighter CTE
-            cte = GetDerivedClassesCollection ().FirstOrDefault (c =>
-                c.GetType ().Name.Equals (ModelLocator.Current.Settings.DefaultSyntaxHighlighterCteNameClassName,
+            cte = GetDerivedClassesCollection().FirstOrDefault(c =>
+                c.GetType().Name.Equals(ModelLocator.Current.Settings.DefaultSyntaxHighlighterCteNameClassName,
                     StringComparison.OrdinalIgnoreCase));
             //if (string.IsNullOrWhiteSpace(language)) {
             //    language = contentType;
@@ -372,50 +372,50 @@ public abstract class ContentTypeEngineBase : ModelBase, INotifyPropertyChanged
     /// </summary>
     /// <param name="filePath"></param>
     /// <returns>The content type</returns>
-    public static string GetContentType (string filePath)
+    public static string GetContentType(string filePath)
     {
         string contentType = ModelLocator.Current.Settings.DefaultContentType;
 
-        if (string.IsNullOrEmpty (filePath))
+        if (string.IsNullOrEmpty(filePath))
         {
             return contentType;
         }
 
         // Expand path
-        filePath = Path.GetFullPath (filePath);
+        filePath = Path.GetFullPath(filePath);
 
         // If there's a file extension get the content type from the file type association mapper
-        string ext = Path.GetExtension (filePath).ToLower ();
+        string ext = Path.GetExtension(filePath).ToLower();
         if (ext != string.Empty)
         {
             // BUGBUG: This assumes all extensions in FilesAssociations are lowercase
-            if (ModelLocator.Current.FileTypeMapping.FilesAssociations.TryGetValue ("*" + ext, out string? ct))
+            if (ModelLocator.Current.FileTypeMapping.FilesAssociations.TryGetValue("*" + ext, out string? ct))
             {
                 // Now find Id in Languages
                 contentType = ModelLocator.Current.FileTypeMapping.ContentTypes
-                    .Where (lang => lang.Id.Equals (ct, StringComparison.OrdinalIgnoreCase))
-                    .DefaultIfEmpty (new ContentType { Id = ModelLocator.Current.Settings.DefaultContentType })
-                    .First ().Id;
+                    .Where(lang => lang.Id.Equals(ct, StringComparison.OrdinalIgnoreCase))
+                    .DefaultIfEmpty(new ContentType { Id = ModelLocator.Current.Settings.DefaultContentType })
+                    .First().Id;
             }
             else
             {
                 // No direct file extension, look in Languages
                 contentType = ModelLocator.Current.FileTypeMapping.ContentTypes
-                    .Where (lang => lang.Extensions
-                        .Count (i => CultureInfo.CurrentCulture.CompareInfo.Compare (i, "*" + ext,
-                                         CompareOptions.IgnoreCase) ==
-                                     0 ||
-                                     CultureInfo.CurrentCulture.CompareInfo.Compare (i, ext,
-                                         CompareOptions.IgnoreCase) ==
-                                     0) > 0)
-                    .DefaultIfEmpty (new ContentType { Id = ModelLocator.Current.Settings.DefaultContentType })
-                    .First ().Id;
+                    .Where(lang => lang.Extensions
+                        .Count(i => CultureInfo.CurrentCulture.CompareInfo.Compare(i, "*" + ext,
+                                        CompareOptions.IgnoreCase) ==
+                                    0 ||
+                                    CultureInfo.CurrentCulture.CompareInfo.Compare(i, ext,
+                                        CompareOptions.IgnoreCase) ==
+                                    0) > 0)
+                    .DefaultIfEmpty(new ContentType { Id = ModelLocator.Current.Settings.DefaultContentType })
+                    .First().Id;
             }
         }
         else
         {
             // Empty means no extension (e.g. .\.ssh\config) - use filename
-            if (ModelLocator.Current.FileTypeMapping.FilesAssociations.TryGetValue ("*" + Path.GetFileName (filePath),
+            if (ModelLocator.Current.FileTypeMapping.FilesAssociations.TryGetValue("*" + Path.GetFileName(filePath),
                     out string? ct))
             {
                 contentType = ct;
@@ -424,11 +424,11 @@ public abstract class ContentTypeEngineBase : ModelBase, INotifyPropertyChanged
             {
                 // No direct file extension, look in Languages
                 contentType = ModelLocator.Current.FileTypeMapping.ContentTypes
-                    .Where (lang => lang.Extensions.Count (i => CultureInfo.CurrentCulture.CompareInfo.Compare (i,
-                        Path.GetFileName (filePath),
+                    .Where(lang => lang.Extensions.Count(i => CultureInfo.CurrentCulture.CompareInfo.Compare(i,
+                        Path.GetFileName(filePath),
                         CompareOptions.IgnoreCase) == 0) > 0)
-                    .DefaultIfEmpty (new ContentType { Id = ModelLocator.Current.Settings.DefaultContentType })
-                    .First ().Id;
+                    .DefaultIfEmpty(new ContentType { Id = ModelLocator.Current.Settings.DefaultContentType })
+                    .First().Id;
             }
         }
 
@@ -441,5 +441,5 @@ public abstract class ContentTypeEngineBase : ModelBase, INotifyPropertyChanged
         return contentType;
     }
 
-    public abstract Task<bool> SetDocumentAsync (string document);
+    public abstract Task<bool> SetDocumentAsync(string document);
 }

--- a/src/WinPrint.Core/ContentTypeEngines/ContentTypeEngineBase.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/ContentTypeEngineBase.cs
@@ -36,19 +36,25 @@ public abstract class ContentTypeEngineBase : ModelBase, INotifyPropertyChanged
 
 #if WINDOWS
     /// <summary>
-    ///     These are the global StringFormat settings; set here to ensure all rendering and measuring uses same settings
+    ///     These are the global StringFormat settings; set here to ensure all rendering and measuring uses same settings.
+    ///     Constructing a <see cref="System.Drawing.StringFormat" /> calls into GDI+, so it is lazily initialized:
+    ///     this lets the type be loaded on a host without GDI+ (e.g. Linux CI running the Windows-targeted test
+    ///     assembly) as long as this member is not actually used.
     /// </summary>
-    public static readonly StringFormat StringFormat = new (StringFormat.GenericTypographic)
-    {
-        FormatFlags = StringFormatFlags.NoClip |
-                      StringFormatFlags.LineLimit |
-                      //StringFormatFlags.FitBlackBox |
-                      StringFormatFlags.MeasureTrailingSpaces |
-                      StringFormatFlags.DisplayFormatControl,
-        Alignment = StringAlignment.Near,
-        LineAlignment = StringAlignment.Near,
-        Trimming = StringTrimming.None
-    };
+    private static readonly Lazy<StringFormat> _stringFormat = new (() =>
+        new StringFormat (StringFormat.GenericTypographic)
+        {
+            FormatFlags = StringFormatFlags.NoClip |
+                          StringFormatFlags.LineLimit |
+                          //StringFormatFlags.FitBlackBox |
+                          StringFormatFlags.MeasureTrailingSpaces |
+                          StringFormatFlags.DisplayFormatControl,
+            Alignment = StringAlignment.Near,
+            LineAlignment = StringAlignment.Near,
+            Trimming = StringTrimming.None
+        });
+
+    public static StringFormat StringFormat => _stringFormat.Value;
 #endif
 
     public static readonly GraphicsStringFormat GraphicsStringFormat = new ()
@@ -77,6 +83,15 @@ public abstract class ContentTypeEngineBase : ModelBase, INotifyPropertyChanged
     ///     Calculated page size. Set by Sheet view model.
     /// </summary>
     public SizeF PageSize { get; set; }
+
+    /// <summary>
+    ///     Optional graphics context used to measure text during <see cref="RenderAsync" /> (reflow).
+    ///     When null, <see cref="RenderAsync" /> creates a platform-default context (System.Drawing on
+    ///     Windows). Tests inject a platform-neutral context (e.g. a recording/fake) so that rendering
+    ///     can be exercised and verified cross-platform.
+    /// </summary>
+    [JsonIgnore]
+    public IGraphicsContext? MeasurementContext { get; set; }
 
     /// <summary>
     ///     ContentType identifier (shorthand for class name).

--- a/src/WinPrint.Core/ContentTypeEngines/ContentTypeEngineBase.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/ContentTypeEngineBase.cs
@@ -175,6 +175,32 @@ public abstract class ContentTypeEngineBase : ModelBase, INotifyPropertyChanged
     }
 
     /// <summary>
+    ///     Resolves the <see cref="IGraphicsContext" /> used to measure text during reflow. Returns the
+    ///     injected <see cref="MeasurementContext" /> when set; otherwise creates a platform-default
+    ///     context (System.Drawing on Windows). When a context is created here, <paramref name="owner" />
+    ///     receives the object that must be disposed once reflow completes (null when the caller-supplied
+    ///     context is returned).
+    /// </summary>
+    protected IGraphicsContext ResolveMeasurementContext (int dpiX, int dpiY, out IDisposable? owner)
+    {
+        if (MeasurementContext is not null)
+        {
+            owner = null;
+            return MeasurementContext;
+        }
+
+#if WINDOWS
+        var windowsContext = new WindowsMeasurementContext (dpiX, dpiY);
+        owner = windowsContext;
+        return windowsContext.Context;
+#else
+        owner = null;
+        throw new InvalidOperationException (
+            $"{GetType ().Name}.RenderAsync requires a MeasurementContext to be set on non-Windows platforms.");
+#endif
+    }
+
+    /// <summary>
     ///     Get total count of pages. Set any local page-size related values (e.g. linesPerPage).
     /// </summary>
     /// <param name="e"></param>

--- a/src/WinPrint.Core/ContentTypeEngines/HtmlCte.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/HtmlCte.cs
@@ -22,20 +22,20 @@ public class HtmlCte : ContentTypeEngineBase, IDisposable
 
     public override string[] SupportedContentTypes => _supportedContentTypes;
 
-    public void Dispose ()
+    public void Dispose()
     {
-        Dispose (true);
-        GC.SuppressFinalize (this);
+        Dispose(true);
+        GC.SuppressFinalize(this);
     }
 
-    public static HtmlCte Create ()
+    public static HtmlCte Create()
     {
-        var content = new HtmlCte ();
-        content.CopyPropertiesFrom (ModelLocator.Current.Settings.HtmlContentTypeEngineSettings);
+        var content = new HtmlCte();
+        content.CopyPropertiesFrom(ModelLocator.Current.Settings.HtmlContentTypeEngineSettings);
         return content;
     }
 
-    private void Dispose (bool disposing)
+    private void Dispose(bool disposing)
     {
         if (_disposed)
         {
@@ -45,20 +45,20 @@ public class HtmlCte : ContentTypeEngineBase, IDisposable
         _disposed = true;
     }
 
-    public override async Task<bool> SetDocumentAsync (string doc)
+    public override async Task<bool> SetDocumentAsync(string doc)
     {
         Document = doc;
-        return await Task.FromResult (true);
+        return await Task.FromResult(true);
     }
 
-    public override async Task<int> RenderAsync (PrintResolution? printerResolution,
+    public override async Task<int> RenderAsync(PrintResolution? printerResolution,
         EventHandler<string>? reflowProgress)
     {
-        LogService.TraceMessage ("HtmlCte is a stub - LiteHtmlSharp dependency removed.");
-        return await Task.FromResult (0);
+        LogService.TraceMessage("HtmlCte is a stub - LiteHtmlSharp dependency removed.");
+        return await Task.FromResult(0);
     }
 
-    public override void PaintPage (IGraphicsContext g, int pageNum)
+    public override void PaintPage(IGraphicsContext g, int pageNum)
     {
         // Stub: LiteHtmlSharp dependency removed
     }

--- a/src/WinPrint.Core/ContentTypeEngines/MarkdownCte.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/MarkdownCte.cs
@@ -25,18 +25,18 @@ public class MarkdownCte : TextCte
     ///     extensions ensures tables, task lists, etc. are handled gracefully.
     /// </summary>
     private static readonly MarkdownPipeline _pipeline =
-        new MarkdownPipelineBuilder ().UseAdvancedExtensions ().Build ();
+        new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
 
     /// <summary>
     ///     ContentType identifier (shorthand for class name).
     /// </summary>
     public override string[] SupportedContentTypes => _supportedContentTypes;
 
-    public static new MarkdownCte Create ()
+    public new static MarkdownCte Create()
     {
-        var engine = new MarkdownCte ();
+        var engine = new MarkdownCte();
         // Populate it with the common settings
-        engine.CopyPropertiesFrom (ModelLocator.Current.Settings.MarkdownContentTypeEngineSettings);
+        engine.CopyPropertiesFrom(ModelLocator.Current.Settings.MarkdownContentTypeEngineSettings);
         return engine;
     }
 
@@ -44,10 +44,10 @@ public class MarkdownCte : TextCte
     ///     Converts the Markdown <paramref name="doc" /> to plain text before handing it to the
     ///     text rendering pipeline.
     /// </summary>
-    public override async Task<bool> SetDocumentAsync (string doc)
+    public override async Task<bool> SetDocumentAsync(string doc)
     {
-        LogService.TraceMessage ($"Converting {doc?.Length ?? 0} chars of Markdown to plain text.");
-        string plainText = Markdown.ToPlainText (doc ?? string.Empty, _pipeline);
-        return await base.SetDocumentAsync (plainText);
+        LogService.TraceMessage($"Converting {doc?.Length ?? 0} chars of Markdown to plain text.");
+        string plainText = Markdown.ToPlainText(doc ?? string.Empty, _pipeline);
+        return await base.SetDocumentAsync(plainText);
     }
 }

--- a/src/WinPrint.Core/ContentTypeEngines/MarkdownCte.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/MarkdownCte.cs
@@ -1,0 +1,53 @@
+// Copyright Kindel, LLC - http://www.kindel.com
+// Published under the MIT License at https://github.com/tig/winprint
+
+using System;
+using System.Threading.Tasks;
+using Markdig;
+using WinPrint.Core.Models;
+using WinPrint.Core.Services;
+
+namespace WinPrint.Core.ContentTypeEngines;
+
+/// <summary>
+///     Implements text/x-markdown (Markdown) file type support.
+///     Uses Markdig to convert the Markdown source to plain text, then renders it through the
+///     text rendering pipeline (inherited from <see cref="TextCte" />), including line numbers
+///     and word/line wrapping. Markdown formatting (emphasis, headings, links, etc.) is flattened
+///     to readable plain text; the document is not syntax highlighted.
+/// </summary>
+public class MarkdownCte : TextCte
+{
+    private static readonly string[] _supportedContentTypes = ["text/x-markdown"];
+
+    /// <summary>
+    ///     The Markdig pipeline used to flatten Markdown to plain text. Enabling advanced
+    ///     extensions ensures tables, task lists, etc. are handled gracefully.
+    /// </summary>
+    private static readonly MarkdownPipeline _pipeline =
+        new MarkdownPipelineBuilder ().UseAdvancedExtensions ().Build ();
+
+    /// <summary>
+    ///     ContentType identifier (shorthand for class name).
+    /// </summary>
+    public override string[] SupportedContentTypes => _supportedContentTypes;
+
+    public static new MarkdownCte Create ()
+    {
+        var engine = new MarkdownCte ();
+        // Populate it with the common settings
+        engine.CopyPropertiesFrom (ModelLocator.Current.Settings.MarkdownContentTypeEngineSettings);
+        return engine;
+    }
+
+    /// <summary>
+    ///     Converts the Markdown <paramref name="doc" /> to plain text before handing it to the
+    ///     text rendering pipeline.
+    /// </summary>
+    public override async Task<bool> SetDocumentAsync (string doc)
+    {
+        LogService.TraceMessage ($"Converting {doc?.Length ?? 0} chars of Markdown to plain text.");
+        string plainText = Markdown.ToPlainText (doc ?? string.Empty, _pipeline);
+        return await base.SetDocumentAsync (plainText);
+    }
+}

--- a/src/WinPrint.Core/ContentTypeEngines/TextCte.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/TextCte.cs
@@ -20,7 +20,7 @@ namespace WinPrint.Core.ContentTypeEngines;
 /// </summary>
 public class TextCte : ContentTypeEngineBase, IDisposable
 {
-    private static readonly string[] _supportedContentTypes = { "text/plain" };
+    private static readonly string[] _supportedContentTypes = ["text/plain"];
     private IGraphicsFont? _cachedFont;
 
     // Protected implementation of Dispose pattern.
@@ -41,23 +41,23 @@ public class TextCte : ContentTypeEngineBase, IDisposable
     /// </summary>
     public override string[] SupportedContentTypes => _supportedContentTypes;
 
-    public void Dispose ()
+    public void Dispose()
     {
-        Dispose (true);
-        GC.SuppressFinalize (this);
+        Dispose(true);
+        GC.SuppressFinalize(this);
     }
 
-    public static TextCte Create ()
+    public static TextCte Create()
     {
-        var engine = new TextCte ();
+        var engine = new TextCte();
         // Populate it with the common settings
-        engine.CopyPropertiesFrom (ModelLocator.Current.Settings.TextContentTypeEngineSettings);
+        engine.CopyPropertiesFrom(ModelLocator.Current.Settings.TextContentTypeEngineSettings);
         return engine;
     }
 
-    private void Dispose (bool disposing)
+    private void Dispose(bool disposing)
     {
-        LogService.TraceMessage ($"disposing: {disposing}");
+        LogService.TraceMessage($"disposing: {disposing}");
 
         if (_disposed)
         {
@@ -68,7 +68,7 @@ public class TextCte : ContentTypeEngineBase, IDisposable
         {
             if (_cachedFont != null)
             {
-                _cachedFont.Dispose ();
+                _cachedFont.Dispose();
             }
 
             _wrappedLines = null;
@@ -78,10 +78,10 @@ public class TextCte : ContentTypeEngineBase, IDisposable
     }
 
     // TODO: Pass doc around by ref to save copies
-    public override async Task<bool> SetDocumentAsync (string doc)
+    public override async Task<bool> SetDocumentAsync(string doc)
     {
         Document = doc;
-        return await Task.FromResult (true);
+        return await Task.FromResult(true);
     }
 
     /// <summary>
@@ -91,19 +91,19 @@ public class TextCte : ContentTypeEngineBase, IDisposable
     /// <param name="printerResolution"></param>
     /// <param name="reflowProgress"></param>
     /// <returns></returns>
-    public override async Task<int> RenderAsync (PrintResolution? printerResolution,
+    public override async Task<int> RenderAsync(PrintResolution? printerResolution,
         EventHandler<string>? reflowProgress)
     {
-        LogService.TraceMessage ();
+        LogService.TraceMessage();
 
         if (Document is null)
         {
-            throw new InvalidOperationException ("Document can't be null for Render");
+            throw new InvalidOperationException("Document can't be null for Render");
         }
 
         if (printerResolution is null)
         {
-            throw new ArgumentNullException (nameof (printerResolution));
+            throw new ArgumentNullException(nameof(printerResolution));
         }
 
         int dpiX = printerResolution.X;
@@ -111,7 +111,7 @@ public class TextCte : ContentTypeEngineBase, IDisposable
 
         // BUGBUG: On Windows we can use the printer's resolution to be more accurate. But on Linux we
         // have to use 96dpi. See https://github.com/mono/libgdiplus/issues/623, etc...
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows) || dpiX < 0 || dpiY < 0)
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || dpiX < 0 || dpiY < 0)
         {
             dpiX = dpiY = 96;
         }
@@ -120,52 +120,52 @@ public class TextCte : ContentTypeEngineBase, IDisposable
         // (Windows); tests/non-Windows hosts inject a platform-neutral context via MeasurementContext so
         // reflow can run cross-platform.
         IDisposable? ownedContext = null;
-        IGraphicsContext g = ResolveMeasurementContext (dpiX, dpiY, out ownedContext);
+        IGraphicsContext g = ResolveMeasurementContext(dpiX, dpiY, out ownedContext);
 
         try
         {
             // Calculate the number of lines per page; first we need our font. Keep it around.
-            _cachedFont?.Dispose ();
-            _cachedFont = g.CreateFont (ContentSettings!.Font.Family, ContentSettings.Font.Size / 72F * 96F,
+            _cachedFont?.Dispose();
+            _cachedFont = g.CreateFont(ContentSettings!.Font.Family, ContentSettings.Font.Size / 72F * 96F,
                 (GraphicsFontStyle)ContentSettings.Font.Style, GraphicsFontUnit.Pixel);
 
-            _lineHeight = _cachedFont.GetHeight (dpiY);
+            _lineHeight = _cachedFont.GetHeight(dpiY);
 
             if (PageSize.Height < _lineHeight)
             {
-                throw new InvalidOperationException (
+                throw new InvalidOperationException(
                     $"The line height ({_lineHeight:F2}) is greater than page height ({PageSize.Height:F2}). " +
                     $"PageSize={PageSize.Width:F2}x{PageSize.Height:F2}, Font={ContentSettings.Font.Family} {ContentSettings.Font.Size}pt, DPI={dpiY}");
             }
 
             // Round down # of lines per page to ensure lines don't clip on bottom
-            _linesPerPage = (int)Math.Floor (PageSize.Height / _lineHeight);
+            _linesPerPage = (int)Math.Floor(PageSize.Height / _lineHeight);
 
             // 3 digits + 1 wide - Will support 999 lines before line numbers start to not fit
             // TODO: Make line number width dynamic
             // Note, MeasureString is actually dependent on lineNumberWidth!
             _lineNumberWidth = ContentSettings.LineNumbers
-                ? MeasureString (g, new string ('0', 4), _cachedFont).Width
+                ? MeasureString(g, new string('0', 4), _cachedFont).Width
                 : 0;
 
             // This is the shortest line length (in chars) that we think we'll see.
             // This is used as a performance optimization (probably premature) and
             // could be 0 with no functional change.
-            _minLineLen = (int)((PageSize.Width - _lineNumberWidth) / MeasureString (g, "W", _cachedFont).Width);
+            _minLineLen = (int)((PageSize.Width - _lineNumberWidth) / MeasureString(g, "W", _cachedFont).Width);
 
             // Note, MeasureLines may increment numPages due to form feeds and line wrapping
-            _wrappedLines = LineWrapDocument (g, Document); // new List<string>();
+            _wrappedLines = LineWrapDocument(g, Document); // new List<string>();
 
-            int n = (int)Math.Ceiling (_wrappedLines.Count / (double)_linesPerPage);
+            int n = (int)Math.Ceiling(_wrappedLines.Count / (double)_linesPerPage);
 
-            Log.Debug ("Rendered {pages} pages of {linesperpage} lines per page, for a total of {lines} lines.", n,
+            Log.Debug("Rendered {pages} pages of {linesperpage} lines per page, for a total of {lines} lines.", n,
                 _linesPerPage, _wrappedLines.Count);
 
-            return await Task.FromResult (n);
+            return await Task.FromResult(n);
         }
         finally
         {
-            ownedContext?.Dispose ();
+            ownedContext?.Dispose();
         }
     }
 
@@ -177,36 +177,36 @@ public class TextCte : ContentTypeEngineBase, IDisposable
     /// <param name="g"></param>
     /// <param name="document"></param>
     /// <returns></returns>
-    private List<WrappedLine> LineWrapDocument (IGraphicsContext g, string document)
+    private List<WrappedLine> LineWrapDocument(IGraphicsContext g, string document)
     {
         // TODO: Profile for performance
         // LogService.TraceMessage();
-        var wrapped = new List<WrappedLine> ();
+        var wrapped = new List<WrappedLine>();
 
 
         int lineCount = 0;
 
         // convert string to stream
-        byte[] byteArray = Encoding.UTF8.GetBytes (document);
-        var stream = new MemoryStream (byteArray);
-        var reader = new StreamReader (stream);
-        while (reader.ReadLine () is { } line)
+        byte[] byteArray = Encoding.UTF8.GetBytes(document);
+        var stream = new MemoryStream(byteArray);
+        var reader = new StreamReader(stream);
+        while (reader.ReadLine() is { } line)
         {
             // Expand tabs
             if (ContentSettings!.TabSpaces > 0)
             {
-                line = line.Replace ("\t", new string (' ', ContentSettings.TabSpaces));
+                line = line.Replace("\t", new string(' ', ContentSettings.TabSpaces));
             }
 
             ++lineCount;
-            if (ContentSettings.NewPageOnFormFeed && line.Contains ("\f"))
+            if (ContentSettings.NewPageOnFormFeed && line.Contains("\f"))
             {
-                lineCount = ExpandFormFeeds (g, wrapped, line, lineCount);
+                lineCount = ExpandFormFeeds(g, wrapped, line, lineCount);
             }
             else
             {
                 //Log.Debug("Line {num}: {line}", lineCount, line);
-                lineCount = AddLine (g, wrapped, line, lineCount);
+                lineCount = AddLine(g, wrapped, line, lineCount);
             }
         }
 
@@ -226,7 +226,7 @@ public class TextCte : ContentTypeEngineBase, IDisposable
     /// <param name="line"></param>
     /// <param name="lineCount"></param>
     /// <returns></returns>
-    private int ExpandFormFeeds (IGraphicsContext g, List<WrappedLine> list, string line, int lineCount)
+    private int ExpandFormFeeds(IGraphicsContext g, List<WrappedLine> list, string line, int lineCount)
     {
         string lineToAdd = "";
 
@@ -237,7 +237,7 @@ public class TextCte : ContentTypeEngineBase, IDisposable
                 if (lineToAdd.Length > 0)
                 {
                     // FF was NOT at start of line. Add it.
-                    AddLine (g, list, lineToAdd, lineCount);
+                    AddLine(g, list, lineToAdd, lineCount);
                     // if we're not at the end of the line t increment line #
                     if (i < line.Length - 1)
                     {
@@ -252,7 +252,7 @@ public class TextCte : ContentTypeEngineBase, IDisposable
 #if DEBUG
                     newLine._textNonWrapped = line;
 #endif
-                    list.Add (newLine);
+                    list.Add(newLine);
                 }
 
                 // Now on next line
@@ -266,7 +266,7 @@ public class TextCte : ContentTypeEngineBase, IDisposable
 
         if (lineToAdd.Length > 0)
         {
-            AddLine (g, list, lineToAdd, lineCount);
+            AddLine(g, list, lineToAdd, lineCount);
         }
 
         return lineCount;
@@ -283,10 +283,10 @@ public class TextCte : ContentTypeEngineBase, IDisposable
     /// <param name="lineToAdd">The, potentially, too-long line to wrap.</param>
     /// <param name="lineCount"></param>
     /// <returns></returns>
-    private int AddLine (IGraphicsContext g, List<WrappedLine> wrappedList, string lineToAdd, int lineCount)
+    private int AddLine(IGraphicsContext g, List<WrappedLine> wrappedList, string lineToAdd, int lineCount)
     {
         // TODO: Profile AddLine for performance
-        MeasureString (g, lineToAdd, _cachedFont!, out int numCharsThatFit, out int l1);
+        MeasureString(g, lineToAdd, _cachedFont!, out int numCharsThatFit, out int l1);
         //Log.Debug("   AddLine: {lineToAdd} - this line should {not}wrap", lineToAdd, lineToAdd.Length <= numCharsThatFit ? "not " : "");
         if (lineToAdd.Length > numCharsThatFit)
         {
@@ -300,7 +300,7 @@ public class TextCte : ContentTypeEngineBase, IDisposable
             for (int i = _minLineLen; i <= lineToAdd.Length; i++)
             {
                 string truncatedLine = lineToAdd[start..end++];
-                MeasureString (g, truncatedLine, _cachedFont!, out int numCharsThatFitTruncated, out int l2);
+                MeasureString(g, truncatedLine, _cachedFont!, out int numCharsThatFitTruncated, out int l2);
                 if (truncatedLine.Length > numCharsThatFitTruncated)
                 {
                     // The truncated line now too big, so shorten it by one char and add it
@@ -310,10 +310,10 @@ public class TextCte : ContentTypeEngineBase, IDisposable
                     wl._textNonWrapped = lineToAdd;
                     //Log.Debug("   Adding shorter line to list: {truncatedLine}, {nonWrappedLineNumber}, {textNonWrapped}", wl.text, wl.nonWrappedLineNumber, wl.textNonWrapped);
 #endif
-                    wrappedList.Add (wl);
+                    wrappedList.Add(wl);
 
                     // Recurse with the rest of the line
-                    AddLine (g, wrappedList, lineToAdd[truncatedLine.Length..], 0);
+                    AddLine(g, wrappedList, lineToAdd[truncatedLine.Length..], 0);
 
                     // exit for loop
                     break;
@@ -327,7 +327,7 @@ public class TextCte : ContentTypeEngineBase, IDisposable
             wl._textNonWrapped = lineToAdd;
             //Log.Debug("   Adding passed to list: {truncatedLine}, {nonWrappedLineNumber}, {textNonWrapped}", wl.text, wl.nonWrappedLineNumber, wl.textNonWrapped);
 #endif
-            wrappedList.Add (wl);
+            wrappedList.Add(wl);
         }
 
         return lineCount;
@@ -338,17 +338,17 @@ public class TextCte : ContentTypeEngineBase, IDisposable
     /// </summary>
     /// <param name="g">Graphics with 0,0 being the origin of the Page</param>
     /// <param name="pageNum">Page number to print</param>
-    public override void PaintPage (IGraphicsContext g, int pageNum)
+    public override void PaintPage(IGraphicsContext g, int pageNum)
     {
-        LogService.TraceMessage ($"{pageNum}");
+        LogService.TraceMessage($"{pageNum}");
         if (_wrappedLines == null)
         {
-            Log.Debug ("wrappedLines must not be null");
+            Log.Debug("wrappedLines must not be null");
             return;
         }
 
-        g.SetTextRenderingMode (GraphicsTextRenderingMode);
-        using IGraphicsFont paintFont = CreatePaintFont (g);
+        g.SetTextRenderingMode(GraphicsTextRenderingMode);
+        using IGraphicsFont paintFont = CreatePaintFont(g);
 
         // Paint each line of the file (each element of _wrappedLines that go on pageNum
         int firstLineInWrappedLines = _linesPerPage * (pageNum - 1);
@@ -362,7 +362,7 @@ public class TextCte : ContentTypeEngineBase, IDisposable
             // Right justify line number
             int x = ContentSettings!.LineNumberSeparator
                 ? (int)(_lineNumberWidth - 6 -
-                        MeasureString (g, $"{_wrappedLines[i]._nonWrappedLineNumber}", paintFont).Width)
+                        MeasureString(g, $"{_wrappedLines[i]._nonWrappedLineNumber}", paintFont).Width)
                 : 0;
 
             // Line #s
@@ -372,7 +372,7 @@ public class TextCte : ContentTypeEngineBase, IDisposable
                 {
                     // TOOD: Figure out how to make the spacing around separator more dynamic
                     // TODO: Allow a different (non-monospace) font for line numbers
-                    g.DrawString ($"{_wrappedLines[i]._nonWrappedLineNumber}", paintFont, g.GrayBrush, x, yPos,
+                    g.DrawString($"{_wrappedLines[i]._nonWrappedLineNumber}", paintFont, g.GrayBrush, x, yPos,
                         GraphicsStringFormat);
                 }
             }
@@ -381,39 +381,39 @@ public class TextCte : ContentTypeEngineBase, IDisposable
             // TODO: Support setting color of line #s and separator
             if (ContentSettings.LineNumbers && ContentSettings.LineNumberSeparator && _lineNumberWidth != 0)
             {
-                g.DrawLine (g.GrayPen, _lineNumberWidth - 2, yPos, _lineNumberWidth - 2, yPos + _lineHeight);
+                g.DrawLine(g.GrayPen, _lineNumberWidth - 2, yPos, _lineNumberWidth - 2, yPos + _lineHeight);
             }
 
             // Text
-            g.DrawString (_wrappedLines[i]._text, paintFont, g.BlackBrush, _lineNumberWidth, yPos,
+            g.DrawString(_wrappedLines[i]._text, paintFont, g.BlackBrush, _lineNumberWidth, yPos,
                 GraphicsStringFormat);
             if (ContentSettings.Diagnostics)
             {
-                g.DrawRectangle (g.RedPen, _lineNumberWidth, yPos, PageSize.Width - _lineNumberWidth, _lineHeight);
+                g.DrawRectangle(g.RedPen, _lineNumberWidth, yPos, PageSize.Width - _lineNumberWidth, _lineHeight);
             }
         }
 
-        Log.Debug ("Painted {lineOnPage} lines.", i - 1);
+        Log.Debug("Painted {lineOnPage} lines.", i - 1);
     }
 
-    private IGraphicsFont CreatePaintFont (IGraphicsContext g)
+    private IGraphicsFont CreatePaintFont(IGraphicsContext g)
     {
         GraphicsFontUnit unit = g.IsDisplayUnit ? GraphicsFontUnit.Point : GraphicsFontUnit.Pixel;
         float size = g.IsDisplayUnit ? ContentSettings!.Font.Size : ContentSettings!.Font.Size / 72F * 96F;
-        return g.CreateFont (ContentSettings.Font.Family, size,
+        return g.CreateFont(ContentSettings.Font.Family, size,
             (GraphicsFontStyle)ContentSettings.Font.Style, unit);
     }
 
-    private GraphicsSizeF MeasureString (IGraphicsContext g, string text, IGraphicsFont font)
+    private GraphicsSizeF MeasureString(IGraphicsContext g, string text, IGraphicsFont font)
     {
-        return MeasureString (g, text, font, out _, out _);
+        return MeasureString(g, text, font, out _, out _);
     }
 
-    private GraphicsSizeF MeasureString (IGraphicsContext g, string text, IGraphicsFont font, out int charsFitted,
+    private GraphicsSizeF MeasureString(IGraphicsContext g, string text, IGraphicsFont font, out int charsFitted,
         out int linesFilled)
     {
-        g.SetTextRenderingMode (GraphicsTextRenderingMode);
-        var proposedSize = new GraphicsSizeF (PageSize.Width - _lineNumberWidth, _lineHeight + _lineHeight / 2);
-        return g.MeasureString (text, font, proposedSize, GraphicsStringFormat, out charsFitted, out linesFilled);
+        g.SetTextRenderingMode(GraphicsTextRenderingMode);
+        var proposedSize = new GraphicsSizeF(PageSize.Width - _lineNumberWidth, _lineHeight + _lineHeight / 2);
+        return g.MeasureString(text, font, proposedSize, GraphicsStringFormat, out charsFitted, out linesFilled);
     }
 }

--- a/src/WinPrint.Core/ContentTypeEngines/TextCte.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/TextCte.cs
@@ -3,10 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
-#if WINDOWS
-using System.Drawing.Printing;
-#endif
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -15,9 +11,6 @@ using Serilog;
 using WinPrint.Core.Abstractions;
 using WinPrint.Core.Models;
 using WinPrint.Core.Services;
-#if WINDOWS
-using Font = System.Drawing.Font;
-#endif
 
 namespace WinPrint.Core.ContentTypeEngines;
 
@@ -28,7 +21,7 @@ namespace WinPrint.Core.ContentTypeEngines;
 public class TextCte : ContentTypeEngineBase, IDisposable
 {
     private static readonly string[] _supportedContentTypes = { "text/plain" };
-    private Font? _cachedFont;
+    private IGraphicsFont? _cachedFont;
 
     // Protected implementation of Dispose pattern.
     // Flag: Has Dispose already been called?
@@ -116,66 +109,82 @@ public class TextCte : ContentTypeEngineBase, IDisposable
         int dpiX = printerResolution.X;
         int dpiY = printerResolution.Y;
 
-        // BUGBUG: On Windows we can use the printer's resolution to be more accurate. But on Linux we 
+        // BUGBUG: On Windows we can use the printer's resolution to be more accurate. But on Linux we
         // have to use 96dpi. See https://github.com/mono/libgdiplus/issues/623, etc...
         if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows) || dpiX < 0 || dpiY < 0)
         {
             dpiX = dpiY = 96;
         }
 
-        // Create a representative Graphcis used for determining glyph metrics.      
-        using var bitmap = new Bitmap (1, 1);
-        bitmap.SetResolution (dpiX, dpiY);
-        var g = Graphics.FromImage (bitmap);
-        g.PageUnit = GraphicsUnit.Display; // Display is 1/100th"
+        // Obtain a graphics context used for determining glyph metrics. Production uses System.Drawing
+        // (Windows); tests/non-Windows hosts inject a platform-neutral context via MeasurementContext so
+        // reflow can run cross-platform.
+        IDisposable? ownedContext = null;
+        IGraphicsContext g = MeasurementContext ?? CreateMeasurementContext (dpiX, dpiY, out ownedContext);
 
-        // Calculate the number of lines per page; first we need our font. Keep it around.
-        _cachedFont = new Font (new FontFamily (ContentSettings!.Font.Family), ContentSettings.Font.Size / 72F * 96,
-            (System.Drawing.FontStyle)ContentSettings.Font.Style, GraphicsUnit.Pixel); // World?
-        Log.Debug ("Font: {f}, {s} ({p}), {st}", _cachedFont.Name, _cachedFont.Size, _cachedFont.SizeInPoints,
-            _cachedFont.Style);
-
-        if (RuntimeInformation.IsOSPlatform (OSPlatform.Linux))
+        try
         {
-            _cachedFont.Dispose ();
-            _cachedFont = new Font (new FontFamily (ContentSettings.Font.Family), ContentSettings.Font.Size, (System.Drawing.FontStyle)ContentSettings.Font.Style,
-                GraphicsUnit.Point);
-            Log.Debug ("Font: {f}, {s} ({p}), {st}", _cachedFont.Name, _cachedFont.Size, _cachedFont.SizeInPoints,
-                _cachedFont.Style);
-            g.PageUnit = GraphicsUnit.Display; // Display is 1/100th"
+            // Calculate the number of lines per page; first we need our font. Keep it around.
+            _cachedFont?.Dispose ();
+            _cachedFont = g.CreateFont (ContentSettings!.Font.Family, ContentSettings.Font.Size / 72F * 96F,
+                (GraphicsFontStyle)ContentSettings.Font.Style, GraphicsFontUnit.Pixel);
+
+            _lineHeight = _cachedFont.GetHeight (dpiY);
+
+            if (PageSize.Height < _lineHeight)
+            {
+                throw new InvalidOperationException (
+                    $"The line height ({_lineHeight:F2}) is greater than page height ({PageSize.Height:F2}). " +
+                    $"PageSize={PageSize.Width:F2}x{PageSize.Height:F2}, Font={ContentSettings.Font.Family} {ContentSettings.Font.Size}pt, DPI={dpiY}");
+            }
+
+            // Round down # of lines per page to ensure lines don't clip on bottom
+            _linesPerPage = (int)Math.Floor (PageSize.Height / _lineHeight);
+
+            // 3 digits + 1 wide - Will support 999 lines before line numbers start to not fit
+            // TODO: Make line number width dynamic
+            // Note, MeasureString is actually dependent on lineNumberWidth!
+            _lineNumberWidth = ContentSettings.LineNumbers
+                ? MeasureString (g, new string ('0', 4), _cachedFont).Width
+                : 0;
+
+            // This is the shortest line length (in chars) that we think we'll see.
+            // This is used as a performance optimization (probably premature) and
+            // could be 0 with no functional change.
+            _minLineLen = (int)((PageSize.Width - _lineNumberWidth) / MeasureString (g, "W", _cachedFont).Width);
+
+            // Note, MeasureLines may increment numPages due to form feeds and line wrapping
+            _wrappedLines = LineWrapDocument (g, Document); // new List<string>();
+
+            int n = (int)Math.Ceiling (_wrappedLines.Count / (double)_linesPerPage);
+
+            Log.Debug ("Rendered {pages} pages of {linesperpage} lines per page, for a total of {lines} lines.", n,
+                _linesPerPage, _wrappedLines.Count);
+
+            return await Task.FromResult (n);
         }
-
-        _lineHeight = _cachedFont.GetHeight (dpiY);
-
-        if (PageSize.Height < _lineHeight)
+        finally
         {
-            throw new InvalidOperationException (
-                $"The line height ({_lineHeight:F2}) is greater than page height ({PageSize.Height:F2}). " +
-                $"PageSize={PageSize.Width:F2}x{PageSize.Height:F2}, Font={_cachedFont.Name} {_cachedFont.SizeInPoints}pt, DPI={dpiY}");
+            ownedContext?.Dispose ();
         }
+    }
 
-        // Round down # of lines per page to ensure lines don't clip on bottom
-        _linesPerPage = (int)Math.Floor (PageSize.Height / _lineHeight);
-
-        // 3 digits + 1 wide - Will support 999 lines before line numbers start to not fit
-        // TODO: Make line number width dynamic
-        // Note, MeasureString is actually dependent on lineNumberWidth!
-        _lineNumberWidth = ContentSettings.LineNumbers ? MeasureString (g, new string ('0', 4)).Width : 0;
-
-        // This is the shortest line length (in chars) that we think we'll see. 
-        // This is used as a performance optimization (probably premature) and
-        // could be 0 with no functional change.
-        _minLineLen = (int)((PageSize.Width - _lineNumberWidth) / MeasureString (g, "W").Width);
-
-        // Note, MeasureLines may increment numPages due to form feeds and line wrapping
-        _wrappedLines = LineWrapDocument (g, Document); // new List<string>();
-
-        int n = (int)Math.Ceiling (_wrappedLines.Count / (double)_linesPerPage);
-
-        Log.Debug ("Rendered {pages} pages of {linesperpage} lines per page, for a total of {lines} lines.", n,
-            _linesPerPage, _wrappedLines.Count);
-
-        return await Task.FromResult (n);
+    /// <summary>
+    ///     Creates the default measurement context when none was injected via
+    ///     <see cref="ContentTypeEngineBase.MeasurementContext" />. On Windows this is a System.Drawing
+    ///     context; on other platforms a measurement context must be supplied by the caller.
+    /// </summary>
+    private static IGraphicsContext CreateMeasurementContext (int dpiX, int dpiY, out IDisposable? owner)
+    {
+#if WINDOWS
+        var windowsContext = new WindowsMeasurementContext (dpiX, dpiY);
+        owner = windowsContext;
+        return windowsContext.Context;
+#else
+        owner = null;
+        throw new InvalidOperationException (
+            "TextCte.RenderAsync requires a MeasurementContext to be set on non-Windows platforms.");
+#endif
     }
 
     /// <summary>
@@ -186,7 +195,7 @@ public class TextCte : ContentTypeEngineBase, IDisposable
     /// <param name="g"></param>
     /// <param name="document"></param>
     /// <returns></returns>
-    private List<WrappedLine> LineWrapDocument (Graphics g, string document)
+    private List<WrappedLine> LineWrapDocument (IGraphicsContext g, string document)
     {
         // TODO: Profile for performance
         // LogService.TraceMessage();
@@ -235,7 +244,7 @@ public class TextCte : ContentTypeEngineBase, IDisposable
     /// <param name="line"></param>
     /// <param name="lineCount"></param>
     /// <returns></returns>
-    private int ExpandFormFeeds (Graphics g, List<WrappedLine> list, string line, int lineCount)
+    private int ExpandFormFeeds (IGraphicsContext g, List<WrappedLine> list, string line, int lineCount)
     {
         string lineToAdd = "";
 
@@ -292,10 +301,10 @@ public class TextCte : ContentTypeEngineBase, IDisposable
     /// <param name="lineToAdd">The, potentially, too-long line to wrap.</param>
     /// <param name="lineCount"></param>
     /// <returns></returns>
-    private int AddLine (Graphics g, List<WrappedLine> wrappedList, string lineToAdd, int lineCount)
+    private int AddLine (IGraphicsContext g, List<WrappedLine> wrappedList, string lineToAdd, int lineCount)
     {
         // TODO: Profile AddLine for performance
-        MeasureString (g, lineToAdd, out int numCharsThatFit, out int l1);
+        MeasureString (g, lineToAdd, _cachedFont!, out int numCharsThatFit, out int l1);
         //Log.Debug("   AddLine: {lineToAdd} - this line should {not}wrap", lineToAdd, lineToAdd.Length <= numCharsThatFit ? "not " : "");
         if (lineToAdd.Length > numCharsThatFit)
         {
@@ -309,7 +318,7 @@ public class TextCte : ContentTypeEngineBase, IDisposable
             for (int i = _minLineLen; i <= lineToAdd.Length; i++)
             {
                 string truncatedLine = lineToAdd[start..end++];
-                MeasureString (g, truncatedLine, out int numCharsThatFitTruncated, out int l2);
+                MeasureString (g, truncatedLine, _cachedFont!, out int numCharsThatFitTruncated, out int l2);
                 if (truncatedLine.Length > numCharsThatFitTruncated)
                 {
                     // The truncated line now too big, so shorten it by one char and add it
@@ -340,44 +349,6 @@ public class TextCte : ContentTypeEngineBase, IDisposable
         }
 
         return lineCount;
-    }
-
-    private SizeF MeasureString (Graphics g, string text)
-    {
-        return MeasureString (g, text, out int charsFitted, out int linesFilled);
-    }
-
-    /// <summary>
-    ///     Measures how much width a string will take, given current page settings (including line numbers)
-    /// </summary>
-    /// <param name="g"></param>
-    /// <param name="text"></param>
-    /// <param name="charsFitted"></param>
-    /// <param name="linesFilled"></param>
-    /// <returns></returns>
-    private SizeF MeasureString (Graphics? g, string text, out int charsFitted, out int linesFilled)
-    {
-        if (g is null)
-        {
-            // define context used for determining glyph metrics.        
-            using var bitmap = new Bitmap (1, 1);
-            g = Graphics.FromImage (bitmap);
-            //g = Graphics.FromHwnd(PrintPreview.Instance.Handle);
-            g.PageUnit = GraphicsUnit.Display;
-        }
-
-        g.TextRenderingHint = TextRenderingHint;
-
-        // determine width     
-        float fontHeight = _lineHeight;
-        // Use page settings including lineNumberWidth
-        var proposedSize = new SizeF (PageSize.Width - _lineNumberWidth, _lineHeight + _lineHeight / 2);
-        SizeF size = g.MeasureString (text, _cachedFont!, proposedSize, StringFormat, out charsFitted, out linesFilled);
-
-        // TODO: HACK to work around MeasureString not working right on Linux
-        //if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-        //    linesFilled = 1;
-        return size;
     }
 
     /// <summary>

--- a/src/WinPrint.Core/ContentTypeEngines/TextCte.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/TextCte.cs
@@ -120,7 +120,7 @@ public class TextCte : ContentTypeEngineBase, IDisposable
         // (Windows); tests/non-Windows hosts inject a platform-neutral context via MeasurementContext so
         // reflow can run cross-platform.
         IDisposable? ownedContext = null;
-        IGraphicsContext g = MeasurementContext ?? CreateMeasurementContext (dpiX, dpiY, out ownedContext);
+        IGraphicsContext g = ResolveMeasurementContext (dpiX, dpiY, out ownedContext);
 
         try
         {
@@ -167,24 +167,6 @@ public class TextCte : ContentTypeEngineBase, IDisposable
         {
             ownedContext?.Dispose ();
         }
-    }
-
-    /// <summary>
-    ///     Creates the default measurement context when none was injected via
-    ///     <see cref="ContentTypeEngineBase.MeasurementContext" />. On Windows this is a System.Drawing
-    ///     context; on other platforms a measurement context must be supplied by the caller.
-    /// </summary>
-    private static IGraphicsContext CreateMeasurementContext (int dpiX, int dpiY, out IDisposable? owner)
-    {
-#if WINDOWS
-        var windowsContext = new WindowsMeasurementContext (dpiX, dpiY);
-        owner = windowsContext;
-        return windowsContext.Context;
-#else
-        owner = null;
-        throw new InvalidOperationException (
-            "TextCte.RenderAsync requires a MeasurementContext to be set on non-Windows platforms.");
-#endif
     }
 
     /// <summary>

--- a/src/WinPrint.Core/ContentTypeEngines/TextMateCte.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/TextMateCte.cs
@@ -131,10 +131,10 @@ public class TextMateCte : ContentTypeEngineBase, IDisposable
             int logicalLineCount = CountLogicalLines (Document, ContentSettings.NewPageOnFormFeed);
             int lineNumberDigits = Math.Max (3, logicalLineCount.ToString (CultureInfo.InvariantCulture).Length);
             _lineNumberWidth = ContentSettings.LineNumbers
-                ? g.MeasureString (new string ('0', lineNumberDigits + 1), _cachedFont).Width
+                ? MeasureRun (g, new string ('0', lineNumberDigits + 1), _cachedFont).Width
                 : 0;
 
-            float charWidth = Math.Max (1, g.MeasureString ("W", _cachedFont).Width);
+            float charWidth = Math.Max (1, MeasureRun (g, "W", _cachedFont).Width);
             int maxLineChars = Math.Max (1, (int)Math.Floor ((PageSize.Width - _lineNumberWidth) / charWidth));
 
             InitializeGrammar ();
@@ -183,7 +183,7 @@ public class TextMateCte : ContentTypeEngineBase, IDisposable
                 if (line.NonWrappedLineNumber > 0)
                 {
                     string lineNumber = line.NonWrappedLineNumber.ToString (CultureInfo.InvariantCulture);
-                    float measuredWidth = graphicsContext.MeasureString (lineNumber, baseFont).Width;
+                    float measuredWidth = MeasureRun (graphicsContext, lineNumber, baseFont).Width;
                     float x = ContentSettings.LineNumberSeparator
                         ? _lineNumberWidth - 6 - measuredWidth
                         : 0;
@@ -219,7 +219,7 @@ public class TextMateCte : ContentTypeEngineBase, IDisposable
                 using IGraphicsBrush brush = graphicsContext.CreateSolidBrush (
                     GraphicsColor.FromArgb (run.Foreground.A, run.Foreground.R, run.Foreground.G, run.Foreground.B));
                 graphicsContext.DrawString (text, runFont, brush, xPos, yPos, GraphicsStringFormat);
-                GraphicsSizeF measuredSize = graphicsContext.MeasureString (text, runFont);
+                GraphicsSizeF measuredSize = MeasureRun (graphicsContext, text, runFont);
 
                 if (ContentSettings.Diagnostics)
                 {
@@ -233,6 +233,19 @@ public class TextMateCte : ContentTypeEngineBase, IDisposable
         }
 
         Log.Debug ("Painted {lineOnPage} TextMate lines.", i - 1);
+    }
+
+    /// <summary>
+    ///     Measures <paramref name="text" /> using the same typographic <see cref="GraphicsStringFormat" />
+    ///     that <see cref="PaintPage" /> draws with. Measuring with the no-format overload uses GDI+'s
+    ///     default format, which pads ~1/6 em on each side; when used to advance the pen between per-token
+    ///     runs that padding accumulates into a visible gap before every token (and inflates the gutter
+    ///     width and wrap column). Keeping measure and draw on the same format avoids that drift.
+    /// </summary>
+    private GraphicsSizeF MeasureRun (IGraphicsContext g, string text, IGraphicsFont font)
+    {
+        var proposedSize = new GraphicsSizeF (PageSize.Width, _lineHeight + _lineHeight / 2);
+        return g.MeasureString (text, font, proposedSize, GraphicsStringFormat, out _, out _);
     }
 
     private static GraphicsFontStyle GetGraphicsFontStyle (TextMateFontStyle textMateStyle)

--- a/src/WinPrint.Core/ContentTypeEngines/TextMateCte.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/TextMateCte.cs
@@ -40,29 +40,29 @@ public class TextMateCte : ContentTypeEngineBase, IDisposable
 
     public override string[] SupportedContentTypes => _supportedContentTypes;
 
-    public void Dispose ()
+    public void Dispose()
     {
-        Dispose (true);
-        GC.SuppressFinalize (this);
+        Dispose(true);
+        GC.SuppressFinalize(this);
     }
 
-    public static TextMateCte Create ()
+    public static TextMateCte Create()
     {
-        var engine = new TextMateCte ();
-        engine.CopyPropertiesFrom (ModelLocator.Current.Settings.TextMateContentTypeEngineSettings);
+        var engine = new TextMateCte();
+        engine.CopyPropertiesFrom(ModelLocator.Current.Settings.TextMateContentTypeEngineSettings);
         return engine;
     }
 
-    public void Configure (string? contentType, string? language, string? filePath)
+    public void Configure(string? contentType, string? language, string? filePath)
     {
         ContentType = contentType;
         Language = language;
         _filePath = filePath;
     }
 
-    private void Dispose (bool disposing)
+    private void Dispose(bool disposing)
     {
-        LogService.TraceMessage ($"disposing: {disposing}");
+        LogService.TraceMessage($"disposing: {disposing}");
 
         if (_disposed)
         {
@@ -71,37 +71,37 @@ public class TextMateCte : ContentTypeEngineBase, IDisposable
 
         if (disposing)
         {
-            _cachedFont?.Dispose ();
+            _cachedFont?.Dispose();
             _wrappedLines = null;
         }
 
         _disposed = true;
     }
 
-    public override async Task<bool> SetDocumentAsync (string doc)
+    public override async Task<bool> SetDocumentAsync(string doc)
     {
         Document = doc;
-        return await Task.FromResult (true);
+        return await Task.FromResult(true);
     }
 
-    public override async Task<int> RenderAsync (PrintResolution? printerResolution,
+    public override async Task<int> RenderAsync(PrintResolution? printerResolution,
         EventHandler<string>? reflowProgress)
     {
-        LogService.TraceMessage ();
+        LogService.TraceMessage();
 
         if (Document is null)
         {
-            throw new InvalidOperationException ("Document can't be null for RenderAsync");
+            throw new InvalidOperationException("Document can't be null for RenderAsync");
         }
 
         if (printerResolution is null)
         {
-            throw new ArgumentNullException (nameof (printerResolution));
+            throw new ArgumentNullException(nameof(printerResolution));
         }
 
         int dpiX = printerResolution.X;
         int dpiY = printerResolution.Y;
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows) || dpiX < 0 || dpiY < 0)
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || dpiX < 0 || dpiY < 0)
         {
             dpiX = dpiY = 96;
         }
@@ -109,66 +109,66 @@ public class TextMateCte : ContentTypeEngineBase, IDisposable
         // Obtain a graphics context used for determining glyph metrics. Production uses System.Drawing
         // (Windows); tests/non-Windows hosts inject a platform-neutral context via MeasurementContext.
         IDisposable? ownedContext = null;
-        IGraphicsContext g = ResolveMeasurementContext (dpiX, dpiY, out ownedContext);
+        IGraphicsContext g = ResolveMeasurementContext(dpiX, dpiY, out ownedContext);
 
         try
         {
-            g.SetTextRenderingMode (GraphicsTextRenderingMode);
+            g.SetTextRenderingMode(GraphicsTextRenderingMode);
 
-            _cachedFont?.Dispose ();
-            _cachedFont = g.CreateFont (ContentSettings!.Font.Family, ContentSettings.Font.Size / 72F * 96F,
+            _cachedFont?.Dispose();
+            _cachedFont = g.CreateFont(ContentSettings!.Font.Family, ContentSettings.Font.Size / 72F * 96F,
                 (GraphicsFontStyle)ContentSettings.Font.Style, GraphicsFontUnit.Pixel);
 
-            _lineHeight = _cachedFont.GetHeight (dpiY);
+            _lineHeight = _cachedFont.GetHeight(dpiY);
             if (PageSize.Height < _lineHeight)
             {
-                throw new InvalidOperationException (
+                throw new InvalidOperationException(
                     $"The line height ({_lineHeight:F2}) is greater than page height ({PageSize.Height:F2}). " +
                     $"PageSize={PageSize.Width:F2}x{PageSize.Height:F2}, Font={ContentSettings.Font.Family} {ContentSettings.Font.Size}pt, DPI={dpiY}");
             }
 
-            _linesPerPage = (int)Math.Floor (PageSize.Height / _lineHeight);
-            int logicalLineCount = CountLogicalLines (Document, ContentSettings.NewPageOnFormFeed);
-            int lineNumberDigits = Math.Max (3, logicalLineCount.ToString (CultureInfo.InvariantCulture).Length);
+            _linesPerPage = (int)Math.Floor(PageSize.Height / _lineHeight);
+            int logicalLineCount = CountLogicalLines(Document, ContentSettings.NewPageOnFormFeed);
+            int lineNumberDigits = Math.Max(3, logicalLineCount.ToString(CultureInfo.InvariantCulture).Length);
             _lineNumberWidth = ContentSettings.LineNumbers
-                ? MeasureRun (g, new string ('0', lineNumberDigits + 1), _cachedFont).Width
+                ? MeasureRun(g, new string('0', lineNumberDigits + 1), _cachedFont).Width
                 : 0;
 
-            float charWidth = Math.Max (1, MeasureRun (g, "W", _cachedFont).Width);
-            int maxLineChars = Math.Max (1, (int)Math.Floor ((PageSize.Width - _lineNumberWidth) / charWidth));
+            float charWidth = Math.Max(1, MeasureRun(g, "W", _cachedFont).Width);
+            int maxLineChars = Math.Max(1, (int)Math.Floor((PageSize.Width - _lineNumberWidth) / charWidth));
 
-            InitializeGrammar ();
-            _wrappedLines = TokenizeAndWrap (Document, maxLineChars);
+            InitializeGrammar();
+            _wrappedLines = TokenizeAndWrap(Document, maxLineChars);
 
-            int pages = (int)Math.Ceiling (_wrappedLines.Count / (double)_linesPerPage);
-            Log.Debug (
+            int pages = (int)Math.Ceiling(_wrappedLines.Count / (double)_linesPerPage);
+            Log.Debug(
                 "Rendered {pages} TextMate pages of {linesperpage} lines per page, for a total of {lines} lines.",
                 pages, _linesPerPage, _wrappedLines.Count);
-            return await Task.FromResult (pages);
+            return await Task.FromResult(pages);
         }
         finally
         {
-            ownedContext?.Dispose ();
+            ownedContext?.Dispose();
         }
     }
 
-    public override void PaintPage (IGraphicsContext graphicsContext, int pageNum)
+    public override void PaintPage(IGraphicsContext graphicsContext, int pageNum)
     {
-        LogService.TraceMessage ($"{pageNum}");
+        LogService.TraceMessage($"{pageNum}");
         if (_wrappedLines is null || _cachedFont is null)
         {
-            Log.Debug ("TextMateCte must be rendered before painting.");
+            Log.Debug("TextMateCte must be rendered before painting.");
             return;
         }
 
-        graphicsContext.SetTextRenderingMode (GraphicsTextRenderingMode);
+        graphicsContext.SetTextRenderingMode(GraphicsTextRenderingMode);
 
         // Create IGraphicsFont equivalents for cross-platform rendering
         GraphicsFontUnit unit = graphicsContext.IsDisplayUnit ? GraphicsFontUnit.Point : GraphicsFontUnit.Pixel;
         float size = graphicsContext.IsDisplayUnit
             ? ContentSettings!.Font.Size
             : ContentSettings!.Font.Size / 72F * 96F;
-        using IGraphicsFont baseFont = graphicsContext.CreateFont (ContentSettings.Font.Family, size,
+        using IGraphicsFont baseFont = graphicsContext.CreateFont(ContentSettings.Font.Family, size,
             (GraphicsFontStyle)ContentSettings.Font.Style, unit);
 
         int firstLineOnPage = _linesPerPage * (pageNum - 1);
@@ -182,25 +182,25 @@ public class TextMateCte : ContentTypeEngineBase, IDisposable
             {
                 if (line.NonWrappedLineNumber > 0)
                 {
-                    string lineNumber = line.NonWrappedLineNumber.ToString (CultureInfo.InvariantCulture);
-                    float measuredWidth = MeasureRun (graphicsContext, lineNumber, baseFont).Width;
+                    string lineNumber = line.NonWrappedLineNumber.ToString(CultureInfo.InvariantCulture);
+                    float measuredWidth = MeasureRun(graphicsContext, lineNumber, baseFont).Width;
                     float x = ContentSettings.LineNumberSeparator
                         ? _lineNumberWidth - 6 - measuredWidth
                         : 0;
-                    graphicsContext.DrawString (lineNumber, baseFont, graphicsContext.GrayBrush, x, yPos,
+                    graphicsContext.DrawString(lineNumber, baseFont, graphicsContext.GrayBrush, x, yPos,
                         GraphicsStringFormat);
                 }
 
                 if (ContentSettings.LineNumberSeparator)
                 {
-                    graphicsContext.DrawLine (graphicsContext.GrayPen, _lineNumberWidth - 4, yPos,
+                    graphicsContext.DrawLine(graphicsContext.GrayPen, _lineNumberWidth - 4, yPos,
                         _lineNumberWidth - 4, yPos + _lineHeight);
                 }
             }
 
             if (ContentSettings.Diagnostics)
             {
-                graphicsContext.DrawRectangle (graphicsContext.RedPen, _lineNumberWidth, yPos,
+                graphicsContext.DrawRectangle(graphicsContext.RedPen, _lineNumberWidth, yPos,
                     PageSize.Width - _lineNumberWidth, _lineHeight);
             }
 
@@ -212,27 +212,27 @@ public class TextMateCte : ContentTypeEngineBase, IDisposable
                     continue;
                 }
 
-                string text = line.Text.Substring (run.Start, Math.Min (run.Length, line.Text.Length - run.Start));
-                GraphicsFontStyle fontStyle = GetGraphicsFontStyle (run.FontStyle);
-                using IGraphicsFont runFont = graphicsContext.CreateFont (ContentSettings.Font.Family, size,
+                string text = line.Text.Substring(run.Start, Math.Min(run.Length, line.Text.Length - run.Start));
+                GraphicsFontStyle fontStyle = GetGraphicsFontStyle(run.FontStyle);
+                using IGraphicsFont runFont = graphicsContext.CreateFont(ContentSettings.Font.Family, size,
                     fontStyle, unit);
-                using IGraphicsBrush brush = graphicsContext.CreateSolidBrush (
-                    GraphicsColor.FromArgb (run.Foreground.A, run.Foreground.R, run.Foreground.G, run.Foreground.B));
-                graphicsContext.DrawString (text, runFont, brush, xPos, yPos, GraphicsStringFormat);
-                GraphicsSizeF measuredSize = MeasureRun (graphicsContext, text, runFont);
+                using IGraphicsBrush brush = graphicsContext.CreateSolidBrush(
+                    GraphicsColor.FromArgb(run.Foreground.A, run.Foreground.R, run.Foreground.G, run.Foreground.B));
+                graphicsContext.DrawString(text, runFont, brush, xPos, yPos, GraphicsStringFormat);
+                GraphicsSizeF measuredSize = MeasureRun(graphicsContext, text, runFont);
 
                 if (ContentSettings.Diagnostics)
                 {
-                    using IGraphicsPen orangePen = graphicsContext.CreatePen (
-                        GraphicsColor.FromRgb (255, 165, 0));
-                    graphicsContext.DrawRectangle (orangePen, xPos, yPos, measuredSize.Width, measuredSize.Height);
+                    using IGraphicsPen orangePen = graphicsContext.CreatePen(
+                        GraphicsColor.FromRgb(255, 165, 0));
+                    graphicsContext.DrawRectangle(orangePen, xPos, yPos, measuredSize.Width, measuredSize.Height);
                 }
 
                 xPos += measuredSize.Width;
             }
         }
 
-        Log.Debug ("Painted {lineOnPage} TextMate lines.", i - 1);
+        Log.Debug("Painted {lineOnPage} TextMate lines.", i - 1);
     }
 
     /// <summary>
@@ -242,21 +242,21 @@ public class TextMateCte : ContentTypeEngineBase, IDisposable
     ///     runs that padding accumulates into a visible gap before every token (and inflates the gutter
     ///     width and wrap column). Keeping measure and draw on the same format avoids that drift.
     /// </summary>
-    private GraphicsSizeF MeasureRun (IGraphicsContext g, string text, IGraphicsFont font)
+    private GraphicsSizeF MeasureRun(IGraphicsContext g, string text, IGraphicsFont font)
     {
-        var proposedSize = new GraphicsSizeF (PageSize.Width, _lineHeight + _lineHeight / 2);
-        return g.MeasureString (text, font, proposedSize, GraphicsStringFormat, out _, out _);
+        var proposedSize = new GraphicsSizeF(PageSize.Width, _lineHeight + _lineHeight / 2);
+        return g.MeasureString(text, font, proposedSize, GraphicsStringFormat, out _, out _);
     }
 
-    private static GraphicsFontStyle GetGraphicsFontStyle (TextMateFontStyle textMateStyle)
+    private static GraphicsFontStyle GetGraphicsFontStyle(TextMateFontStyle textMateStyle)
     {
-        var style = GraphicsFontStyle.Regular;
-        if (textMateStyle.HasFlag (TextMateFontStyle.Bold))
+        GraphicsFontStyle style = GraphicsFontStyle.Regular;
+        if (textMateStyle.HasFlag(TextMateFontStyle.Bold))
         {
             style |= GraphicsFontStyle.Bold;
         }
 
-        if (textMateStyle.HasFlag (TextMateFontStyle.Italic))
+        if (textMateStyle.HasFlag(TextMateFontStyle.Italic))
         {
             style |= GraphicsFontStyle.Italic;
         }
@@ -264,82 +264,82 @@ public class TextMateCte : ContentTypeEngineBase, IDisposable
         return style;
     }
 
-    private void InitializeGrammar ()
+    private void InitializeGrammar()
     {
-        ThemeName theme = ParseTheme (ContentSettings?.Style);
-        var options = new RegistryOptions (theme);
-        _registry = new Registry (options);
-        _resolvedScopeName = ResolveScopeName (options);
-        _grammar = string.IsNullOrEmpty (_resolvedScopeName) ? null : _registry.LoadGrammar (_resolvedScopeName);
-        Log.Debug ("TextMate grammar: {scope}", _resolvedScopeName ?? "(plain text)");
+        ThemeName theme = ParseTheme(ContentSettings?.Style);
+        var options = new RegistryOptions(theme);
+        _registry = new Registry(options);
+        _resolvedScopeName = ResolveScopeName(options);
+        _grammar = string.IsNullOrEmpty(_resolvedScopeName) ? null : _registry.LoadGrammar(_resolvedScopeName);
+        Log.Debug("TextMate grammar: {scope}", _resolvedScopeName ?? "(plain text)");
     }
 
-    private string? ResolveScopeName (RegistryOptions options)
+    private string? ResolveScopeName(RegistryOptions options)
     {
-        if (!string.IsNullOrEmpty (_filePath))
+        if (!string.IsNullOrEmpty(_filePath))
         {
-            string extension = Path.GetExtension (_filePath);
-            if (!string.IsNullOrEmpty (extension))
+            string extension = Path.GetExtension(_filePath);
+            if (!string.IsNullOrEmpty(extension))
             {
-                string? scope = options.GetScopeByExtension (extension);
-                if (!string.IsNullOrEmpty (scope))
+                string? scope = options.GetScopeByExtension(extension);
+                if (!string.IsNullOrEmpty(scope))
                 {
                     return scope;
                 }
             }
         }
 
-        List<Language>? languages = options.GetAvailableLanguages ();
-        string? normalizedContentType = Normalize (ContentType);
-        string? normalizedLanguage = Normalize (Language);
-        Language? match = languages.FirstOrDefault (l =>
-            Matches (l.Id, normalizedLanguage) ||
-            Matches (l.Id, normalizedContentType) ||
-            (l.Aliases?.Any (a => Matches (a, normalizedLanguage) || Matches (a, normalizedContentType)) ?? false) ||
-            (l.MimeTypes?.Any (m => Matches (m, normalizedContentType)) ?? false));
+        List<Language>? languages = options.GetAvailableLanguages();
+        string? normalizedContentType = Normalize(ContentType);
+        string? normalizedLanguage = Normalize(Language);
+        Language? match = languages.FirstOrDefault(l =>
+            Matches(l.Id, normalizedLanguage) ||
+            Matches(l.Id, normalizedContentType) ||
+            (l.Aliases?.Any(a => Matches(a, normalizedLanguage) || Matches(a, normalizedContentType)) ?? false) ||
+            (l.MimeTypes?.Any(m => Matches(m, normalizedContentType)) ?? false));
 
-        return match is null ? null : options.GetScopeByLanguageId (match.Id);
+        return match is null ? null : options.GetScopeByLanguageId(match.Id);
     }
 
-    private static bool Matches (string? value, string? normalized)
+    private static bool Matches(string? value, string? normalized)
     {
-        return !string.IsNullOrEmpty (value) && !string.IsNullOrEmpty (normalized) && Normalize (value) == normalized;
+        return !string.IsNullOrEmpty(value) && !string.IsNullOrEmpty(normalized) && Normalize(value) == normalized;
     }
 
-    private static string? Normalize (string? value)
+    private static string? Normalize(string? value)
     {
-        return string.IsNullOrWhiteSpace (value)
+        return string.IsNullOrWhiteSpace(value)
             ? null
-            : new string (value.Where (char.IsLetterOrDigit).Select (char.ToLowerInvariant).ToArray ());
+            : new string([.. value.Where(char.IsLetterOrDigit).Select(char.ToLowerInvariant)]);
     }
 
-    private List<TextMateWrappedLine> TokenizeAndWrap (string document, int maxLineChars)
+    private List<TextMateWrappedLine> TokenizeAndWrap(string document, int maxLineChars)
     {
-        var wrapped = new List<TextMateWrappedLine> ();
+        var wrapped = new List<TextMateWrappedLine>();
         IStateStack? ruleStack = null;
         int lineNumber = 0;
 
-        using var reader = new StringReader (document);
+        using var reader = new StringReader(document);
         string? line;
-        while ((line = reader.ReadLine ()) != null)
+        while ((line = reader.ReadLine()) != null)
         {
             if (ContentSettings!.TabSpaces > 0)
             {
-                line = line.Replace ("\t", new string (' ', ContentSettings.TabSpaces));
+                line = line.Replace("\t", new string(' ', ContentSettings.TabSpaces));
             }
 
             lineNumber++;
-            if (ContentSettings.NewPageOnFormFeed && line.Contains ('\f'))
+            if (ContentSettings.NewPageOnFormFeed && line.Contains('\f'))
             {
-                string[] parts = line.Split ('\f');
+                string[] parts = line.Split('\f');
                 for (int i = 0; i < parts.Length; i++)
                 {
                     if (i > 0)
                     {
-                        AddBlankLinesToNextPage (wrapped);
+                        AddBlankLinesToNextPage(wrapped);
                     }
 
-                    AddTokenizedLine (wrapped, parts[i], lineNumber, maxLineChars, ref ruleStack);
+                    AddTokenizedLine(wrapped, parts[i], lineNumber, maxLineChars, ref ruleStack);
                     if (i < parts.Length - 1)
                     {
                         lineNumber++;
@@ -348,56 +348,56 @@ public class TextMateCte : ContentTypeEngineBase, IDisposable
             }
             else
             {
-                AddTokenizedLine (wrapped, line, lineNumber, maxLineChars, ref ruleStack);
+                AddTokenizedLine(wrapped, line, lineNumber, maxLineChars, ref ruleStack);
             }
         }
 
         if (wrapped.Count == 0)
         {
-            wrapped.Add (new TextMateWrappedLine { NonWrappedLineNumber = 1 });
+            wrapped.Add(new TextMateWrappedLine { NonWrappedLineNumber = 1 });
         }
 
         return wrapped;
     }
 
-    private void AddBlankLinesToNextPage (List<TextMateWrappedLine> wrapped)
+    private void AddBlankLinesToNextPage(List<TextMateWrappedLine> wrapped)
     {
         while (_linesPerPage > 0 && wrapped.Count % _linesPerPage != 0)
         {
-            wrapped.Add (new TextMateWrappedLine ());
+            wrapped.Add(new TextMateWrappedLine());
         }
     }
 
-    private void AddTokenizedLine (List<TextMateWrappedLine> wrapped, string line, int lineNumber, int maxLineChars,
+    private void AddTokenizedLine(List<TextMateWrappedLine> wrapped, string line, int lineNumber, int maxLineChars,
         ref IStateStack? ruleStack)
     {
         List<(int Start, int End, Color Foreground, TextMateFontStyle FontStyle)> tokens =
-            TokenizeLine (line, ref ruleStack);
+            TokenizeLine(line, ref ruleStack);
         if (line.Length == 0)
         {
-            wrapped.Add (new TextMateWrappedLine { NonWrappedLineNumber = lineNumber });
+            wrapped.Add(new TextMateWrappedLine { NonWrappedLineNumber = lineNumber });
             return;
         }
 
         for (int start = 0; start < line.Length; start += maxLineChars)
         {
-            int length = Math.Min (maxLineChars, line.Length - start);
+            int length = Math.Min(maxLineChars, line.Length - start);
             var wrappedLine = new TextMateWrappedLine
             {
                 NonWrappedLineNumber = start == 0 ? lineNumber : 0,
-                Text = line.Substring (start, length)
+                Text = line.Substring(start, length)
             };
 
             foreach ((int Start, int End, Color Foreground, TextMateFontStyle FontStyle) token in tokens)
             {
-                int intersectionStart = Math.Max (token.Start, start);
-                int intersectionEnd = Math.Min (token.End, start + length);
+                int intersectionStart = Math.Max(token.Start, start);
+                int intersectionEnd = Math.Min(token.End, start + length);
                 if (intersectionEnd <= intersectionStart)
                 {
                     continue;
                 }
 
-                wrappedLine.Runs.Add (new TextMateWrappedRun
+                wrappedLine.Runs.Add(new TextMateWrappedRun
                 {
                     Start = intersectionStart - start,
                     Length = intersectionEnd - intersectionStart,
@@ -408,14 +408,14 @@ public class TextMateCte : ContentTypeEngineBase, IDisposable
 
             if (wrappedLine.Runs.Count == 0)
             {
-                wrappedLine.Runs.Add (new TextMateWrappedRun { Start = 0, Length = wrappedLine.Text.Length });
+                wrappedLine.Runs.Add(new TextMateWrappedRun { Start = 0, Length = wrappedLine.Text.Length });
             }
 
-            wrapped.Add (wrappedLine);
+            wrapped.Add(wrappedLine);
         }
     }
 
-    private List<(int Start, int End, Color Foreground, TextMateFontStyle FontStyle)> TokenizeLine (string line,
+    private List<(int Start, int End, Color Foreground, TextMateFontStyle FontStyle)> TokenizeLine(string line,
         ref IStateStack? ruleStack)
     {
         if (_grammar is null || _registry is null)
@@ -425,11 +425,11 @@ public class TextMateCte : ContentTypeEngineBase, IDisposable
         }
 
         ITokenizeLineResult2? result =
-            _grammar.TokenizeLine2 (new LineText (line), ruleStack, TimeSpan.FromSeconds (1));
+            _grammar.TokenizeLine2(new LineText(line), ruleStack, TimeSpan.FromSeconds(1));
         ruleStack = result.RuleStack;
         int[]? encodedTokens = result.Tokens;
-        string[] colorMap = _registry.GetColorMap ().ToArray ();
-        var tokens = new List<(int Start, int End, Color Foreground, TextMateFontStyle FontStyle)> ();
+        string[] colorMap = [.. _registry.GetColorMap()];
+        var tokens = new List<(int Start, int End, Color Foreground, TextMateFontStyle FontStyle)>();
 
         for (int i = 0; i < encodedTokens.Length; i += 2)
         {
@@ -441,16 +441,16 @@ public class TextMateCte : ContentTypeEngineBase, IDisposable
             }
 
             int metadata = encodedTokens[i + 1];
-            tokens.Add ((start, end, GetForegroundColor (metadata, colorMap),
-                EncodedTokenAttributes.GetFontStyle (metadata)));
+            tokens.Add((start, end, GetForegroundColor(metadata, colorMap),
+                EncodedTokenAttributes.GetFontStyle(metadata)));
         }
 
         return tokens.Count == 0 ? [(0, line.Length, Color.Black, TextMateFontStyle.None)] : tokens;
     }
 
-    private static Color GetForegroundColor (int metadata, string[] colorMap)
+    private static Color GetForegroundColor(int metadata, string[] colorMap)
     {
-        int colorId = EncodedTokenAttributes.GetForeground (metadata);
+        int colorId = EncodedTokenAttributes.GetForeground(metadata);
         int colorIndex = colorId - 1;
         if (colorIndex < 0 || colorIndex >= colorMap.Length)
         {
@@ -458,15 +458,15 @@ public class TextMateCte : ContentTypeEngineBase, IDisposable
         }
 
         string color = colorMap[colorIndex];
-        return ColorTranslator.FromHtml (color);
+        return ColorTranslator.FromHtml(color);
     }
 
-    private static ThemeName ParseTheme (string? style)
+    private static ThemeName ParseTheme(string? style)
     {
-        return Enum.TryParse (style, true, out ThemeName theme) ? theme : ThemeName.VisualStudioLight;
+        return Enum.TryParse(style, true, out ThemeName theme) ? theme : ThemeName.VisualStudioLight;
     }
 
-    private static int CountLogicalLines (string document, bool countFormFeeds)
+    private static int CountLogicalLines(string document, bool countFormFeeds)
     {
         if (document.Length == 0)
         {

--- a/src/WinPrint.Core/ContentTypeEngines/TextMateCte.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/TextMateCte.cs
@@ -1,9 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-#if WINDOWS
-using System.Drawing.Printing;
-#endif
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -16,12 +13,6 @@ using TextMateSharp.Registry;
 using WinPrint.Core.Abstractions;
 using WinPrint.Core.Models;
 using WinPrint.Core.Services;
-#if WINDOWS
-using DrawingFont = System.Drawing.Font;
-#endif
-#if WINDOWS
-using DrawingFontStyle = System.Drawing.FontStyle;
-#endif
 using TextMateFontStyle = TextMateSharp.Themes.FontStyle;
 
 namespace WinPrint.Core.ContentTypeEngines;
@@ -32,14 +23,11 @@ namespace WinPrint.Core.ContentTypeEngines;
 public class TextMateCte : ContentTypeEngineBase, IDisposable
 {
     private static readonly string[] _supportedContentTypes = ["text/plain"];
-    private DrawingFont? _boldFont;
-    private DrawingFont? _boldItalicFont;
 
-    private DrawingFont? _cachedFont;
+    private IGraphicsFont? _cachedFont;
     private bool _disposed;
     private string? _filePath;
     private IGrammar? _grammar;
-    private DrawingFont? _italicFont;
     private float _lineHeight;
     private float _lineNumberWidth;
     private int _linesPerPage;
@@ -84,9 +72,6 @@ public class TextMateCte : ContentTypeEngineBase, IDisposable
         if (disposing)
         {
             _cachedFont?.Dispose ();
-            _boldFont?.Dispose ();
-            _italicFont?.Dispose ();
-            _boldItalicFont?.Dispose ();
             _wrappedLines = null;
         }
 
@@ -121,54 +106,50 @@ public class TextMateCte : ContentTypeEngineBase, IDisposable
             dpiX = dpiY = 96;
         }
 
-        using var bitmap = new Bitmap (1, 1);
-        bitmap.SetResolution (dpiX, dpiY);
-        using var g = Graphics.FromImage (bitmap);
-        g.PageUnit = GraphicsUnit.Display;
-        g.TextRenderingHint = TextRenderingHint;
+        // Obtain a graphics context used for determining glyph metrics. Production uses System.Drawing
+        // (Windows); tests/non-Windows hosts inject a platform-neutral context via MeasurementContext.
+        IDisposable? ownedContext = null;
+        IGraphicsContext g = ResolveMeasurementContext (dpiX, dpiY, out ownedContext);
 
-        _cachedFont?.Dispose ();
-        _boldFont?.Dispose ();
-        _italicFont?.Dispose ();
-        _boldItalicFont?.Dispose ();
-        _boldFont = null;
-        _italicFont = null;
-        _boldItalicFont = null;
-
-        _cachedFont = new DrawingFont (ContentSettings!.Font.Family, ContentSettings.Font.Size / 72F * 96,
-            (DrawingFontStyle)ContentSettings.Font.Style, GraphicsUnit.Pixel);
-        if (RuntimeInformation.IsOSPlatform (OSPlatform.Linux))
+        try
         {
-            _cachedFont.Dispose ();
-            _cachedFont = new DrawingFont (ContentSettings.Font.Family, ContentSettings.Font.Size,
-                (DrawingFontStyle)ContentSettings.Font.Style, GraphicsUnit.Point);
-        }
+            g.SetTextRenderingMode (GraphicsTextRenderingMode);
 
-        _lineHeight = _cachedFont.GetHeight (dpiY);
-        if (PageSize.Height < _lineHeight)
+            _cachedFont?.Dispose ();
+            _cachedFont = g.CreateFont (ContentSettings!.Font.Family, ContentSettings.Font.Size / 72F * 96F,
+                (GraphicsFontStyle)ContentSettings.Font.Style, GraphicsFontUnit.Pixel);
+
+            _lineHeight = _cachedFont.GetHeight (dpiY);
+            if (PageSize.Height < _lineHeight)
+            {
+                throw new InvalidOperationException (
+                    $"The line height ({_lineHeight:F2}) is greater than page height ({PageSize.Height:F2}). " +
+                    $"PageSize={PageSize.Width:F2}x{PageSize.Height:F2}, Font={ContentSettings.Font.Family} {ContentSettings.Font.Size}pt, DPI={dpiY}");
+            }
+
+            _linesPerPage = (int)Math.Floor (PageSize.Height / _lineHeight);
+            int logicalLineCount = CountLogicalLines (Document, ContentSettings.NewPageOnFormFeed);
+            int lineNumberDigits = Math.Max (3, logicalLineCount.ToString (CultureInfo.InvariantCulture).Length);
+            _lineNumberWidth = ContentSettings.LineNumbers
+                ? g.MeasureString (new string ('0', lineNumberDigits + 1), _cachedFont).Width
+                : 0;
+
+            float charWidth = Math.Max (1, g.MeasureString ("W", _cachedFont).Width);
+            int maxLineChars = Math.Max (1, (int)Math.Floor ((PageSize.Width - _lineNumberWidth) / charWidth));
+
+            InitializeGrammar ();
+            _wrappedLines = TokenizeAndWrap (Document, maxLineChars);
+
+            int pages = (int)Math.Ceiling (_wrappedLines.Count / (double)_linesPerPage);
+            Log.Debug (
+                "Rendered {pages} TextMate pages of {linesperpage} lines per page, for a total of {lines} lines.",
+                pages, _linesPerPage, _wrappedLines.Count);
+            return await Task.FromResult (pages);
+        }
+        finally
         {
-            throw new InvalidOperationException (
-                $"The line height ({_lineHeight:F2}) is greater than page height ({PageSize.Height:F2}). " +
-                $"PageSize={PageSize.Width:F2}x{PageSize.Height:F2}, Font={_cachedFont.Name} {_cachedFont.SizeInPoints}pt, DPI={dpiY}");
+            ownedContext?.Dispose ();
         }
-
-        _linesPerPage = (int)Math.Floor (PageSize.Height / _lineHeight);
-        int logicalLineCount = CountLogicalLines (Document, ContentSettings.NewPageOnFormFeed);
-        int lineNumberDigits = Math.Max (3, logicalLineCount.ToString (CultureInfo.InvariantCulture).Length);
-        _lineNumberWidth = ContentSettings.LineNumbers
-            ? MeasureString (g, new string ('0', lineNumberDigits + 1)).Width
-            : 0;
-
-        float charWidth = Math.Max (1, MeasureString (g, "W").Width);
-        int maxLineChars = Math.Max (1, (int)Math.Floor ((PageSize.Width - _lineNumberWidth) / charWidth));
-
-        InitializeGrammar ();
-        _wrappedLines = TokenizeAndWrap (Document, maxLineChars);
-
-        int pages = (int)Math.Ceiling (_wrappedLines.Count / (double)_linesPerPage);
-        Log.Debug ("Rendered {pages} TextMate pages of {linesperpage} lines per page, for a total of {lines} lines.",
-            pages, _linesPerPage, _wrappedLines.Count);
-        return await Task.FromResult (pages);
     }
 
     public override void PaintPage (IGraphicsContext graphicsContext, int pageNum)
@@ -465,54 +446,6 @@ public class TextMateCte : ContentTypeEngineBase, IDisposable
 
         string color = colorMap[colorIndex];
         return ColorTranslator.FromHtml (color);
-    }
-
-    private DrawingFont GetFont (TextMateFontStyle textMateStyle)
-    {
-        if (ContentSettings!.DisableFontStyles || textMateStyle is TextMateFontStyle.None or TextMateFontStyle.NotSet)
-        {
-            return _cachedFont!;
-        }
-
-        DrawingFontStyle style = DrawingFontStyle.Regular;
-        if (textMateStyle.HasFlag (TextMateFontStyle.Bold))
-        {
-            style |= DrawingFontStyle.Bold;
-        }
-
-        if (textMateStyle.HasFlag (TextMateFontStyle.Italic))
-        {
-            style |= DrawingFontStyle.Italic;
-        }
-
-        if (style == (DrawingFontStyle.Bold | DrawingFontStyle.Italic))
-        {
-            return _boldItalicFont ??=
-                new DrawingFont (_cachedFont!.FontFamily, _cachedFont.Size, style, _cachedFont.Unit);
-        }
-
-        if (style == DrawingFontStyle.Bold)
-        {
-            return _boldFont ??= new DrawingFont (_cachedFont!.FontFamily, _cachedFont.Size, style, _cachedFont.Unit);
-        }
-
-        if (style == DrawingFontStyle.Italic)
-        {
-            return _italicFont ??= new DrawingFont (_cachedFont!.FontFamily, _cachedFont.Size, style, _cachedFont.Unit);
-        }
-
-        return _cachedFont!;
-    }
-
-    private SizeF MeasureString (Graphics g, string text)
-    {
-        return MeasureString (g, _cachedFont, text);
-    }
-
-    private static SizeF MeasureString (Graphics g, DrawingFont? font, string text)
-    {
-        var proposedSize = new SizeF (10000, font!.GetHeight () + font.GetHeight () / 2);
-        return g.MeasureString (text, font, proposedSize, StringFormat, out _, out _);
     }
 
     private static ThemeName ParseTheme (string? style)

--- a/src/WinPrint.Core/ContentTypeEngines/WindowsMeasurementContext.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/WindowsMeasurementContext.cs
@@ -1,0 +1,38 @@
+// Copyright Kindel, LLC - http://www.kindel.com
+// Published under the MIT License at https://github.com/tig/winprint
+
+using System;
+using System.Drawing;
+using WinPrint.Core.Abstractions;
+
+namespace WinPrint.Core.ContentTypeEngines;
+
+/// <summary>
+///     Owns the System.Drawing <see cref="Bitmap" />/<see cref="Graphics" /> used to back a
+///     measurement <see cref="IGraphicsContext" /> during reflow on Windows, disposing them when
+///     reflow completes. This is the default measurement context used by <see cref="TextCte" /> when
+///     no <see cref="ContentTypeEngineBase.MeasurementContext" /> has been injected.
+/// </summary>
+internal sealed class WindowsMeasurementContext : IDisposable
+{
+    private readonly Bitmap _bitmap;
+    private readonly Graphics _graphics;
+
+    public WindowsMeasurementContext (int dpiX, int dpiY)
+    {
+        // A representative 1x1 surface is enough for glyph metrics.
+        _bitmap = new Bitmap (1, 1);
+        _bitmap.SetResolution (dpiX, dpiY);
+        _graphics = Graphics.FromImage (_bitmap);
+        _graphics.PageUnit = GraphicsUnit.Display; // Display is 1/100th"
+        Context = new SystemDrawingGraphicsContext (_graphics);
+    }
+
+    public IGraphicsContext Context { get; }
+
+    public void Dispose ()
+    {
+        _graphics.Dispose ();
+        _bitmap.Dispose ();
+    }
+}

--- a/src/WinPrint.Core/ContentTypeEngines/WindowsMeasurementContext.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/WindowsMeasurementContext.cs
@@ -18,21 +18,21 @@ internal sealed class WindowsMeasurementContext : IDisposable
     private readonly Bitmap _bitmap;
     private readonly Graphics _graphics;
 
-    public WindowsMeasurementContext (int dpiX, int dpiY)
+    public WindowsMeasurementContext(int dpiX, int dpiY)
     {
         // A representative 1x1 surface is enough for glyph metrics.
-        _bitmap = new Bitmap (1, 1);
-        _bitmap.SetResolution (dpiX, dpiY);
-        _graphics = Graphics.FromImage (_bitmap);
+        _bitmap = new Bitmap(1, 1);
+        _bitmap.SetResolution(dpiX, dpiY);
+        _graphics = Graphics.FromImage(_bitmap);
         _graphics.PageUnit = GraphicsUnit.Display; // Display is 1/100th"
-        Context = new SystemDrawingGraphicsContext (_graphics);
+        Context = new SystemDrawingGraphicsContext(_graphics);
     }
 
     public IGraphicsContext Context { get; }
 
-    public void Dispose ()
+    public void Dispose()
     {
-        _graphics.Dispose ();
-        _bitmap.Dispose ();
+        _graphics.Dispose();
+        _bitmap.Dispose();
     }
 }

--- a/src/WinPrint.Core/Helpers/DelayedEvent.cs
+++ b/src/WinPrint.Core/Helpers/DelayedEvent.cs
@@ -8,7 +8,7 @@ namespace WinPrint.Core.Helpers;
 /// <summary>
 ///     This class wraps FileSystemEventArgs and RenamedEventArgs objects and detection of duplicate events.
 /// </summary>
-public class DelayedEvent (FileSystemEventArgs args)
+public class DelayedEvent(FileSystemEventArgs args)
 {
     public FileSystemEventArgs Args { get; } = args;
 
@@ -18,11 +18,10 @@ public class DelayedEvent (FileSystemEventArgs args)
     public bool Delayed { get; set; }
 
 #pragma warning disable CA1720 // Identifier contains type name
-    public virtual bool IsDuplicate (object? obj)
+    public virtual bool IsDuplicate(object? obj)
     {
 #pragma warning restore CA1720 // Identifier contains type name
-        var delayedEvent = obj as DelayedEvent;
-        if (delayedEvent == null)
+        if (obj is not DelayedEvent delayedEvent)
         {
             return false; // this is not null so they are different
         }

--- a/src/WinPrint.Core/Helpers/Diagnostics.cs
+++ b/src/WinPrint.Core/Helpers/Diagnostics.cs
@@ -4,8 +4,8 @@ namespace WinPrint.Core.Helpers;
 
 internal class Diagnostics
 {
-    [DllImport ("libgdiplus", ExactSpelling = true)]
-    internal static extern string GetLibgdiplusVersion ();
+    [DllImport("libgdiplus", ExactSpelling = true)]
+    internal static extern string GetLibgdiplusVersion();
 
     ///// <summary>
     ///// Gets the version of libgdiplus. 

--- a/src/WinPrint.Core/Helpers/FileSystemSafeWatcher.cs
+++ b/src/WinPrint.Core/Helpers/FileSystemSafeWatcher.cs
@@ -30,7 +30,7 @@ public class FileSystemSafeWatcher
     /// <summary>
     ///     Lock order is _enterThread, _events.SyncRoot
     /// </summary>
-    private readonly object? _enterThread = new (); // Only one timer event is processed at any given moment
+    private readonly object? _enterThread = new(); // Only one timer event is processed at any given moment
 
     private readonly FileSystemWatcher? _fileSystemWatcher;
     private int _consolidationInterval = 1000; // milliseconds
@@ -41,22 +41,22 @@ public class FileSystemSafeWatcher
 
     #region Delegate to FileSystemWatcher
 
-    public FileSystemSafeWatcher ()
+    public FileSystemSafeWatcher()
     {
-        _fileSystemWatcher = new FileSystemWatcher ();
-        Initialize ();
+        _fileSystemWatcher = new FileSystemWatcher();
+        Initialize();
     }
 
-    public FileSystemSafeWatcher (string path)
+    public FileSystemSafeWatcher(string path)
     {
-        _fileSystemWatcher = new FileSystemWatcher (path);
-        Initialize ();
+        _fileSystemWatcher = new FileSystemWatcher(path);
+        Initialize();
     }
 
-    public FileSystemSafeWatcher (string path, string filter)
+    public FileSystemSafeWatcher(string path, string filter)
     {
-        _fileSystemWatcher = new FileSystemWatcher (path, filter);
-        Initialize ();
+        _fileSystemWatcher = new FileSystemWatcher(path, filter);
+        Initialize();
     }
 
     /// <summary>
@@ -74,12 +74,12 @@ public class FileSystemSafeWatcher
             _fileSystemWatcher!.EnableRaisingEvents = value;
             if (value)
             {
-                _serverTimer!.Start ();
+                _serverTimer!.Start();
             }
             else
             {
-                _serverTimer!.Stop ();
-                _events!.Clear ();
+                _serverTimer!.Stop();
+                _events!.Clear();
             }
         }
     }
@@ -187,72 +187,72 @@ public class FileSystemSafeWatcher
     ///     Begins the initialization of a System.IO.FileSystemWatcher used on a form or used by another component. The
     ///     initialization occurs at run time.
     /// </summary>
-    public void BeginInit ()
+    public void BeginInit()
     {
-        _fileSystemWatcher!.BeginInit ();
+        _fileSystemWatcher!.BeginInit();
     }
 
     /// <summary>
     ///     Releases the unmanaged resources used by the System.IO.FileSystemWatcher and optionally releases the managed
     ///     resources.
     /// </summary>
-    public void Dispose ()
+    public void Dispose()
     {
-        Uninitialize ();
+        Uninitialize();
     }
 
     /// <summary>
     ///     Ends the initialization of a System.IO.FileSystemWatcher used on a form or used by another component. The
     ///     initialization occurs at run time.
     /// </summary>
-    public void EndInit ()
+    public void EndInit()
     {
-        _fileSystemWatcher!.EndInit ();
+        _fileSystemWatcher!.EndInit();
     }
 
     /// <summary>
     ///     Raises the System.IO.FileSystemWatcher.Changed event.
     /// </summary>
     /// <param name="e">A System.IO.FileSystemEventArgs that contains the event data.</param>
-    protected void OnChanged (FileSystemEventArgs e)
+    protected void OnChanged(FileSystemEventArgs e)
     {
-        Changed?.Invoke (this, e);
+        Changed?.Invoke(this, e);
     }
 
     /// <summary>
     ///     Raises the System.IO.FileSystemWatcher.Created event.
     /// </summary>
     /// <param name="e">A System.IO.FileSystemEventArgs that contains the event data.</param>
-    protected void OnCreated (FileSystemEventArgs e)
+    protected void OnCreated(FileSystemEventArgs e)
     {
-        Created?.Invoke (this, e);
+        Created?.Invoke(this, e);
     }
 
     /// <summary>
     ///     Raises the System.IO.FileSystemWatcher.Deleted event.
     /// </summary>
     /// <param name="e">A System.IO.FileSystemEventArgs that contains the event data.</param>
-    protected void OnDeleted (FileSystemEventArgs e)
+    protected void OnDeleted(FileSystemEventArgs e)
     {
-        Deleted?.Invoke (this, e);
+        Deleted?.Invoke(this, e);
     }
 
     /// <summary>
     ///     Raises the System.IO.FileSystemWatcher.Error event.
     /// </summary>
     /// <param name="e">An System.IO.ErrorEventArgs that contains the event data.</param>
-    protected void OnError (ErrorEventArgs e)
+    protected void OnError(ErrorEventArgs e)
     {
-        Error?.Invoke (this, e);
+        Error?.Invoke(this, e);
     }
 
     /// <summary>
     ///     Raises the System.IO.FileSystemWatcher.Renamed event.
     /// </summary>
     /// <param name="e">A System.IO.RenamedEventArgs that contains the event data.</param>
-    protected void OnRenamed (RenamedEventArgs e)
+    protected void OnRenamed(RenamedEventArgs e)
     {
-        Renamed?.Invoke (this, e);
+        Renamed?.Invoke(this, e);
     }
 
     /// <summary>
@@ -261,10 +261,10 @@ public class FileSystemSafeWatcher
     /// </summary>
     /// <param name="changeType">The System.IO.WatcherChangeTypes to watch for.</param>
     /// <returns>A System.IO.WaitForChangedResult that contains specific information on the change that occurred.</returns>
-    public WaitForChangedResult WaitForChanged (WatcherChangeTypes changeType)
+    public WaitForChangedResult WaitForChanged(WatcherChangeTypes changeType)
     {
         //TODO
-        throw new NotImplementedException ();
+        throw new NotImplementedException();
     }
 
     /// <summary>
@@ -275,63 +275,63 @@ public class FileSystemSafeWatcher
     /// <param name="changeType">The System.IO.WatcherChangeTypes to watch for.</param>
     /// <param name="timeout">The time (in milliseconds) to wait before timing out.</param>
     /// <returns>A System.IO.WaitForChangedResult that contains specific information on the change that occurred.</returns>
-    public WaitForChangedResult WaitForChanged (WatcherChangeTypes changeType, int timeout)
+    public WaitForChangedResult WaitForChanged(WatcherChangeTypes changeType, int timeout)
     {
         //TODO
-        throw new NotImplementedException ();
+        throw new NotImplementedException();
     }
 
     #endregion
 
     #region Implementation
 
-    private void Initialize ()
+    private void Initialize()
     {
-        _events = ArrayList.Synchronized (new ArrayList (32));
+        _events = ArrayList.Synchronized(new ArrayList(32));
         _fileSystemWatcher!.Changed += FileSystemEventHandler;
         _fileSystemWatcher.Created += FileSystemEventHandler;
         _fileSystemWatcher.Deleted += FileSystemEventHandler;
         _fileSystemWatcher.Error += ErrorEventHandler;
         _fileSystemWatcher.Renamed += RenamedEventHandler;
-        _serverTimer = new Timer (_consolidationInterval);
+        _serverTimer = new Timer(_consolidationInterval);
         _serverTimer.Elapsed += ElapsedEventHandler;
         _serverTimer.AutoReset = true;
         _serverTimer.Enabled = _fileSystemWatcher.EnableRaisingEvents;
     }
 
-    private void Uninitialize ()
+    private void Uninitialize()
     {
-        _fileSystemWatcher?.Dispose ();
+        _fileSystemWatcher?.Dispose();
 
-        _serverTimer?.Dispose ();
+        _serverTimer?.Dispose();
     }
 
-    private void FileSystemEventHandler (object? sender, FileSystemEventArgs e)
+    private void FileSystemEventHandler(object? sender, FileSystemEventArgs e)
     {
-        _events!.Add (new DelayedEvent (e));
+        _events!.Add(new DelayedEvent(e));
     }
 
-    private void ErrorEventHandler (object? sender, ErrorEventArgs e)
+    private void ErrorEventHandler(object? sender, ErrorEventArgs e)
     {
-        OnError (e);
+        OnError(e);
     }
 
-    private void RenamedEventHandler (object? sender, RenamedEventArgs e)
+    private void RenamedEventHandler(object? sender, RenamedEventArgs e)
     {
-        _events!.Add (new DelayedEvent (e));
+        _events!.Add(new DelayedEvent(e));
     }
 
-    private void ElapsedEventHandler (object? sender, ElapsedEventArgs e)
+    private void ElapsedEventHandler(object? sender, ElapsedEventArgs e)
     {
         // We don't fire the events inside the lock. We will queue them here until
         // the code exits the locks.
         Queue? eventsToBeFired = null;
-        if (Monitor.TryEnter (_enterThread!))
+        if (Monitor.TryEnter(_enterThread!))
         {
             // Only one thread at a time is processing the events                
             try
             {
-                eventsToBeFired = new Queue (32);
+                eventsToBeFired = new Queue(32);
                 // Lock the collection while processing the events
                 lock (_events!.SyncRoot)
                 {
@@ -344,10 +344,10 @@ public class FileSystemSafeWatcher
                             // We just need to remove any duplicates
                             for (int j = i + 1; j < _events.Count; j++)
                             {
-                                if (current.IsDuplicate (_events[j]))
+                                if (current.IsDuplicate(_events[j]))
                                 {
                                     // Removing later duplicates
-                                    _events.RemoveAt (j);
+                                    _events.RemoveAt(j);
                                     j--; // Don't skip next event
                                 }
                             }
@@ -360,7 +360,7 @@ public class FileSystemSafeWatcher
                                 FileStream? stream = null;
                                 try
                                 {
-                                    stream = File.Open (current.Args.FullPath, FileMode.Open, FileAccess.Read,
+                                    stream = File.Open(current.Args.FullPath, FileMode.Open, FileAccess.Read,
                                         FileShare.None);
                                     // If this succeeds, the file is finished
                                 }
@@ -372,7 +372,7 @@ public class FileSystemSafeWatcher
                                 {
                                     if (stream != null)
                                     {
-                                        stream.Close ();
+                                        stream.Close();
                                     }
                                 }
                             }
@@ -380,9 +380,9 @@ public class FileSystemSafeWatcher
                             if (raiseEvent)
                             {
                                 // Add the event to the list of events to be fired
-                                eventsToBeFired.Enqueue (current);
+                                eventsToBeFired.Enqueue(current);
                                 // Remove it from the current list
-                                _events.RemoveAt (i);
+                                _events.RemoveAt(i);
                                 i--; // Don't skip next event
                             }
                         }
@@ -397,13 +397,13 @@ public class FileSystemSafeWatcher
             }
             finally
             {
-                Monitor.Exit (_enterThread!);
+                Monitor.Exit(_enterThread!);
             }
         }
         // else - this timer event was skipped, processing will happen during the next timer event
 
         // Now fire all the events if any events are in eventsToBeFired
-        RaiseEvents (eventsToBeFired!);
+        RaiseEvents(eventsToBeFired!);
     }
 
     public int ConsolidationInterval
@@ -417,29 +417,29 @@ public class FileSystemSafeWatcher
     }
 
 #pragma warning disable CA1030 // Use events where appropriate
-    protected void RaiseEvents (Queue? deQueue)
+    protected void RaiseEvents(Queue? deQueue)
     {
 #pragma warning restore CA1030 // Use events where appropriate
         if (deQueue is { Count: > 0 })
         {
             while (deQueue.Count > 0)
             {
-                var de = (DelayedEvent)deQueue.Dequeue ()!;
+                var de = (DelayedEvent)deQueue.Dequeue()!;
                 switch (de.Args!.ChangeType)
                 {
                     case WatcherChangeTypes.Changed:
-                        OnChanged (de.Args);
+                        OnChanged(de.Args);
                         break;
                     case WatcherChangeTypes.Created:
-                        OnCreated (de.Args);
+                        OnCreated(de.Args);
                         break;
                     case WatcherChangeTypes.Deleted:
-                        OnDeleted (de.Args);
+                        OnDeleted(de.Args);
                         break;
                     case WatcherChangeTypes.Renamed:
                         if (de.Args is RenamedEventArgs renamedEventArgs)
                         {
-                            OnRenamed (renamedEventArgs);
+                            OnRenamed(renamedEventArgs);
                         }
 
                         break;

--- a/src/WinPrint.Core/Helpers/FileWatcher.cs
+++ b/src/WinPrint.Core/Helpers/FileWatcher.cs
@@ -10,9 +10,9 @@ public class FileWatcher : IDisposable
     private FileSystemSafeWatcher? _fileWatcher;
 #pragma warning restore IDE0052 // Remove unread private members
 
-    public FileWatcher (string file)
+    public FileWatcher(string file)
     {
-        _fileWatcher = CreateFileWatcher (file);
+        _fileWatcher = CreateFileWatcher(file);
     }
 
     public event EventHandler? ChangedEvent;
@@ -21,7 +21,7 @@ public class FileWatcher : IDisposable
     ///     OnChangeEvent is raised whenever the CommandTable is updated due to
     ///     user commands file changes
     /// </summary>
-    protected virtual void OnChangedEvent ()
+    protected virtual void OnChangedEvent()
     {
         // Make a temporary copy of the event to avoid possibility of
         // a race condition if the last subscriber unsubscribes
@@ -29,19 +29,19 @@ public class FileWatcher : IDisposable
         EventHandler? handler = ChangedEvent;
 
         // Event will be null if there are no subscribers
-        handler?.Invoke (this, EventArgs.Empty);
+        handler?.Invoke(this, EventArgs.Empty);
     }
 
-    private FileSystemSafeWatcher CreateFileWatcher (string path)
+    private FileSystemSafeWatcher CreateFileWatcher(string path)
     {
         // Create a new FileSystemSafeWatcher and set its properties.
         var watcher = new FileSystemSafeWatcher
         {
-            Path = Path.GetDirectoryName (path) ?? string.Empty,
+            Path = Path.GetDirectoryName(path) ?? string.Empty,
             /* Watch for changes in LastAccess and LastWrite times, and
                the renaming of files or directories. */
             NotifyFilter = NotifyFilters.LastWrite,
-            Filter = Path.GetFileName (path)
+            Filter = Path.GetFileName(path)
         };
 
         // Add event handlers.
@@ -52,27 +52,27 @@ public class FileWatcher : IDisposable
 
         // Begin watching.
         watcher.EnableRaisingEvents = true;
-        LogService.TraceMessage ($"FileSystemSafeWatcher: Watching {watcher.Path}\\{watcher.Filter} for changes.");
+        LogService.TraceMessage($"FileSystemSafeWatcher: Watching {watcher.Path}\\{watcher.Filter} for changes.");
         return watcher;
     }
 
-    private void OnChanged (object? source, FileSystemEventArgs e)
+    private void OnChanged(object? source, FileSystemEventArgs e)
     {
         //Logger.Instance.Log4.Info($"Commands:{e.FullPath} changed.");
-        OnChangedEvent ();
+        OnChangedEvent();
     }
 
-    private void OnRenamed (object? source, RenamedEventArgs e)
+    private void OnRenamed(object? source, RenamedEventArgs e)
     {
         // Specify what is done when a file is renamed.
-        LogService.TraceMessage ($"FileSystemSafeWatcher:{e.OldFullPath} renamed to {e.FullPath}");
+        LogService.TraceMessage($"FileSystemSafeWatcher:{e.OldFullPath} renamed to {e.FullPath}");
     }
 
     #region IDisposable Support
 
     private bool _disposedValue; // To detect redundant calls
 
-    protected virtual void Dispose (bool disposing)
+    protected virtual void Dispose(bool disposing)
     {
         if (!_disposedValue)
         {
@@ -92,11 +92,11 @@ public class FileWatcher : IDisposable
         }
     }
 
-    public void Dispose ()
+    public void Dispose()
     {
         // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-        Dispose (true);
-        GC.SuppressFinalize (this);
+        Dispose(true);
+        GC.SuppressFinalize(this);
     }
 
     #endregion

--- a/src/WinPrint.Core/Helpers/HtmlResources.cs
+++ b/src/WinPrint.Core/Helpers/HtmlResources.cs
@@ -4,45 +4,45 @@ using WinPrint.Core.Services;
 
 namespace WinPrint.LiteHtml;
 
-public class HtmlResources (string filePath)
+public class HtmlResources(string filePath)
 {
-    public byte[] GetResourceBytes (string resource)
+    public byte[] GetResourceBytes(string resource)
     {
-        LogService.TraceMessage ($"{resource}");
-        byte[] data = Array.Empty<byte> ();
-        if (string.IsNullOrWhiteSpace (resource))
+        LogService.TraceMessage($"{resource}");
+        byte[] data = [];
+        if (string.IsNullOrWhiteSpace(resource))
         {
             return data;
         }
 
         try
         {
-            data = File.ReadAllBytes ($"{Path.GetDirectoryName (filePath)}\\{resource}");
+            data = File.ReadAllBytes($"{Path.GetDirectoryName(filePath)}\\{resource}");
         }
         catch (Exception e)
         {
-            LogService.TraceMessage ($"GetResourceBytes({resource}) - {e.Message}");
+            LogService.TraceMessage($"GetResourceBytes({resource}) - {e.Message}");
         }
 
         return data;
     }
 
-    public string GetResourceString (string resource)
+    public string GetResourceString(string resource)
     {
-        LogService.TraceMessage ($"{resource}");
+        LogService.TraceMessage($"{resource}");
         string data = string.Empty;
-        if (string.IsNullOrWhiteSpace (resource))
+        if (string.IsNullOrWhiteSpace(resource))
         {
             return data;
         }
 
         try
         {
-            if (resource.StartsWith ("file:"))
+            if (resource.StartsWith("file:"))
             {
-                var urlBuilder = new UriBuilder (resource);
-                using var reader = new StreamReader (urlBuilder.Path);
-                data = reader.ReadToEnd ();
+                var urlBuilder = new UriBuilder(resource);
+                using var reader = new StreamReader(urlBuilder.Path);
+                data = reader.ReadToEnd();
             }
 
             // TODO: Implement loading external html resources
@@ -52,7 +52,7 @@ public class HtmlResources (string filePath)
         }
         catch (Exception e)
         {
-            LogService.TraceMessage ($"GetResourceString({resource}) - {e.Message}");
+            LogService.TraceMessage($"GetResourceString({resource}) - {e.Message}");
             return data;
         }
     }

--- a/src/WinPrint.Core/Models/ContentSettings.cs
+++ b/src/WinPrint.Core/Models/ContentSettings.cs
@@ -9,7 +9,7 @@ public class ContentSettings : ModelBase
     private int _darkness;
     private bool _diagnostics;
     private bool _disableFontStyles;
-    private Font _font = new ();
+    private Font _font = new();
     private bool _grayscale;
     private bool _lineNumberSeparator = true;
     private bool _lineNumbers = true;
@@ -25,7 +25,7 @@ public class ContentSettings : ModelBase
     public Font Font
     {
         get => _font;
-        set => SetField (ref _font, value);
+        set => SetField(ref _font, value);
     }
 
     /// <summary>
@@ -35,7 +35,7 @@ public class ContentSettings : ModelBase
     public bool PrintBackground
     {
         get => _printBackground;
-        set => SetField (ref _printBackground, value);
+        set => SetField(ref _printBackground, value);
     }
 
     /// <summary>
@@ -46,7 +46,7 @@ public class ContentSettings : ModelBase
     public bool Grayscale
     {
         get => _grayscale;
-        set => SetField (ref _grayscale, value);
+        set => SetField(ref _grayscale, value);
     }
 
     /// <summary>
@@ -56,7 +56,7 @@ public class ContentSettings : ModelBase
     public int Darkness
     {
         get => _darkness;
-        set => SetField (ref _darkness, value);
+        set => SetField(ref _darkness, value);
     }
 
     /// <summary>
@@ -66,7 +66,7 @@ public class ContentSettings : ModelBase
     public string Style
     {
         get => _style;
-        set => SetField (ref _style, value);
+        set => SetField(ref _style, value);
     }
 
     /// <summary>
@@ -76,7 +76,7 @@ public class ContentSettings : ModelBase
     public bool DisableFontStyles
     {
         get => _disableFontStyles;
-        set => SetField (ref _disableFontStyles, value);
+        set => SetField(ref _disableFontStyles, value);
     }
 
     /// <summary>
@@ -86,7 +86,7 @@ public class ContentSettings : ModelBase
     public bool LineNumbers
     {
         get => _lineNumbers;
-        set => SetField (ref _lineNumbers, value);
+        set => SetField(ref _lineNumbers, value);
     }
 
     /// <summary>
@@ -96,7 +96,7 @@ public class ContentSettings : ModelBase
     public bool LineNumberSeparator
     {
         get => _lineNumberSeparator;
-        set => SetField (ref _lineNumberSeparator, value);
+        set => SetField(ref _lineNumberSeparator, value);
     }
 
     /// <summary>
@@ -106,7 +106,7 @@ public class ContentSettings : ModelBase
     public int TabSpaces
     {
         get => _tabSpaces;
-        set => SetField (ref _tabSpaces, value);
+        set => SetField(ref _tabSpaces, value);
     }
 
     /// <summary>
@@ -116,7 +116,7 @@ public class ContentSettings : ModelBase
     public bool NewPageOnFormFeed
     {
         get => _newPageOnFormFeed;
-        set => SetField (ref _newPageOnFormFeed, value);
+        set => SetField(ref _newPageOnFormFeed, value);
     }
 
     /// <summary>
@@ -126,6 +126,6 @@ public class ContentSettings : ModelBase
     public bool Diagnostics
     {
         get => _diagnostics;
-        set => SetField (ref _diagnostics, value);
+        set => SetField(ref _diagnostics, value);
     }
 }

--- a/src/WinPrint.Core/Models/ContentType.cs
+++ b/src/WinPrint.Core/Models/ContentType.cs
@@ -13,13 +13,13 @@ public class ContentType
 
     [SafeForTelemetry] public string Title { get; set; } = string.Empty;
 
-    public override int GetHashCode ()
+    public override int GetHashCode()
     {
-        return Id?.GetHashCode () ?? 0;
+        return Id?.GetHashCode() ?? 0;
     }
 
-    public override bool Equals (object? obj)
+    public override bool Equals(object? obj)
     {
-        return obj is ContentType other && string.Equals (Id, other.Id, StringComparison.Ordinal);
+        return obj is ContentType other && string.Equals(Id, other.Id, StringComparison.Ordinal);
     }
 }

--- a/src/WinPrint.Core/Models/FileTypeMapping.cs
+++ b/src/WinPrint.Core/Models/FileTypeMapping.cs
@@ -18,7 +18,7 @@ public class FileTypeMapping : ModelBase
     //    "aliases": [ "Java", "java" ]
     //}]
 
-    public Dictionary<string, string> FilesAssociations { get; set; } = new ();
+    public Dictionary<string, string> FilesAssociations { get; set; } = [];
 
     public IList<ContentType> ContentTypes { get; set; } = [];
 }

--- a/src/WinPrint.Core/Models/Font.cs
+++ b/src/WinPrint.Core/Models/Font.cs
@@ -27,7 +27,7 @@ public class Font : ICloneable
         get => _style;
         set
         {
-            if (!Enum.IsDefined (typeof (FontStyle), value))
+            if (!Enum.IsDefined(typeof(FontStyle), value))
             {
                 value = FontStyle.Bold | FontStyle.Italic;
             }
@@ -48,19 +48,19 @@ public class Font : ICloneable
         //SetField(ref size, value);
     } = 8F;
 
-    public object Clone ()
+    public object Clone()
     {
-        return MemberwiseClone ();
+        return MemberwiseClone();
     }
 
-    public override int GetHashCode ()
+    public override int GetHashCode()
     {
-        return HashCode.Combine (Family, Size, Style);
+        return HashCode.Combine(Family, Size, Style);
     }
 
-    public override bool Equals (object? obj)
+    public override bool Equals(object? obj)
     {
-        if (!(obj is Font font))
+        if (obj is not Font font)
         {
             return false;
         }
@@ -70,7 +70,7 @@ public class Font : ICloneable
                && font.Style == Style;
     }
 
-    public static bool operator == (Font? m1, Font? m2)
+    public static bool operator ==(Font? m1, Font? m2)
     {
         if (m1 is null)
         {
@@ -82,13 +82,13 @@ public class Font : ICloneable
             return false;
         }
 
-        return m1.Equals (m2);
+        return m1.Equals(m2);
     }
 
     /// <summary>
     ///     Tests whether two <see cref='Font' /> objects are different.
     /// </summary>
-    public static bool operator != (Font? m1, Font? m2)
+    public static bool operator !=(Font? m1, Font? m2)
     {
         return !(m1 == m2);
     }
@@ -96,9 +96,9 @@ public class Font : ICloneable
     /// <summary>
     ///     Provides some interesting information for the Font in String form.
     /// </summary>
-    public override string ToString ()
+    public override string ToString()
     {
-        return $"{Family}, {Size.ToString (CultureInfo.InvariantCulture)}pt, {Style.ToString ()}";
+        return $"{Family}, {Size.ToString(CultureInfo.InvariantCulture)}pt, {Style.ToString()}";
     }
 
     //public Font() {

--- a/src/WinPrint.Core/Models/HeaderFooter.cs
+++ b/src/WinPrint.Core/Models/HeaderFooter.cs
@@ -57,7 +57,7 @@ public abstract class HeaderFooter : ModelBase
     public string? Text
     {
         get => _text;
-        set => SetField (ref _text, value);
+        set => SetField(ref _text, value);
     }
 
     /// <summary>
@@ -70,11 +70,11 @@ public abstract class HeaderFooter : ModelBase
     {
         get
         {
-            var matches = Regex.Matches (Text ?? string.Empty,
+            var matches = Regex.Matches(Text ?? string.Empty,
                     @"(?<start>\{)+(?<property>[\w\.\[\]]+)(?<format>:[^}]+)?(?<end>\})+")
-                .Select (match => match.Value)
-                .ToList ();
-            return string.Join (", ", from macro in matches select macro);
+                .Select(match => match.Value)
+                .ToList();
+            return string.Join(", ", from macro in matches select macro);
         }
     }
 
@@ -85,7 +85,7 @@ public abstract class HeaderFooter : ModelBase
     public Font? Font
     {
         get => _font;
-        set => SetField (ref _font, value);
+        set => SetField(ref _font, value);
     }
 
     /// <summary>
@@ -95,7 +95,7 @@ public abstract class HeaderFooter : ModelBase
     public bool LeftBorder
     {
         get => _leftBorder;
-        set => SetField (ref _leftBorder, value);
+        set => SetField(ref _leftBorder, value);
     }
 
     /// <summary>
@@ -105,7 +105,7 @@ public abstract class HeaderFooter : ModelBase
     public bool TopBorder
     {
         get => _topBorder;
-        set => SetField (ref _topBorder, value);
+        set => SetField(ref _topBorder, value);
     }
 
     /// <summary>
@@ -115,7 +115,7 @@ public abstract class HeaderFooter : ModelBase
     public bool RightBorder
     {
         get => _rightBorder;
-        set => SetField (ref _rightBorder, value);
+        set => SetField(ref _rightBorder, value);
     }
 
     /// <summary>
@@ -125,7 +125,7 @@ public abstract class HeaderFooter : ModelBase
     public bool BottomBorder
     {
         get => _bottomBorder;
-        set => SetField (ref _bottomBorder, value);
+        set => SetField(ref _bottomBorder, value);
     }
 
     /// <summary>
@@ -135,7 +135,7 @@ public abstract class HeaderFooter : ModelBase
     public bool Enabled
     {
         get => _enabled;
-        set => SetField (ref _enabled, value);
+        set => SetField(ref _enabled, value);
     }
 
     /// <summary>
@@ -145,6 +145,6 @@ public abstract class HeaderFooter : ModelBase
     public int VerticalPadding
     {
         get => _verticalPadding;
-        set => SetField (ref _verticalPadding, value);
+        set => SetField(ref _verticalPadding, value);
     }
 }

--- a/src/WinPrint.Core/Models/Macros.cs
+++ b/src/WinPrint.Core/Models/Macros.cs
@@ -7,7 +7,7 @@ using System.Text.RegularExpressions;
 
 namespace WinPrint.Core.Models;
 
-public sealed class Macros (SheetViewModel svm)
+public sealed class Macros(SheetViewModel svm)
 {
     /// <summary>
     ///     The SheetModel the Macros will pull data from.
@@ -23,12 +23,12 @@ public sealed class Macros (SheetViewModel svm)
     ///     The extension (including the period ".").
     /// </summary>
     public string FileExtension =>
-        string.IsNullOrEmpty (SheetViewModel.File) ? "" : Path.GetExtension (SheetViewModel.File);
+        string.IsNullOrEmpty(SheetViewModel.File) ? "" : Path.GetExtension(SheetViewModel.File);
 
     /// <summary>
     ///     The file name and extension. If FileName was not provided, Title will be used.
     /// </summary>
-    public string FileName => GetFileNameOrTitle ();
+    public string FileName => GetFileNameOrTitle();
 
     /// <summary>
     ///     The Title of the print request.
@@ -39,19 +39,19 @@ public sealed class Macros (SheetViewModel svm)
     ///     The file name of the file without the extension and period ".".
     /// </summary>
     public string FileNameWithoutExtension =>
-        string.IsNullOrEmpty (SheetViewModel.File) ? "" : Path.GetFileNameWithoutExtension (SheetViewModel.File);
+        string.IsNullOrEmpty(SheetViewModel.File) ? "" : Path.GetFileNameWithoutExtension(SheetViewModel.File);
 
     /// <summary>
     ///     The directory for the specified string without the filename or extension.
     /// </summary>
     public string FileDirectoryName =>
-        (string.IsNullOrEmpty (SheetViewModel.File) ? "" : Path.GetDirectoryName (FullPath)) ?? string.Empty;
+        (string.IsNullOrEmpty(SheetViewModel.File) ? "" : Path.GetDirectoryName(FullPath)) ?? string.Empty;
 
     /// <summary>
     ///     The absolute path for the file.
     /// </summary>
-    public string FullPath => IsValidFilename (SheetViewModel.File) ? Path.GetFullPath (SheetViewModel.File) :
-        string.IsNullOrEmpty (SheetViewModel.File) ? "" : SheetViewModel.File;
+    public string FullPath => IsValidFilename(SheetViewModel.File) ? Path.GetFullPath(SheetViewModel.File) :
+        string.IsNullOrEmpty(SheetViewModel.File) ? "" : SheetViewModel.File;
 
     /// <summary>
     ///     The time and date when printed.
@@ -61,32 +61,32 @@ public sealed class Macros (SheetViewModel svm)
     /// <summary>
     ///     The time and date the file was last revised.
     /// </summary>
-    public DateTime DateRevised => IsValidFilename (SheetViewModel.File)
-        ? File.GetLastWriteTime (SheetViewModel.File)
+    public DateTime DateRevised => IsValidFilename(SheetViewModel.File)
+        ? File.GetLastWriteTime(SheetViewModel.File)
         : DateTime.MinValue;
 
     /// <summary>
     ///     The time and date the file was created.
     /// </summary>
-    public DateTime DateCreated => IsValidFilename (SheetViewModel.File)
-        ? File.GetCreationTime (SheetViewModel.File)
+    public DateTime DateCreated => IsValidFilename(SheetViewModel.File)
+        ? File.GetCreationTime(SheetViewModel.File)
         : DateTime.MinValue;
 
     /// <summary>
     ///     The language (e.g. "C#" or "java").
     /// </summary>
-    public string Language => string.IsNullOrEmpty (SheetViewModel.Language) ? string.Empty : SheetViewModel.Language;
+    public string Language => string.IsNullOrEmpty(SheetViewModel.Language) ? string.Empty : SheetViewModel.Language;
 
     /// <summary>
     ///     The Contetn Type (e.g. "text/x-csharp")
     /// </summary>
     public string? ContentType =>
-        string.IsNullOrEmpty (SheetViewModel.ContentType) ? string.Empty : SheetViewModel.ContentType;
+        string.IsNullOrEmpty(SheetViewModel.ContentType) ? string.Empty : SheetViewModel.ContentType;
 
     /// <summary>
     ///     The file content type engine name (e.g. "TextCte", "AnsiCte").
     /// </summary>
-    public string CteName => SheetViewModel.ContentEngine?.GetType ().Name ?? string.Empty;
+    public string CteName => SheetViewModel.ContentEngine?.GetType().Name ?? string.Empty;
 
     /// <summary>
     ///     The style used for formatting (e.g. "default" or "colorful"; from Pygments.org).
@@ -100,16 +100,16 @@ public sealed class Macros (SheetViewModel svm)
     public int Page { get; set; }
 
     // https://stackoverflow.com/questions/62771/how-do-i-check-if-a-given-string-is-a-legal-valid-file-name-under-windows#62855
-    private bool IsValidFilename (string testName)
+    private bool IsValidFilename(string testName)
     {
-        if (string.IsNullOrEmpty (testName))
+        if (string.IsNullOrEmpty(testName))
         {
             return false;
         }
 
-        var containsABadCharacter = new Regex ("["
-                                               + Regex.Escape (new string (Path.GetInvalidPathChars ())) + "]");
-        if (containsABadCharacter.IsMatch (testName))
+        var containsABadCharacter = new Regex("["
+                                              + Regex.Escape(new string(Path.GetInvalidPathChars())) + "]");
+        if (containsABadCharacter.IsMatch(testName))
         {
             return false;
         }
@@ -118,7 +118,7 @@ public sealed class Macros (SheetViewModel svm)
 
         // other checks for UNC, drive-path format, etc
 
-        if (!File.Exists (testName))
+        if (!File.Exists(testName))
         {
             return false;
         }
@@ -127,18 +127,18 @@ public sealed class Macros (SheetViewModel svm)
     }
 
     // Title and FileName are synomous. 
-    private string GetFileNameOrTitle ()
+    private string GetFileNameOrTitle()
     {
         string retval = "";
 
-        if (string.IsNullOrEmpty (SheetViewModel.File))
+        if (string.IsNullOrEmpty(SheetViewModel.File))
         {
             return retval;
         }
 
         try
         {
-            retval = Path.GetFileName (SheetViewModel.File);
+            retval = Path.GetFileName(SheetViewModel.File);
         }
         catch (ArgumentException)
         {
@@ -160,11 +160,11 @@ public sealed class Macros (SheetViewModel svm)
     /// <param name="sheetNum">
     ///     <Page #/ param>
     ///         <returns></returns>
-    public string ReplaceMacros (string? value)
+    public string ReplaceMacros(string? value)
     {
-        return Regex.Replace (value!, @"(?<start>\{)+(?<property>[\w\.\[\]]+)(?<format>:[^}]+)?(?<end>\})+", match =>
+        return Regex.Replace(value!, @"(?<start>\{)+(?<property>[\w\.\[\]]+)(?<format>:[^}]+)?(?<end>\})+", match =>
         {
-            ParameterExpression p = Expression.Parameter (typeof (Macros), "Macros");
+            ParameterExpression p = Expression.Parameter(typeof(Macros), "Macros");
 
             Group startGroup = match.Groups["start"];
             Group propertyGroup = match.Groups["property"];
@@ -174,17 +174,17 @@ public sealed class Macros (SheetViewModel svm)
             try
             {
                 // Generate and parse a LambdaExpression
-                LambdaExpression e = DynamicExpressionParser.ParseLambda (new[] { p }, null, propertyGroup.Value);
-                object? computedValue = e.Compile ().DynamicInvoke (this);
+                LambdaExpression e = DynamicExpressionParser.ParseLambda([p], null, propertyGroup.Value);
+                object? computedValue = e.Compile().DynamicInvoke(this);
                 if (formatGroup.Success)
                 {
                     // There's a format specifier
                     // The following does: string.Format("{0:formatGroup.Value}", computedValue)
-                    return string.Format (CultureInfo.InvariantCulture, "{0" + formatGroup.Value + "}", computedValue);
+                    return string.Format(CultureInfo.InvariantCulture, "{0" + formatGroup.Value + "}", computedValue);
                 }
 
                 // Get here when there is no format specifier.
-                return (computedValue ?? "").ToString ()!;
+                return (computedValue ?? "").ToString()!;
             }
             catch
             {

--- a/src/WinPrint.Core/Models/ModelBase.cs
+++ b/src/WinPrint.Core/Models/ModelBase.cs
@@ -12,26 +12,26 @@ public abstract class ModelBase : INotifyPropertyChanged
 {
     public event PropertyChangedEventHandler? PropertyChanged;
 
-    protected void OnPropertyChanged ([CallerMemberName] string? propertyName = null)
+    protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
     {
-        PropertyChanged?.Invoke (this, new PropertyChangedEventArgs (propertyName));
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
 
-    protected bool SetField<T> (ref T field, T value, [CallerMemberName] string? propertyName = null)
+    protected bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
     {
-        if (EqualityComparer<T>.Default.Equals (field, value))
+        if (EqualityComparer<T>.Default.Equals(field, value))
         {
             return false;
         }
 
         field = value;
-        OnPropertyChanged (propertyName);
+        OnPropertyChanged(propertyName);
         return true;
     }
 
-    public override string ToString ()
+    public override string ToString()
     {
-        return JsonSerializer.Serialize (this, GetType ());
+        return JsonSerializer.Serialize(this, GetType());
         //return base.ToString();
     }
 
@@ -41,25 +41,25 @@ public abstract class ModelBase : INotifyPropertyChanged
     ///     property of a class derived from ModelBase to enable emitting to telemetry.
     /// </summary>
     /// <returns>A dictionary with the properties and values (as strings). Suitable for calling TrackEvent().</returns>
-    public virtual IDictionary<string, string?> GetTelemetryDictionary ()
+    public virtual IDictionary<string, string?> GetTelemetryDictionary()
     {
-        var dictionary = new Dictionary<string, string?> ();
-        foreach (PropertyDescriptor property in TypeDescriptor.GetProperties (this))
+        var dictionary = new Dictionary<string, string?>();
+        foreach (PropertyDescriptor property in TypeDescriptor.GetProperties(this))
         {
-            if (property.Attributes.Contains (new SafeForTelemetry ()))
+            if (property.Attributes.Contains(new SafeForTelemetry()))
             {
-                object? value = property.GetValue (this);
+                object? value = property.GetValue(this);
                 if (value != null)
                 {
-                    if (property.PropertyType.IsSubclassOf (typeof (ModelBase)))
+                    if (property.PropertyType.IsSubclassOf(typeof(ModelBase)))
                     {
                         // Go deep
-                        IDictionary<string, string?> propDict = ((ModelBase)value).GetTelemetryDictionary ();
-                        dictionary.Add (property.Name, JsonSerializer.Serialize (propDict, propDict.GetType ()));
+                        IDictionary<string, string?> propDict = ((ModelBase)value).GetTelemetryDictionary();
+                        dictionary.Add(property.Name, JsonSerializer.Serialize(propDict, propDict.GetType()));
                     }
                     else
                     {
-                        dictionary.Add (property.Name, JsonSerializer.Serialize (value, value.GetType ()));
+                        dictionary.Add(property.Name, JsonSerializer.Serialize(value, value.GetType()));
                     }
                 }
             }
@@ -76,76 +76,76 @@ public abstract class ModelBase : INotifyPropertyChanged
     ///     https://github.com/dotnet/corefx/issues/37627
     /// </summary>
     /// <param name="source"></param>
-    public virtual void CopyPropertiesFrom (ModelBase? source)
+    public virtual void CopyPropertiesFrom(ModelBase? source)
     {
         if (source is null)
         {
             return;
         }
 
-        var sourceProps = source.GetType ().GetProperties ().Where (x => x.CanRead).ToList ();
-        var destProps = GetType ().GetProperties ().Where (x => x.CanWrite).ToList ();
+        var sourceProps = source.GetType().GetProperties().Where(x => x.CanRead).ToList();
+        var destProps = GetType().GetProperties().Where(x => x.CanWrite).ToList();
         foreach ((PropertyInfo? sourceProp, PropertyInfo? destProp) in
                  // check if the property can be set or no.
                  from sourceProp in sourceProps
-                 where destProps.Any (x => x.Name == sourceProp.Name)
-                 let destProp = destProps.First (x => x.Name == sourceProp.Name)
+                 where destProps.Any(x => x.Name == sourceProp.Name)
+                 let destProp = destProps.First(x => x.Name == sourceProp.Name)
                  where destProp.CanWrite
                  select (sourceProp, destProp))
         {
             // "System.Collections.Generic.IList`
             if (sourceProp.Name != "Sheets")
             {
-                if (sourceProp.PropertyType.IsSubclassOf (typeof (ModelBase)))
+                if (sourceProp.PropertyType.IsSubclassOf(typeof(ModelBase)))
                 {
                     // Property is subclass of ModelBase - Recurse through sub-objects
-                    if (sourceProp.GetValue (source, null) is ModelBase sourceValue)
+                    if (sourceProp.GetValue(source, null) is ModelBase sourceValue)
                     {
-                        if (destProp.GetValue (this) is not ModelBase destValue)
+                        if (destProp.GetValue(this) is not ModelBase destValue)
                         {
                             // Destination is null. Create it.
-                            destValue = (ModelBase)Activator.CreateInstance (destProp.PropertyType)!;
-                            destProp.SetValue (this, destValue);
+                            destValue = (ModelBase)Activator.CreateInstance(destProp.PropertyType)!;
+                            destProp.SetValue(this, destValue);
                         }
 
-                        destValue.CopyPropertiesFrom (sourceValue);
+                        destValue.CopyPropertiesFrom(sourceValue);
                     }
                     else
                     {
-                        destProp.SetValue (this, null);
+                        destProp.SetValue(this, null);
                     }
                 }
                 else
                 {
-                    destProp.SetValue (this, sourceProp.GetValue (source, null), null);
+                    destProp.SetValue(this, sourceProp.GetValue(source, null), null);
                 }
             }
             else
             {
                 Dictionary<string, SheetSettings> sourceList =
-                    sourceProp.GetValue (source) as Dictionary<string, SheetSettings> ??
-                    new Dictionary<string, SheetSettings> ();
+                    sourceProp.GetValue(source) as Dictionary<string, SheetSettings> ??
+                    [];
 
                 Dictionary<string, SheetSettings> destList =
-                    destProp.GetValue (this) as Dictionary<string, SheetSettings> ??
-                    new Dictionary<string, SheetSettings> ();
+                    destProp.GetValue(this) as Dictionary<string, SheetSettings> ??
+                    [];
 
                 foreach (KeyValuePair<string, SheetSettings> src in sourceList)
                 {
-                    if (destList.ContainsKey (src.Key))
+                    if (destList.ContainsKey(src.Key))
                     {
-                        destList[src.Key].CopyPropertiesFrom (src.Value);
+                        destList[src.Key].CopyPropertiesFrom(src.Value);
                     }
                     else
                     {
-                        destList[src.Key] = new SheetSettings ();
-                        destList[src.Key].CopyPropertiesFrom (src.Value);
+                        destList[src.Key] = new SheetSettings();
+                        destList[src.Key].CopyPropertiesFrom(src.Value);
                     }
                 }
 
-                if (destProp.GetValue (this) is null)
+                if (destProp.GetValue(this) is null)
                 {
-                    destProp.SetValue (this, destList, null);
+                    destProp.SetValue(this, destList, null);
                 }
             }
         }

--- a/src/WinPrint.Core/Models/ModelLocator.cs
+++ b/src/WinPrint.Core/Models/ModelLocator.cs
@@ -10,32 +10,32 @@ public class ModelLocator
 {
     private static ModelLocator? _current;
 
-    private ModelLocator ()
+    private ModelLocator()
     {
         // Register the models via the Services Factory
-        SimpleIoc.Default.Register (SettingsService.Create);
-        SimpleIoc.Default.Register (FileTypeMappingService.Create);
-        SimpleIoc.Default.Register<Options> ();
+        SimpleIoc.Default.Register(SettingsService.Create);
+        SimpleIoc.Default.Register(FileTypeMappingService.Create);
+        SimpleIoc.Default.Register<Options>();
     }
 
-    public static ModelLocator Current => _current ??= new ModelLocator ();
+    public static ModelLocator Current => _current ??= new ModelLocator();
 
-    public Settings Settings => SimpleIoc.Default.GetInstance<Settings> ();
+    public Settings Settings => SimpleIoc.Default.GetInstance<Settings>();
 
-    public Options Options => SimpleIoc.Default.GetInstance<Options> ();
-    public FileTypeMapping FileTypeMapping => SimpleIoc.Default.GetInstance<FileTypeMapping> ();
+    public Options Options => SimpleIoc.Default.GetInstance<Options>();
+    public FileTypeMapping FileTypeMapping => SimpleIoc.Default.GetInstance<FileTypeMapping>();
 
-    public void Register<VM, V> ()
+    public void Register<VM, V>()
         where VM : class
     {
-        SimpleIoc.Default.Register<VM> ();
+        SimpleIoc.Default.Register<VM>();
     }
 
-    public static void Reset ()
+    public static void Reset()
     {
         _current = null;
-        SimpleIoc.Default.Unregister<Settings> ();
-        SimpleIoc.Default.Unregister<FileTypeMapping> ();
-        SimpleIoc.Default.Unregister<Options> ();
+        SimpleIoc.Default.Unregister<Settings>();
+        SimpleIoc.Default.Unregister<FileTypeMapping>();
+        SimpleIoc.Default.Unregister<Options>();
     }
 }

--- a/src/WinPrint.Core/Models/Options.cs
+++ b/src/WinPrint.Core/Models/Options.cs
@@ -10,7 +10,7 @@ public class Options : ModelBase
 {
     // Files
     [JsonIgnore]
-    [Value (0, Required = true, MetaName = "<files>", HelpText = "One or more files to be printed.")]
+    [Value(0, Required = true, MetaName = "<files>", HelpText = "One or more files to be printed.")]
     public IEnumerable<string>? Files { get; set; }
 
     /// <summary>
@@ -19,76 +19,76 @@ public class Options : ModelBase
     [JsonIgnore]
     [SafeForTelemetry]
     // TODO: This won't work once we support wildcards
-    public int NumFiles => Files!.Count ();
+    public int NumFiles => Files!.Count();
 
     // Print options
     [SafeForTelemetry]
-    [Option ('s', "sheet", Required = false,
+    [Option('s', "sheet", Required = false,
         HelpText = "Sheet definition to use for formatting. Use sheet ID or friendly name.")]
     public string? Sheet { get; set; }
 
     [SafeForTelemetry]
-    [Option ('l', "landscape", Required = false, Default = false, HelpText = "Force landscape orientation.")]
+    [Option('l', "landscape", Required = false, Default = false, HelpText = "Force landscape orientation.")]
     public bool Landscape { get; set; }
 
     [SafeForTelemetry]
-    [Option ('r', "portrait", Required = false, Default = false, HelpText = "Force portrait orientation.")]
+    [Option('r', "portrait", Required = false, Default = false, HelpText = "Force portrait orientation.")]
     public bool Portrait { get; set; }
 
     [SafeForTelemetry]
-    [Option ('p', "printer", HelpText = "Printer name.")]
+    [Option('p', "printer", HelpText = "Printer name.")]
     public string? Printer { get; set; }
 
     [SafeForTelemetry]
-    [Option ('z', "paper-size", HelpText = "Paper size name.")]
+    [Option('z', "paper-size", HelpText = "Paper size name.")]
     public string? PaperSize { get; set; }
 
     [SafeForTelemetry]
-    [Option ('f', "from-sheet", Default = 0,
+    [Option('f', "from-sheet", Default = 0,
         HelpText = "Number of first sheet to print (may be used with --to-sheet).")]
     public int FromPage { get; set; }
 
     [SafeForTelemetry]
-    [Option ('t', "to-sheet", Default = 0, HelpText = "Number of last sheet to print (may be used with --from-sheet).")]
+    [Option('t', "to-sheet", Default = 0, HelpText = "Number of last sheet to print (may be used with --from-sheet).")]
     public int ToPage { get; set; }
 
     [SafeForTelemetry]
-    [Option ('c', "count-sheets", Default = false, Required = false,
+    [Option('c', "count-sheets", Default = false, Required = false,
         HelpText = "Exit code is set to number of sheets that would be printed. Use --verbose to display the count.")]
     public bool CountPages { get; set; }
 
     [SafeForTelemetry]
-    [Option ('e', "content-type-engine", Default = "", Required = false,
+    [Option('e', "content-type-engine", Default = "", Required = false,
         HelpText =
             "Name of the Content Type Engine to use for rendering (\"text/plain\", \"text/html\", or \"<language>\".")]
     public string? ContentType { get; set; }
 
     // App Options
     [SafeForTelemetry]
-    [Option ('v', "verbose", Default = false, HelpText = "Verbose console output (log is always verbose).")]
+    [Option('v', "verbose", Default = false, HelpText = "Verbose console output (log is always verbose).")]
     public bool Verbose { get; set; }
 
     [SafeForTelemetry]
-    [Option ('d', "debug", Default = false, HelpText = "Debug-level console & log output.")]
+    [Option('d', "debug", Default = false, HelpText = "Debug-level console & log output.")]
     public bool Debug { get; set; }
 
     [SafeForTelemetry]
-    [Option ('g', "gui", Default = false, SetName = "gui",
+    [Option('g', "gui", Default = false, SetName = "gui",
         HelpText = "Show WinPrint GUI (to preview or change sheet settings).")]
     public bool Gui { get; set; }
 
-    [Usage (ApplicationAlias = "winprint")]
+    [Usage(ApplicationAlias = "winprint")]
     public static IEnumerable<Example> Examples => new List<Example>
     {
-        new ("Print Program.cs in landscape mode",
+        new("Print Program.cs in landscape mode",
             new Options { Files = new List<string> { "Program.cs" }, Landscape = true }),
-        new ("Print all .cs files on a specific printer with a specific paper size",
+        new("Print all .cs files on a specific printer with a specific paper size",
             new Options { Files = new List<string> { "*.cs" }, Printer = "Fabricam 535", PaperSize = "A4" }),
-        new ("Print the first two sheets of Program.cs",
+        new("Print the first two sheets of Program.cs",
             new Options { Files = new List<string> { "Program.cs" }, FromPage = 1, ToPage = 2 }),
-        new ("Print Program.cs using the 2 Up sheet definition",
+        new("Print Program.cs using the 2 Up sheet definition",
             new Options { Files = new List<string> { "Program.cs" }, Sheet = "2 Up" }),
-        new ("Print tapes.pas using C-like syntax highlighting.",
+        new("Print tapes.pas using C-like syntax highlighting.",
             new Options { Files = new List<string> { "tapes.pas" }, ContentType = "clike" })
     };
 }

--- a/src/WinPrint.Core/Models/SafeForTelemetry.cs
+++ b/src/WinPrint.Core/Models/SafeForTelemetry.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace WinPrint.Core.Models;
 
-[AttributeUsage (AttributeTargets.Property)]
+[AttributeUsage(AttributeTargets.Property)]
 public class SafeForTelemetry : Attribute
 {
 }

--- a/src/WinPrint.Core/Models/Settings.cs
+++ b/src/WinPrint.Core/Models/Settings.cs
@@ -8,7 +8,7 @@ namespace WinPrint.Core.Models;
 
 public class Settings : ModelBase
 {
-    private Font _diagnosticRulesFont = new () { Family = "sansserif", Size = 8F, Style = FontStyle.Regular };
+    private Font _diagnosticRulesFont = new() { Family = "sansserif", Size = 8F, Style = FontStyle.Regular };
     private bool _previewBounds;
     private bool _previewContentBounds;
     private bool _previewHardMargins;
@@ -38,7 +38,7 @@ public class Settings : ModelBase
     public WindowLocation? Location
     {
         get => location;
-        set => SetField (ref location, value);
+        set => SetField(ref location, value);
     }
 
     /// <summary>
@@ -48,14 +48,14 @@ public class Settings : ModelBase
     public WindowSize? Size
     {
         get => size;
-        set => SetField (ref size, value);
+        set => SetField(ref size, value);
     }
 
     [SafeForTelemetry]
     public FormWindowState WindowState
     {
         get => windowState;
-        set => SetField (ref windowState, value);
+        set => SetField(ref windowState, value);
     }
 
     /// <summary>
@@ -65,13 +65,13 @@ public class Settings : ModelBase
     public Guid DefaultSheet
     {
         get => defaultSheet;
-        set => SetField (ref defaultSheet, value);
+        set => SetField(ref defaultSheet, value);
     }
 
     /// <summary>
     ///     Sheet definitons
     /// </summary>
-    public Dictionary<string, SheetSettings> Sheets { get; set; } = new ();
+    public Dictionary<string, SheetSettings> Sheets { get; set; } = [];
 
     [JsonIgnore]
     [SafeForTelemetry]
@@ -99,17 +99,17 @@ public class Settings : ModelBase
     /// <summary>
     ///     Content type handlers
     /// </summary>
-    public AnsiCte AnsiContentTypeEngineSettings { get; set; } = new ();
+    public AnsiCte AnsiContentTypeEngineSettings { get; set; } = new();
 
-    public TextMateCte TextMateContentTypeEngineSettings { get; set; } = new ();
-    public TextCte TextContentTypeEngineSettings { get; set; } = new ();
-    public MarkdownCte MarkdownContentTypeEngineSettings { get; set; } = new ();
-    public HtmlCte HtmlContentTypeEngineSettings { get; set; } = new ();
+    public TextMateCte TextMateContentTypeEngineSettings { get; set; } = new();
+    public TextCte TextContentTypeEngineSettings { get; set; } = new();
+    public MarkdownCte MarkdownContentTypeEngineSettings { get; set; } = new();
+    public HtmlCte HtmlContentTypeEngineSettings { get; set; } = new();
 
     /// <summary>
     ///     File Type Mappings.
     /// </summary>
-    public FileTypeMapping FileTypeMapping { get; set; } = new ();
+    public FileTypeMapping FileTypeMapping { get; set; } = new();
 
     [JsonIgnore]
     [SafeForTelemetry]
@@ -152,119 +152,119 @@ public class Settings : ModelBase
     public Font DiagnosticRulesFont
     {
         get => _diagnosticRulesFont;
-        set => SetField (ref _diagnosticRulesFont, value);
+        set => SetField(ref _diagnosticRulesFont, value);
     }
 
     [SafeForTelemetry]
     public bool PreviewPrintableArea
     {
         get => _previewPrintableArea;
-        set => SetField (ref _previewPrintableArea, value);
+        set => SetField(ref _previewPrintableArea, value);
     }
 
     [SafeForTelemetry]
     public bool PrintPrintableArea
     {
         get => _printPrintableArea;
-        set => SetField (ref _printPrintableArea, value);
+        set => SetField(ref _printPrintableArea, value);
     }
 
     [SafeForTelemetry]
     public bool PreviewPaperSize
     {
         get => _previewPageSize;
-        set => SetField (ref _previewPageSize, value);
+        set => SetField(ref _previewPageSize, value);
     }
 
     [SafeForTelemetry]
     public bool PrintPaperSize
     {
         get => _printPageSize;
-        set => SetField (ref _printPageSize, value);
+        set => SetField(ref _printPageSize, value);
     }
 
     [SafeForTelemetry]
     public bool PreviewMargins
     {
         get => _previewMargins;
-        set => SetField (ref _previewMargins, value);
+        set => SetField(ref _previewMargins, value);
     }
 
     [SafeForTelemetry]
     public bool PrintMargins
     {
         get => _printMargins;
-        set => SetField (ref _printMargins, value);
+        set => SetField(ref _printMargins, value);
     }
 
     [SafeForTelemetry]
     public bool PreviewHardMargins
     {
         get => _previewHardMargins;
-        set => SetField (ref _previewHardMargins, value);
+        set => SetField(ref _previewHardMargins, value);
     }
 
     [SafeForTelemetry]
     public bool PrintHardMargins
     {
         get => _printHardMargins;
-        set => SetField (ref _printHardMargins, value);
+        set => SetField(ref _printHardMargins, value);
     }
 
     [SafeForTelemetry]
     public bool PrintBounds
     {
         get => _printBounds;
-        set => SetField (ref _printBounds, value);
+        set => SetField(ref _printBounds, value);
     }
 
     [SafeForTelemetry]
     public bool PreviewBounds
     {
         get => _previewBounds;
-        set => SetField (ref _previewBounds, value);
+        set => SetField(ref _previewBounds, value);
     }
 
     [SafeForTelemetry]
     public bool PrintContentBounds
     {
         get => _printContentBounds;
-        set => SetField (ref _printContentBounds, value);
+        set => SetField(ref _printContentBounds, value);
     }
 
     [SafeForTelemetry]
     public bool PreviewContentBounds
     {
         get => _previewContentBounds;
-        set => SetField (ref _previewContentBounds, value);
+        set => SetField(ref _previewContentBounds, value);
     }
 
     [SafeForTelemetry]
     public bool PrintHeaderFooterBounds
     {
         get => _printHeaderFooterBounds;
-        set => SetField (ref _printHeaderFooterBounds, value);
+        set => SetField(ref _printHeaderFooterBounds, value);
     }
 
     [SafeForTelemetry]
     public bool PreviewHeaderFooterBounds
     {
         get => _previewHeaderFooterBounds;
-        set => SetField (ref _previewHeaderFooterBounds, value);
+        set => SetField(ref _previewHeaderFooterBounds, value);
     }
 
     [SafeForTelemetry]
     public bool PreviewPageBounds
     {
         get => _previewPageBounds;
-        set => SetField (ref _previewPageBounds, value);
+        set => SetField(ref _previewPageBounds, value);
     }
 
     [SafeForTelemetry]
     public bool PrintPageBounds
     {
         get => _printPageBounds;
-        set => SetField (ref _printPageBounds, value);
+        set => SetField(ref _printPageBounds, value);
     }
 
     /// <summary>
@@ -274,7 +274,7 @@ public class Settings : ModelBase
     public bool ShowPrintDialog
     {
         get => _printDialog;
-        set => SetField (ref _printDialog, value);
+        set => SetField(ref _printDialog, value);
     }
 
     /// <summary>
@@ -294,11 +294,11 @@ public class Settings : ModelBase
     ///     the .config.json file.
     /// </summary>
     /// <returns>A Settings object with default settings.</returns>
-    public static Settings CreateDefaultSettings ()
+    public static Settings CreateDefaultSettings()
     {
         string monoSpaceFamily = "monospace";
         string sansSerifFamily = "sansserif";
-        if (RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             monoSpaceFamily = "Consolas";
             sansSerifFamily = "Calibri";
@@ -342,7 +342,7 @@ public class Settings : ModelBase
                 //NewPageOnFormFeed = false,
                 //TabSpaces = 4
             },
-            MarkdownContentTypeEngineSettings = new MarkdownCte (),
+            MarkdownContentTypeEngineSettings = new MarkdownCte(),
 
             // Html fonts are determined by:
             // 1) Sheet (all HTML & CSS ignored)
@@ -358,7 +358,7 @@ public class Settings : ModelBase
                 //},
             },
             DefaultSheet = Uuid.DefaultSheet,
-            Sheets = new Dictionary<string, SheetSettings> ()
+            Sheets = []
         };
 
         // Create default 2 Up sheet
@@ -407,7 +407,7 @@ public class Settings : ModelBase
         sheet.Footer.VerticalPadding = 1;
 
         sheet.Margins.Left = sheet.Margins.Top = sheet.Margins.Right = sheet.Margins.Bottom = 30;
-        settings.Sheets.Add (Uuid.DefaultSheet.ToString (), sheet);
+        settings.Sheets.Add(Uuid.DefaultSheet.ToString(), sheet);
 
         // Create default 1 Up sheet
         sheet = new SheetSettings
@@ -458,7 +458,7 @@ public class Settings : ModelBase
         sheet.Footer.VerticalPadding = 1;
 
         sheet.Margins.Left = sheet.Margins.Top = sheet.Margins.Right = sheet.Margins.Bottom = 30;
-        settings.Sheets.Add (Uuid.DefaultSheet1Up.ToString (), sheet);
+        settings.Sheets.Add(Uuid.DefaultSheet1Up.ToString(), sheet);
 
         settings.FileTypeMapping = new FileTypeMapping
         {
@@ -475,21 +475,21 @@ public class Settings : ModelBase
             // text/plain - because it is not defined by Pygments
             // text/ansi - because it is not defined by Pygments
             // icon - Icon is so esoteric it makes a good test
-            ContentTypes = new List<ContentType>
-            {
-                new ()
+            ContentTypes =
+            [
+                new()
                 {
                     Id = "text/plain",
                     Title = "Plain Text",
-                    Extensions = new List<string> { "*.txt" },
-                    Aliases = new List<string> { "text" }
+                    Extensions = ["*.txt"],
+                    Aliases = ["text"]
                 },
-                new ()
+                new()
                 {
                     Id = "text/ansi",
                     Title = "ANSI Text",
-                    Extensions = new List<string> { "*.an", "*.ans", "*.ansi" },
-                    Aliases = new List<string> { "ansi" }
+                    Extensions = ["*.an", "*.ans", "*.ansi"],
+                    Aliases = ["ansi"]
                 }
                 //new ContentType() {
                 //    Id = "text/x-icon",
@@ -501,7 +501,7 @@ public class Settings : ModelBase
                 //        "Unicon"
                 //    }
                 //}
-            }
+            ]
         };
 
         return settings;

--- a/src/WinPrint.Core/Models/Settings.cs
+++ b/src/WinPrint.Core/Models/Settings.cs
@@ -101,9 +101,7 @@ public class Settings : ModelBase
     /// </summary>
     public AnsiCte AnsiContentTypeEngineSettings { get; set; } = new ();
 
-#if WINDOWS
     public TextMateCte TextMateContentTypeEngineSettings { get; set; } = new ();
-#endif
     public TextCte TextContentTypeEngineSettings { get; set; } = new ();
     public MarkdownCte MarkdownContentTypeEngineSettings { get; set; } = new ();
     public HtmlCte HtmlContentTypeEngineSettings { get; set; } = new ();
@@ -326,12 +324,10 @@ public class Settings : ModelBase
             DefaultCteClassName = "TextMateCte",
             DefaultSyntaxHighlighterCteNameClassName = "TextMateCte",
             AnsiContentTypeEngineSettings = new AnsiCte { ContentSettings = new ContentSettings { Style = "pastie" } },
-#if WINDOWS
             TextMateContentTypeEngineSettings = new TextMateCte
             {
                 ContentSettings = new ContentSettings { Style = "VisualStudioLight" }
             },
-#endif
             TextContentTypeEngineSettings = new TextCte
             {
                 // This font will be overriddent by Sheet defined fonts (if any)

--- a/src/WinPrint.Core/Models/Settings.cs
+++ b/src/WinPrint.Core/Models/Settings.cs
@@ -104,6 +104,7 @@ public class Settings : ModelBase
 #if WINDOWS
     public TextMateCte TextMateContentTypeEngineSettings { get; set; } = new ();
     public TextCte TextContentTypeEngineSettings { get; set; } = new ();
+    public MarkdownCte MarkdownContentTypeEngineSettings { get; set; } = new ();
 #endif
     public HtmlCte HtmlContentTypeEngineSettings { get; set; } = new ();
 
@@ -344,6 +345,7 @@ public class Settings : ModelBase
                 //NewPageOnFormFeed = false,
                 //TabSpaces = 4
             },
+            MarkdownContentTypeEngineSettings = new MarkdownCte (),
 #endif
 
             // Html fonts are determined by:

--- a/src/WinPrint.Core/Models/Settings.cs
+++ b/src/WinPrint.Core/Models/Settings.cs
@@ -103,9 +103,9 @@ public class Settings : ModelBase
 
 #if WINDOWS
     public TextMateCte TextMateContentTypeEngineSettings { get; set; } = new ();
+#endif
     public TextCte TextContentTypeEngineSettings { get; set; } = new ();
     public MarkdownCte MarkdownContentTypeEngineSettings { get; set; } = new ();
-#endif
     public HtmlCte HtmlContentTypeEngineSettings { get; set; } = new ();
 
     /// <summary>
@@ -331,6 +331,7 @@ public class Settings : ModelBase
             {
                 ContentSettings = new ContentSettings { Style = "VisualStudioLight" }
             },
+#endif
             TextContentTypeEngineSettings = new TextCte
             {
                 // This font will be overriddent by Sheet defined fonts (if any)
@@ -346,7 +347,6 @@ public class Settings : ModelBase
                 //TabSpaces = 4
             },
             MarkdownContentTypeEngineSettings = new MarkdownCte (),
-#endif
 
             // Html fonts are determined by:
             // 1) Sheet (all HTML & CSS ignored)

--- a/src/WinPrint.Core/Models/SheetSettings.cs
+++ b/src/WinPrint.Core/Models/SheetSettings.cs
@@ -11,13 +11,13 @@ public class SheetSettings : ModelBase
 
     private ContentSettings? _contentSettings;
     private int _darkness;
-    private Footer _footer = new ();
+    private Footer _footer = new();
     private bool _grayscale;
 
-    private Header _header = new ();
+    private Header _header = new();
 
     private bool _landscape;
-    private PrintMargins _margins = new (0, 0, 0, 0);
+    private PrintMargins _margins = new(0, 0, 0, 0);
 
     //private Guid id;
     private string _name = "";
@@ -33,7 +33,7 @@ public class SheetSettings : ModelBase
     public string Name
     {
         get => _name;
-        set => SetField (ref _name, value);
+        set => SetField(ref _name, value);
     }
 
     /// <summary>
@@ -43,7 +43,7 @@ public class SheetSettings : ModelBase
     public bool Landscape
     {
         get => _landscape;
-        set => SetField (ref _landscape, value);
+        set => SetField(ref _landscape, value);
     }
 
     /// <summary>
@@ -53,7 +53,7 @@ public class SheetSettings : ModelBase
     public int Rows
     {
         get => _rows;
-        set => SetField (ref _rows, value);
+        set => SetField(ref _rows, value);
     }
 
     /// <summary>
@@ -63,7 +63,7 @@ public class SheetSettings : ModelBase
     public int Columns
     {
         get => _columns;
-        set => SetField (ref _columns, value);
+        set => SetField(ref _columns, value);
     }
 
     /// <summary>
@@ -73,14 +73,14 @@ public class SheetSettings : ModelBase
     public int Padding
     {
         get => _padding;
-        set => SetField (ref _padding, value);
+        set => SetField(ref _padding, value);
     }
 
     [SafeForTelemetry]
     public bool PageSeparator
     {
         get => _pageSeparator;
-        set => SetField (ref _pageSeparator, value);
+        set => SetField(ref _pageSeparator, value);
     }
 
     /// <summary>
@@ -90,7 +90,7 @@ public class SheetSettings : ModelBase
     public PrintMargins Margins
     {
         get => _margins;
-        set => SetField (ref _margins, value);
+        set => SetField(ref _margins, value);
     }
 
     /// <summary>
@@ -103,7 +103,7 @@ public class SheetSettings : ModelBase
             //if (contentSettings is null)
             //    contentSettings = new ContentSettings();
             _contentSettings;
-        set => SetField (ref _contentSettings, value);
+        set => SetField(ref _contentSettings, value);
     }
 
     /// <summary>
@@ -113,7 +113,7 @@ public class SheetSettings : ModelBase
     public Header Header
     {
         get => _header;
-        set => SetField (ref _header, value);
+        set => SetField(ref _header, value);
     }
 
     /// <summary>
@@ -123,7 +123,7 @@ public class SheetSettings : ModelBase
     public Footer Footer
     {
         get => _footer;
-        set => SetField (ref _footer, value);
+        set => SetField(ref _footer, value);
     }
 
     // The following members are runtime-only and do NOT get persisted, hence "internal"
@@ -133,7 +133,7 @@ public class SheetSettings : ModelBase
     internal bool PrintBackground
     {
         get => _printBackground;
-        set => SetField (ref _printBackground, value);
+        set => SetField(ref _printBackground, value);
     }
 
     /// <summary>
@@ -143,7 +143,7 @@ public class SheetSettings : ModelBase
     internal bool Grayscale
     {
         get => _grayscale;
-        set => SetField (ref _grayscale, value);
+        set => SetField(ref _grayscale, value);
     }
 
     /// <summary>
@@ -152,6 +152,6 @@ public class SheetSettings : ModelBase
     internal int Darkness
     {
         get => _darkness;
-        set => SetField (ref _darkness, value);
+        set => SetField(ref _darkness, value);
     }
 }

--- a/src/WinPrint.Core/Models/Uuid.cs
+++ b/src/WinPrint.Core/Models/Uuid.cs
@@ -11,9 +11,9 @@ namespace WinPrint.Core;
 //
 public static class Uuid
 {
-    public static readonly Guid UpgradeCode = Guid.Parse ("{0002A500-0000-0000-C000-000000000046}");
-    public static readonly Guid ProductCode = Guid.Parse ("{0002A501-0000-0000-C000-000000000046}");
+    public static readonly Guid UpgradeCode = Guid.Parse("{0002A500-0000-0000-C000-000000000046}");
+    public static readonly Guid ProductCode = Guid.Parse("{0002A501-0000-0000-C000-000000000046}");
 
-    public static readonly Guid DefaultSheet = Guid.Parse ("{0002A500-0000-0000-C000-000000000046}");
-    public static readonly Guid DefaultSheet1Up = Guid.Parse ("{0002A501-0000-0000-C000-000000000046}");
+    public static readonly Guid DefaultSheet = Guid.Parse("{0002A500-0000-0000-C000-000000000046}");
+    public static readonly Guid DefaultSheet1Up = Guid.Parse("{0002A501-0000-0000-C000-000000000046}");
 }

--- a/src/WinPrint.Core/Models/WindowLocation.cs
+++ b/src/WinPrint.Core/Models/WindowLocation.cs
@@ -2,11 +2,11 @@ namespace WinPrint.Core.Models;
 
 public class WindowLocation
 {
-    public WindowLocation ()
+    public WindowLocation()
     {
     }
 
-    public WindowLocation (int x, int y)
+    public WindowLocation(int x, int y)
     {
         X = x;
         Y = y;

--- a/src/WinPrint.Core/Models/WindowSize.cs
+++ b/src/WinPrint.Core/Models/WindowSize.cs
@@ -6,11 +6,11 @@ namespace WinPrint.Core.Models;
 
 public class WindowSize
 {
-    public WindowSize ()
+    public WindowSize()
     {
     }
 
-    public WindowSize (int width, int height)
+    public WindowSize(int width, int height)
     {
         Width = width;
         Height = height;

--- a/src/WinPrint.Core/Print.cs
+++ b/src/WinPrint.Core/Print.cs
@@ -29,7 +29,7 @@ public class Print : IDisposable
     private bool _disposed;
     private int _sheetsPrinted;
 
-    public Print ()
+    public Print()
     {
         PrintDocument.BeginPrint += BeginPrint;
         PrintDocument.EndPrint += EndPrint;
@@ -37,14 +37,14 @@ public class Print : IDisposable
         PrintDocument.PrintPage += PrintSheet;
     }
 
-    public SheetViewModel SheetViewModel { get; } = new ();
+    public SheetViewModel SheetViewModel { get; } = new();
 
-    public PrintDocument PrintDocument { get; } = new ();
+    public PrintDocument PrintDocument { get; } = new();
 
-    public void Dispose ()
+    public void Dispose()
     {
-        Dispose (true);
-        GC.SuppressFinalize (this);
+        Dispose(true);
+        GC.SuppressFinalize(this);
     }
 
     /// <summary>
@@ -52,36 +52,36 @@ public class Print : IDisposable
     /// </summary>
     public event EventHandler<int>? PrintingSheet;
 
-    protected void OnPrintingSheet (int sheetNum)
+    protected void OnPrintingSheet(int sheetNum)
     {
-        PrintingSheet?.Invoke (this, sheetNum);
+        PrintingSheet?.Invoke(this, sheetNum);
     }
 
     /// <summary>
     ///     Sets the printer to be used for printing.
     /// </summary>
     /// <param name="printerName"></param>
-    public void SetPrinter (string printerName)
+    public void SetPrinter(string printerName)
     {
-        Log.Debug (LogService.GetTraceMsg ("{p}"), printerName);
-        if (!string.IsNullOrEmpty (printerName))
+        Log.Debug(LogService.GetTraceMsg("{p}"), printerName);
+        if (!string.IsNullOrEmpty(printerName))
         {
             try
             {
                 PrintDocument.PrinterSettings.PrinterName = printerName;
-                ServiceLocator.Current.TelemetryService.TrackEvent ("Set Printer",
+                ServiceLocator.Current.TelemetryService.TrackEvent("Set Printer",
                     new Dictionary<string, string?> { ["printerName"] = printerName });
             }
             catch (NullReferenceException)
             {
                 // On Linux if an invalid printer name is passed in we get a 
                 // NullReferenceException. 
-                throw new InvalidPrinterException (PrintDocument.PrinterSettings);
+                throw new InvalidPrinterException(PrintDocument.PrinterSettings);
             }
 
             if (!PrintDocument.PrinterSettings.IsValid)
             {
-                throw new InvalidPrinterException (PrintDocument.PrinterSettings);
+                throw new InvalidPrinterException(PrintDocument.PrinterSettings);
             }
         }
     }
@@ -90,14 +90,14 @@ public class Print : IDisposable
     ///     Sets the paper size to be used for printing.
     /// </summary>
     /// <param name="paperSizeName"></param>
-    public void SetPaperSize (string paperSizeName)
+    public void SetPaperSize(string paperSizeName)
     {
-        if (!string.IsNullOrEmpty (paperSizeName))
+        if (!string.IsNullOrEmpty(paperSizeName))
         {
             bool found = false;
             foreach (PaperSize size in PrintDocument.PrinterSettings.PaperSizes)
             {
-                if (size.PaperName.Equals (paperSizeName, StringComparison.InvariantCultureIgnoreCase))
+                if (size.PaperName.Equals(paperSizeName, StringComparison.InvariantCultureIgnoreCase))
                 {
                     PrintDocument.DefaultPageSettings.PaperSize = size;
                     found = true;
@@ -106,22 +106,22 @@ public class Print : IDisposable
 
             if (!found)
             {
-                var sb = new StringBuilder ();
-                sb.Append (
+                var sb = new StringBuilder();
+                sb.Append(
                     $"'{paperSizeName}' is not a valid paper size for the '{PrintDocument.PrinterSettings.PrinterName}' printer.");
-                sb.Append (Environment.NewLine);
-                sb.Append ($"'{PrintDocument.PrinterSettings.PrinterName}' supports these printer sizes:");
-                sb.Append (Environment.NewLine);
+                sb.Append(Environment.NewLine);
+                sb.Append($"'{PrintDocument.PrinterSettings.PrinterName}' supports these printer sizes:");
+                sb.Append(Environment.NewLine);
                 foreach (PaperSize size in PrintDocument.PrinterSettings.PaperSizes)
                 {
-                    sb.Append ($"    {size.PaperName}");
-                    sb.Append (Environment.NewLine);
+                    sb.Append($"    {size.PaperName}");
+                    sb.Append(Environment.NewLine);
                 }
 
-                throw new Exception (sb.ToString ());
+                throw new Exception(sb.ToString());
             }
 
-            ServiceLocator.Current.TelemetryService.TrackEvent ("Set Paper Size",
+            ServiceLocator.Current.TelemetryService.TrackEvent("Set Paper Size",
                 new Dictionary<string, string?> { ["paperSizeName"] = paperSizeName });
         }
     }
@@ -132,21 +132,21 @@ public class Print : IDisposable
     /// <param name="fromSheet"></param>
     /// <param name="toSheet"></param>
     /// <returns>The number of sheets that would have been printed.</returns>
-    public async Task<int> CountSheets (int fromSheet = 1, int toSheet = 0)
+    public async Task<int> CountSheets(int fromSheet = 1, int toSheet = 0)
     {
         // BUGBUG: Ignores from/to
-        SheetViewModel.SetPrinterPageSettings (PrintDocument.DefaultPageSettings);
-        await SheetViewModel.ReflowAsync ().ConfigureAwait (false);
+        SheetViewModel.SetPrinterPageSettings(PrintDocument.DefaultPageSettings);
+        await SheetViewModel.ReflowAsync().ConfigureAwait(false);
 
-        ServiceLocator.Current.TelemetryService.TrackEvent ("Count Sheets",
+        ServiceLocator.Current.TelemetryService.TrackEvent("Count Sheets",
             new Dictionary<string, string?>
             {
-                ["type"] = SheetViewModel.ContentEngine?.GetType ().Name,
+                ["type"] = SheetViewModel.ContentEngine?.GetType().Name,
                 ["contentType"] = SheetViewModel.ContentType,
                 ["language"] = SheetViewModel.Language,
                 ["printer"] = PrintDocument.PrinterSettings.PrinterName,
-                ["fromSheet"] = fromSheet.ToString (),
-                ["toSheet"] = toSheet.ToString ()
+                ["fromSheet"] = fromSheet.ToString(),
+                ["toSheet"] = toSheet.ToString()
             },
             new Dictionary<string, double> { ["sheetsPrinted"] = SheetViewModel.NumSheets });
         ;
@@ -157,11 +157,11 @@ public class Print : IDisposable
     ///     Executes the print job.
     /// </summary>
     /// <returns>The number of sheets that were printed.</returns>
-    public async Task<int> DoPrint ()
+    public async Task<int> DoPrint()
     {
         PrintDocument.DocumentName = SheetViewModel.File;
-        SheetViewModel.SetPrinterPageSettings (PrintDocument.DefaultPageSettings);
-        await SheetViewModel.ReflowAsync ().ConfigureAwait (false);
+        SheetViewModel.SetPrinterPageSettings(PrintDocument.DefaultPageSettings);
+        await SheetViewModel.ReflowAsync().ConfigureAwait(false);
 
         PrintDocument.PrinterSettings.FromPage =
             PrintDocument.PrinterSettings.FromPage == 0 ? 1 : PrintDocument.PrinterSettings.FromPage;
@@ -170,24 +170,24 @@ public class Print : IDisposable
             : PrintDocument.PrinterSettings.ToPage;
 
         _curSheet = PrintDocument.PrinterSettings.FromPage;
-        PrintDocument.Print ();
+        PrintDocument.Print();
 
-        ServiceLocator.Current.TelemetryService.TrackEvent ("Print Complete",
+        ServiceLocator.Current.TelemetryService.TrackEvent("Print Complete",
             new Dictionary<string, string?>
             {
-                ["type"] = SheetViewModel.ContentEngine?.GetType ().Name,
+                ["type"] = SheetViewModel.ContentEngine?.GetType().Name,
                 ["contentType"] = SheetViewModel.ContentType,
                 ["language"] = SheetViewModel.Language,
                 ["printer"] = PrintDocument.PrinterSettings.PrinterName,
-                ["fromSheet"] = PrintDocument.PrinterSettings.FromPage.ToString (),
-                ["toSheet"] = PrintDocument.PrinterSettings.ToPage.ToString ()
+                ["fromSheet"] = PrintDocument.PrinterSettings.FromPage.ToString(),
+                ["toSheet"] = PrintDocument.PrinterSettings.ToPage.ToString()
             },
             new Dictionary<string, double> { ["sheetsPrinted"] = _sheetsPrinted });
 
         return _sheetsPrinted;
     }
 
-    protected virtual void Dispose (bool disposing)
+    protected virtual void Dispose(bool disposing)
     {
         if (_disposed)
         {
@@ -196,7 +196,7 @@ public class Print : IDisposable
 
         if (disposing)
         {
-            PrintDocument.Dispose ();
+            PrintDocument.Dispose();
         }
 
         _disposed = true;
@@ -204,33 +204,33 @@ public class Print : IDisposable
 
     #region System.Drawing.Printing Event Handlers
 
-    [SuppressMessage ("Design", "CA1031:Do not catch general exception types", Justification = "<Pending>")]
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "<Pending>")]
     // Occurs when the Print() method is called and before the first page of the document prints.
-    private void BeginPrint (object sender, PrintEventArgs ev)
+    private void BeginPrint(object sender, PrintEventArgs ev)
     {
-        LogService.TraceMessage ("Print.BeginPrint");
+        LogService.TraceMessage("Print.BeginPrint");
         _sheetsPrinted = 0;
     }
 
     // Occurs when the last page of the document has printed.
-    private void EndPrint (object sender, PrintEventArgs ev)
+    private void EndPrint(object sender, PrintEventArgs ev)
     {
-        LogService.TraceMessage ("Print.EndPrint");
+        LogService.TraceMessage("Print.EndPrint");
         // Reset so PrintPreviewDialog Print button works
         _curSheet = PrintDocument.PrinterSettings.FromPage;
     }
 
     // Occurs immediately before each PrintPage event.
-    private void QueryPageSettings (object sender, QueryPageSettingsEventArgs e)
+    private void QueryPageSettings(object sender, QueryPageSettingsEventArgs e)
     {
-        LogService.TraceMessage ("Print.QueryPageSettings");
+        LogService.TraceMessage("Print.QueryPageSettings");
     }
 
     // The PrintPage event is raised for each page to be printed.
-    private void PrintSheet (object sender, PrintPageEventArgs ev)
+    private void PrintSheet(object sender, PrintPageEventArgs ev)
     {
-        LogService.TraceMessage ($"Sheet {_curSheet}");
-        OnPrintingSheet (_curSheet);
+        LogService.TraceMessage($"Sheet {_curSheet}");
+        OnPrintingSheet(_curSheet);
 
         if (ev.PageSettings.PrinterSettings.PrintRange == PrintRange.SomePages)
         {
@@ -246,7 +246,7 @@ public class Print : IDisposable
             // BUGBUG: LINUX - On pages > 1 in landscape mode, landscape mode is lost
             if (ev.Graphics is not null)
             {
-                SheetViewModel.PrintSheet (ev.Graphics, _curSheet);
+                SheetViewModel.PrintSheet(ev.Graphics, _curSheet);
             }
 
             _sheetsPrinted++;

--- a/src/WinPrint.Core/Services/FileTypeMappingService.cs
+++ b/src/WinPrint.Core/Services/FileTypeMappingService.cs
@@ -16,11 +16,11 @@ namespace WinPrint.Core.Services;
 public class FileTypeMappingService
 {
     // Factory - creates 
-    public static FileTypeMapping Create ()
+    public static FileTypeMapping Create()
     {
         // 
-        LogService.TraceMessage ("FileAssociationsService.Create()");
-        return ServiceLocator.Current.FileTypeMappingService.Load ();
+        LogService.TraceMessage("FileAssociationsService.Create()");
+        return ServiceLocator.Current.FileTypeMappingService.Load();
     }
 
     /// <summary>
@@ -29,7 +29,7 @@ public class FileTypeMappingService
     ///     defined there in.
     /// </summary>
     /// <returns></returns>
-    public FileTypeMapping Load ()
+    public FileTypeMapping Load()
     {
         var jsonOptions = new JsonSerializerOptions
         {
@@ -40,15 +40,15 @@ public class FileTypeMappingService
             ReadCommentHandling = JsonCommentHandling.Skip
         };
 
-        FileTypeMapping associations = JsonSerializer.Deserialize<FileTypeMapping> (Resources.languages, jsonOptions) ??
-                                       new FileTypeMapping ();
+        FileTypeMapping associations = JsonSerializer.Deserialize<FileTypeMapping>(Resources.languages, jsonOptions) ??
+                                       new FileTypeMapping();
 
         // TODO: Consider calling into lang-map and/or Pygments to update extensions at runtime?
         // https://github.com/jonschlinkert/lang-map
 
         // Merge in any associations set in settings file
-        Debug.Assert (ModelLocator.Current.Settings.FileTypeMapping != null);
-        Debug.Assert (ModelLocator.Current.Settings.FileTypeMapping.ContentTypes != null);
+        Debug.Assert(ModelLocator.Current.Settings.FileTypeMapping != null);
+        Debug.Assert(ModelLocator.Current.Settings.FileTypeMapping.ContentTypes != null);
         if (ModelLocator.Current.Settings.FileTypeMapping.FilesAssociations != null)
         {
             foreach (KeyValuePair<string, string> fa in ModelLocator.Current.Settings.FileTypeMapping.FilesAssociations)
@@ -58,10 +58,10 @@ public class FileTypeMappingService
         }
 
         // Merge in any language defintions set in settings file
-        var langs = new List<ContentType> (associations.ContentTypes);
-        var langsSettings = new List<ContentType> (ModelLocator.Current.Settings.FileTypeMapping.ContentTypes);
+        var langs = new List<ContentType>(associations.ContentTypes);
+        var langsSettings = new List<ContentType>(ModelLocator.Current.Settings.FileTypeMapping.ContentTypes);
         // TODO: override Equals and GetHashCode for Language
-        var result = langsSettings.Union (langs).ToList ();
+        var result = langsSettings.Union(langs).ToList();
 
         associations.ContentTypes = result;
 

--- a/src/WinPrint.Core/Services/LogService.cs
+++ b/src/WinPrint.Core/Services/LogService.cs
@@ -18,10 +18,10 @@ namespace WinPrint.Core.Services;
 public class LogService
 {
     public string? LogPath { get; set; }
-    public LoggingLevelSwitch MasterLevelSwitch { get; set; } = new ();
-    public LoggingLevelSwitch FileLevelSwitch { get; set; } = new ();
-    public LoggingLevelSwitch ConsoleLevelSwitch { get; set; } = new ();
-    public LoggingLevelSwitch DebugLevelSwitch { get; set; } = new ();
+    public LoggingLevelSwitch MasterLevelSwitch { get; set; } = new();
+    public LoggingLevelSwitch FileLevelSwitch { get; set; } = new();
+    public LoggingLevelSwitch ConsoleLevelSwitch { get; set; } = new();
+    public LoggingLevelSwitch DebugLevelSwitch { get; set; } = new();
 
     /// <summary>
     ///     Starts Serilog-based logging.
@@ -30,7 +30,7 @@ public class LogService
     /// <param name="consoleSink">Provides the ILogEventSink for the console.</param>
     /// <param name="debug">If true, the console log will emit LogEventLevel.Debug entries</param>
     /// <param name="verbose">If true, the console log will emit LogEventLevel.Information entries.</param>
-    public void Start (string appName, ILogEventSink? consoleSink = null, bool debug = false, bool verbose = false)
+    public void Start(string appName, ILogEventSink? consoleSink = null, bool debug = false, bool verbose = false)
     {
         MasterLevelSwitch.MinimumLevel = LogEventLevel.Verbose;
         DebugLevelSwitch.MinimumLevel = LogEventLevel.Debug;
@@ -44,11 +44,11 @@ public class LogService
             // TODO: Keep this at Debug until after Beta, then change it to Information
             FileLevelSwitch.MinimumLevel = LogEventLevel.Debug;
 #endif
-        string? productVersion = FileVersionInfo.GetVersionInfo (Assembly.GetAssembly (typeof (LogService))!.Location)
+        string? productVersion = FileVersionInfo.GetVersionInfo(Assembly.GetAssembly(typeof(LogService))!.Location)
             .FileVersion;
         LogPath =
             $"{SettingsService.SettingsPath}{Path.DirectorySeparatorChar}logs{Path.DirectorySeparatorChar}{appName}.log"
-                .Replace (@"file:\", "");
+                .Replace(@"file:\", "");
 
         if (consoleSink == null)
         {
@@ -59,51 +59,51 @@ public class LogService
         if (consoleSink == null)
         {
             // GUI
-            Log.Logger = new LoggerConfiguration ()
-                .MinimumLevel.ControlledBy (MasterLevelSwitch)
-                .WriteTo.Debug (levelSwitch: DebugLevelSwitch)
-                .WriteTo.File (LogPath, shared: true, levelSwitch: FileLevelSwitch)
-                .CreateLogger ();
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.ControlledBy(MasterLevelSwitch)
+                .WriteTo.Debug(levelSwitch: DebugLevelSwitch)
+                .WriteTo.File(LogPath, shared: true, levelSwitch: FileLevelSwitch)
+                .CreateLogger();
         }
         else
         {
             // Console / Powershell
-            Log.Logger = new LoggerConfiguration ()
-                .MinimumLevel.ControlledBy (MasterLevelSwitch)
-                .WriteTo.Sink (consoleSink, levelSwitch: ConsoleLevelSwitch)
-                .WriteTo.Debug (levelSwitch: DebugLevelSwitch)
-                .WriteTo.File (LogPath, shared: true, levelSwitch: FileLevelSwitch)
-                .CreateLogger ();
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.ControlledBy(MasterLevelSwitch)
+                .WriteTo.Sink(consoleSink, levelSwitch: ConsoleLevelSwitch)
+                .WriteTo.Debug(levelSwitch: DebugLevelSwitch)
+                .WriteTo.File(LogPath, shared: true, levelSwitch: FileLevelSwitch)
+                .CreateLogger();
         }
 
-        Log.Debug ("--------- {app} {v} ---------", appName, productVersion);
+        Log.Debug("--------- {app} {v} ---------", appName, productVersion);
         if (ServiceLocator.Current.TelemetryService.TelemetryEnabled)
         {
 #if CI_BUILD
                 var msg = "CI_BUILD so no telemetry will be tracked.";
 #else
-            string msg = string.IsNullOrEmpty (TelemetryService.GetInstrumentationKey ())
+            string msg = string.IsNullOrEmpty(TelemetryService.GetInstrumentationKey())
                 ? "However, telemetry key is missing so no telemetry will be tracked."
                 : "";
 #endif
-            Log.Debug ($"Telemetry is enabled. {msg}");
+            Log.Debug($"Telemetry is enabled. {msg}");
         }
 
-        Log.Debug ("Logging to {path}", ServiceLocator.Current.LogService.LogPath);
-        Log.Debug ("OS Environment: {os}, architecture: {arch}, .NET version: {dotnet}",
+        Log.Debug("Logging to {path}", ServiceLocator.Current.LogService.LogPath);
+        Log.Debug("OS Environment: {os}, architecture: {arch}, .NET version: {dotnet}",
             Environment.OSVersion, Environment.Is64BitProcess ? "x64" : "x86", Environment.Version);
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            Log.Debug ("libgdiplus version: {v}", Diagnostics.GetLibgdiplusVersion ());
+            Log.Debug("libgdiplus version: {v}", Diagnostics.GetLibgdiplusVersion());
         }
     }
 
-    public static void TraceMessage (string msg = "",
+    public static void TraceMessage(string msg = "",
         [CallerMemberName] string memberName = "",
         [CallerFilePath] string sourceFilePath = "",
         [CallerLineNumber] int sourceLineNumber = 0)
     {
-        Log.Debug ($"{Path.GetFileName (sourceFilePath)}:{sourceLineNumber} {memberName}: {{msg}}", msg);
+        Log.Debug($"{Path.GetFileName(sourceFilePath)}:{sourceLineNumber} {memberName}: {{msg}}", msg);
     }
 
     /// <summary>
@@ -116,11 +116,11 @@ public class LogService
     /// <param name="sourceFilePath"></param>
     /// <param name="sourceLineNumber"></param>
     /// <returns></returns>
-    public static string GetTraceMsg (string msg = "",
+    public static string GetTraceMsg(string msg = "",
         [CallerMemberName] string memberName = "",
         [CallerFilePath] string sourceFilePath = "",
         [CallerLineNumber] int sourceLineNumber = 0)
     {
-        return $"{Path.GetFileName (sourceFilePath)}:{sourceLineNumber} {memberName}: {msg}";
+        return $"{Path.GetFileName(sourceFilePath)}:{sourceLineNumber} {memberName}: {msg}";
     }
 }

--- a/src/WinPrint.Core/Services/PygmentsConverterService.cs
+++ b/src/WinPrint.Core/Services/PygmentsConverterService.cs
@@ -20,9 +20,9 @@ public class PygmentsConverterService
 
     private Process? _proc;
 
-    internal PygmentsConverterService Create ()
+    internal PygmentsConverterService Create()
     {
-        return new PygmentsConverterService ();
+        return new PygmentsConverterService();
     }
 
 
@@ -30,7 +30,7 @@ public class PygmentsConverterService
     ///     Check that Python 3.x is installed and that pygmentize.exe works
     /// </summary>
     /// <returns>true if pygmentize.exe is working, false otherwise + message</returns>
-    public (bool installed, string message) CheckInstall ()
+    public (bool installed, string message) CheckInstall()
     {
         if (_pygmentsInstalled)
         {
@@ -39,7 +39,7 @@ public class PygmentsConverterService
 
         string message = string.Empty;
 
-        var proc = new Process ();
+        var proc = new Process();
 
         proc.StartInfo.RedirectStandardInput = true;
         proc.StartInfo.RedirectStandardOutput = true;
@@ -52,19 +52,19 @@ public class PygmentsConverterService
         bool python = false;
         try
         {
-            Log.Information ("Source code formatting: Verifying Python is installed");
+            Log.Information("Source code formatting: Verifying Python is installed");
             proc.StartInfo.FileName = "python.exe";
             proc.StartInfo.Arguments = "-V";
-            Log.Debug ("Pygments: Starting process {proc} {args}", proc.StartInfo.FileName, proc.StartInfo.Arguments);
-            proc.Start ();
+            Log.Debug("Pygments: Starting process {proc} {args}", proc.StartInfo.FileName, proc.StartInfo.Arguments);
+            proc.Start();
 
-            if (proc.WaitForExit (5000))
+            if (proc.WaitForExit(5000))
             {
-                string? output = proc.StandardOutput.ReadLine ();
-                if (output != null && output.StartsWith ("Python "))
+                string? output = proc.StandardOutput.ReadLine();
+                if (output != null && output.StartsWith("Python "))
                 {
                     python = true;
-                    Log.Debug ("Pygments: Python is installed: {output}", output);
+                    Log.Debug("Pygments: Python is installed: {output}", output);
                 }
                 else
                 {
@@ -87,7 +87,7 @@ public class PygmentsConverterService
         {
             message =
                 $"Python 3.x must be installed (and on the PATH) for source code formatting to work.\n\nType `winget install python` at a command prompt to install Python.\n\n{message}";
-            Log.Debug ("Pygments: {message}", message);
+            Log.Debug("Pygments: {message}", message);
             return (_pygmentsInstalled, message);
         }
 
@@ -96,26 +96,26 @@ public class PygmentsConverterService
         // from https://stackoverflow.com/questions/62162970/programmatically-determine-pip-user-install-location-scripts-directory/62167797#62167797
         try
         {
-            Log.Information ("Source code formatting: Verifying Python scripts location");
+            Log.Information("Source code formatting: Verifying Python scripts location");
             proc.StartInfo.FileName = "python.exe";
             proc.StartInfo.Arguments =
                 "-c \"import os,sysconfig;print(sysconfig.get_path('scripts',f'{os.name}_user'))\"";
-            Log.Debug ("Pygments: Starting process {proc} {args}", proc.StartInfo.FileName, proc.StartInfo.Arguments);
-            proc.Start ();
+            Log.Debug("Pygments: Starting process {proc} {args}", proc.StartInfo.FileName, proc.StartInfo.Arguments);
+            proc.Start();
 
-            if (proc.WaitForExit (5000))
+            if (proc.WaitForExit(5000))
             {
-                _scriptsPath = proc.StandardOutput.ReadLine ();
-                if (!string.IsNullOrEmpty (_scriptsPath) && _scriptsPath.ToLowerInvariant ().EndsWith ("scripts"))
+                _scriptsPath = proc.StandardOutput.ReadLine();
+                if (!string.IsNullOrEmpty(_scriptsPath) && _scriptsPath.ToLowerInvariant().EndsWith("scripts"))
                 {
-                    Log.Debug ("Pygments: Python scripts folder: {scriptsPath}", _scriptsPath);
+                    Log.Debug("Pygments: Python scripts folder: {scriptsPath}", _scriptsPath);
                     message = _scriptsPath;
                 }
                 else
                 {
-                    _scriptsPath = proc.StandardError.ReadToEnd ();
+                    _scriptsPath = proc.StandardError.ReadToEnd();
 
-                    Log.Debug ("Pygments: Python error: {scriptsPath}", _scriptsPath);
+                    Log.Debug("Pygments: Python error: {scriptsPath}", _scriptsPath);
                     message =
                         $"Could not find the Python scripts folder.\n{proc.StartInfo.FileName} failed to start: {_scriptsPath}";
                 }
@@ -131,37 +131,37 @@ public class PygmentsConverterService
             message = $"{proc.StartInfo.FileName} {proc.StartInfo.Arguments} failed:\n{ex.Message}";
         }
 
-        if (string.IsNullOrEmpty (_scriptsPath))
+        if (string.IsNullOrEmpty(_scriptsPath))
         {
             message = $"Could not find Pygments. Source code formatting will not work.\n\n{message}";
-            Log.Debug ("Pygments: {message}", message);
+            Log.Debug("Pygments: {message}", message);
             return (_pygmentsInstalled, message);
         }
 
         // Test pygmentize.exe - Which is installed in the app's Program File dir
         try
         {
-            Log.Information ("Source code formatting: Verifying Pygments is installed");
+            Log.Information("Source code formatting: Verifying Pygments is installed");
             proc.StartInfo.FileName = @$"{_scriptsPath}\pygmentize.exe";
             proc.StartInfo.Arguments = "-V";
-            Log.Debug ("Pygments: Starting process {proc} {args}", proc.StartInfo.FileName, proc.StartInfo.Arguments);
-            proc.Start ();
+            Log.Debug("Pygments: Starting process {proc} {args}", proc.StartInfo.FileName, proc.StartInfo.Arguments);
+            proc.Start();
 
-            if (proc.WaitForExit (5000))
+            if (proc.WaitForExit(5000))
             {
-                string? output = proc.StandardOutput.ReadLine ();
-                if (output != null && output.StartsWith ("Pygments version "))
+                string? output = proc.StandardOutput.ReadLine();
+                if (output != null && output.StartsWith("Pygments version "))
                 {
                     _pygmentsInstalled = true;
                     message = $"Pygments is functional: {output}";
-                    Log.Debug ("Pygments: {output}", message);
+                    Log.Debug("Pygments: {output}", message);
                     return (_pygmentsInstalled, message);
                 }
 
                 message =
                     $"Pygments is not installed. {proc.StartInfo.FileName} failed to start: {(output == null ? "no output" : output)}";
                 // Try to install it
-                (_pygmentsInstalled, message) = InstallPygments ();
+                (_pygmentsInstalled, message) = InstallPygments();
             }
             else
             {
@@ -172,9 +172,9 @@ public class PygmentsConverterService
         {
             // Console and WinForms are different
             message = $"{proc.StartInfo.FileName} {proc.StartInfo.Arguments} failed:\n{ex.Message}";
-            Log.Debug ("Pygments: {message}", message);
+            Log.Debug("Pygments: {message}", message);
             // Try to install it
-            (_pygmentsInstalled, message) = InstallPygments ();
+            (_pygmentsInstalled, message) = InstallPygments();
         }
 
         if (!_pygmentsInstalled)
@@ -182,7 +182,7 @@ public class PygmentsConverterService
             message = $"Pygments error. Source code formatting will not function.\n\n{message}";
         }
 
-        Log.Debug ("Pygments: {message}", message);
+        Log.Debug("Pygments: {message}", message);
         return (_pygmentsInstalled, message);
     }
 
@@ -249,11 +249,11 @@ public class PygmentsConverterService
     ///     Installs pygments via pip install
     /// </summary>
     /// <returns>true if pygmentize.exe is working, false otherwise + message</returns>
-    private static (bool installed, string message) InstallPygments ()
+    private static (bool installed, string message) InstallPygments()
     {
         string message;
 
-        var proc = new Process ();
+        var proc = new Process();
 
         proc.StartInfo.RedirectStandardInput = true;
         proc.StartInfo.RedirectStandardOutput = true;
@@ -266,28 +266,28 @@ public class PygmentsConverterService
         bool pygments = false;
         try
         {
-            Log.Information ("Source code formatting: Installing Pygments");
+            Log.Information("Source code formatting: Installing Pygments");
 
             proc.StartInfo.FileName = "pip.exe";
             proc.StartInfo.Arguments = "install Pygments --upgrade";
-            Log.Debug ("Pygments: Attempting to install Pygments via: {cmd} {args}", proc.StartInfo.FileName,
+            Log.Debug("Pygments: Attempting to install Pygments via: {cmd} {args}", proc.StartInfo.FileName,
                 proc.StartInfo.Arguments);
-            proc.Start ();
+            proc.Start();
 
             // TODO: 30 secs is a long time without status updates 
-            if (proc.WaitForExit (30000))
+            if (proc.WaitForExit(30000))
             {
-                string output = proc.StandardOutput.ReadToEnd ();
-                if (output.Contains ("Successfully installed Pygments") ||
-                    output.Contains ("Requirement already satisfied"))
+                string output = proc.StandardOutput.ReadToEnd();
+                if (output.Contains("Successfully installed Pygments") ||
+                    output.Contains("Requirement already satisfied"))
                 {
                     pygments = true;
-                    Log.Debug ("Pygments: Pygments is installed: {output}", output);
+                    Log.Debug("Pygments: Pygments is installed: {output}", output);
                     message = "Pygments is installed";
                 }
                 else
                 {
-                    output = proc.StandardError.ReadToEnd ();
+                    output = proc.StandardError.ReadToEnd();
 
                     message = $"Error installing Pygments.\n{proc.StartInfo.FileName} failed to start: {output}";
                 }
@@ -306,36 +306,36 @@ public class PygmentsConverterService
         if (!pygments)
         {
             message = $"Pygments: Pygments must be installed for source code formatting to work.\n\n{message}";
-            Log.Debug ("{message}", message);
+            Log.Debug("{message}", message);
             return (pygments, message);
         }
 
         return (pygments, message);
     }
 
-    public async Task<string> ConvertAsync (string document, string style, string language)
+    public async Task<string> ConvertAsync(string document, string style, string language)
     {
-        LogService.TraceMessage ();
+        LogService.TraceMessage();
 
         if (_proc != null || _eventHandled != null)
         {
-            throw new InvalidOperationException ("Pygments: ConvertAsync already in progress.");
+            throw new InvalidOperationException("Pygments: ConvertAsync already in progress.");
         }
 
-        if (string.IsNullOrEmpty (_scriptsPath))
+        if (string.IsNullOrEmpty(_scriptsPath))
         {
-            (bool installed, string message) = CheckInstall ();
+            (bool installed, string message) = CheckInstall();
             if (!installed)
             {
-                throw new InvalidOperationException ($"Pygments: {message}");
+                throw new InvalidOperationException($"Pygments: {message}");
             }
         }
 
-        string file = Path.GetTempFileName ();
-        _proc = new Process ();
+        string file = Path.GetTempFileName();
+        _proc = new Process();
         _proc.StartInfo.FileName = @$"{_scriptsPath}\pygmentize.exe";
         _proc.StartInfo.Arguments =
-            $"-P outencoding=utf-8 -f 16m -O style=\"{(string.IsNullOrEmpty (style) ? "default" : style)}\" -l \"{language}\" -o \"{file}.an\" \"{file}\"";
+            $"-P outencoding=utf-8 -f 16m -O style=\"{(string.IsNullOrEmpty(style) ? "default" : style)}\" -l \"{language}\" -o \"{file}.an\" \"{file}\"";
         _proc.StartInfo.RedirectStandardInput = true;
         _proc.StartInfo.RedirectStandardOutput = true;
         _proc.StartInfo.RedirectStandardError = true;
@@ -344,53 +344,53 @@ public class PygmentsConverterService
         _proc.EnableRaisingEvents = true;
         _proc.Exited += Proc_Exited;
 
-        _eventHandled = new TaskCompletionSource<bool> ();
+        _eventHandled = new TaskCompletionSource<bool>();
 
         try
         {
-            Log.Debug ("Pygments: Writing temp file {file}", file);
-            await File.WriteAllTextAsync (file, document, Encoding.UTF8).ConfigureAwait (true);
-            Log.Debug ("Pygments: Starting {pyg} {args}", _proc.StartInfo.FileName, _proc.StartInfo.Arguments);
-            _proc.Start ();
+            Log.Debug("Pygments: Writing temp file {file}", file);
+            await File.WriteAllTextAsync(file, document, Encoding.UTF8).ConfigureAwait(true);
+            Log.Debug("Pygments: Starting {pyg} {args}", _proc.StartInfo.FileName, _proc.StartInfo.Arguments);
+            _proc.Start();
 
-            Log.Debug ("Waiting for pygments to exit");
-            await Task.WhenAny (_eventHandled.Task, Task.Delay (10000)).ConfigureAwait (true);
+            Log.Debug("Waiting for pygments to exit");
+            await Task.WhenAny(_eventHandled.Task, Task.Delay(10000)).ConfigureAwait(true);
 
             if (_proc.ExitCode != 0)
             {
-                string stdErr = await _proc.StandardError.ReadToEndAsync ();
-                Log.Debug ("Pygments: StandardError: {stdErr}", stdErr);
-                string stdOut = await _proc.StandardOutput.ReadToEndAsync ();
-                Log.Debug ("Pygments: StandardOutput: {stdOut}", stdOut);
-                if (stdErr.StartsWith ("Usage:"))
+                string stdErr = await _proc.StandardError.ReadToEndAsync();
+                Log.Debug("Pygments: StandardError: {stdErr}", stdErr);
+                string stdOut = await _proc.StandardOutput.ReadToEndAsync();
+                Log.Debug("Pygments: StandardOutput: {stdOut}", stdOut);
+                if (stdErr.StartsWith("Usage:"))
                 {
                     stdErr = "Invalid command line.";
                 }
 
                 document = $"Pygments: pygmentize.exe error (exit code: {_proc.ExitCode}): {stdErr}";
-                Log.Debug ("{document}", document);
-                throw new InvalidOperationException (document);
+                Log.Debug("{document}", document);
+                throw new InvalidOperationException(document);
             }
             else
             {
-                if (!string.IsNullOrEmpty ($"{file}.an") && File.Exists ($"{file}.an"))
+                if (!string.IsNullOrEmpty($"{file}.an") && File.Exists($"{file}.an"))
                 {
-                    Log.Debug ("Pygments: Reading {file}", $"{file}.an");
-                    document = await File.ReadAllTextAsync ($"{file}.an", Encoding.UTF8).ConfigureAwait (true);
+                    Log.Debug("Pygments: Reading {file}", $"{file}.an");
+                    document = await File.ReadAllTextAsync($"{file}.an", Encoding.UTF8).ConfigureAwait(true);
 
                     // HACK: Because of this bug: https://github.com/pygments/pygments/issues/1435
                     if (document[^1] == '\n')
                     {
-                        document = document.Remove (document.Length - 1, 1);
+                        document = document.Remove(document.Length - 1, 1);
                     }
                 }
                 else
                 {
                     // TODO: This should really throw an exception
-                    string stdErr = await _proc.StandardError.ReadToEndAsync ();
+                    string stdErr = await _proc.StandardError.ReadToEndAsync();
                     document = $"Pygments failed to create converter file: {stdErr}";
-                    Log.Debug ("Pygments: {document}", document);
-                    throw new InvalidOperationException (document);
+                    Log.Debug("Pygments: {document}", document);
+                    throw new InvalidOperationException(document);
                 }
             }
         }
@@ -399,24 +399,24 @@ public class PygmentsConverterService
             // TODO: Better error message (output of stderr?)
             document =
                 $"Could not format document:\n{_proc.StartInfo.FileName} {_proc.StartInfo.Arguments} failed:\n{e.Message}";
-            Log.Debug (e, "{document}", document);
-            throw new InvalidOperationException (document);
+            Log.Debug(e, "{document}", document);
+            throw new InvalidOperationException(document);
         }
         finally
         {
             // Clean up
-            if (!string.IsNullOrEmpty (file) && File.Exists (file))
+            if (!string.IsNullOrEmpty(file) && File.Exists(file))
             {
-                File.Delete (file);
+                File.Delete(file);
             }
 
-            if (!string.IsNullOrEmpty ($"{file}.an") && File.Exists ($"{file}.an"))
+            if (!string.IsNullOrEmpty($"{file}.an") && File.Exists($"{file}.an"))
             {
-                File.Delete ($"{file}.an");
+                File.Delete($"{file}.an");
             }
 
             _proc.Exited -= Proc_Exited;
-            _proc?.Dispose ();
+            _proc?.Dispose();
             _proc = null;
             _eventHandled = null;
         }
@@ -424,14 +424,14 @@ public class PygmentsConverterService
         return document;
     }
 
-    private void Proc_Exited (object? sender, EventArgs e)
+    private void Proc_Exited(object? sender, EventArgs e)
     {
-        Log.Debug ("Pygments: pygmatize exited: Time: {exitTime}, ExitCode: {exitCode}, ElapsedTime: {elapsedTime}ms",
-            _proc!.ExitTime, _proc.ExitCode, Math.Round ((_proc.ExitTime - _proc.StartTime).TotalMilliseconds));
+        Log.Debug("Pygments: pygmatize exited: Time: {exitTime}, ExitCode: {exitCode}, ElapsedTime: {elapsedTime}ms",
+            _proc!.ExitTime, _proc.ExitCode, Math.Round((_proc.ExitTime - _proc.StartTime).TotalMilliseconds));
 
         if (_eventHandled != null)
         {
-            _eventHandled.TrySetResult (true);
+            _eventHandled.TrySetResult(true);
         }
     }
 }

--- a/src/WinPrint.Core/Services/ServiceLocator.cs
+++ b/src/WinPrint.Core/Services/ServiceLocator.cs
@@ -6,41 +6,41 @@ public class ServiceLocator
 {
     private static ServiceLocator? _current;
 
-    private ServiceLocator ()
+    private ServiceLocator()
     {
-        SimpleIoc.Default.Register<SettingsService> ();
-        SimpleIoc.Default.Register<FileTypeMappingService> ();
-        SimpleIoc.Default.Register<LogService> (true);
-        SimpleIoc.Default.Register<TelemetryService> (true);
-        SimpleIoc.Default.Register<UpdateService> ();
-        SimpleIoc.Default.Register<PygmentsConverterService> ();
+        SimpleIoc.Default.Register<SettingsService>();
+        SimpleIoc.Default.Register<FileTypeMappingService>();
+        SimpleIoc.Default.Register<LogService>(true);
+        SimpleIoc.Default.Register<TelemetryService>(true);
+        SimpleIoc.Default.Register<UpdateService>();
+        SimpleIoc.Default.Register<PygmentsConverterService>();
     }
 
-    public static ServiceLocator Current => _current ??= new ServiceLocator ();
+    public static ServiceLocator Current => _current ??= new ServiceLocator();
 
-    public LogService LogService => SimpleIoc.Default.GetInstance<LogService> ();
-    public TelemetryService TelemetryService => SimpleIoc.Default.GetInstance<TelemetryService> ();
-    public SettingsService SettingsService => SimpleIoc.Default.GetInstance<SettingsService> ();
-    public FileTypeMappingService FileTypeMappingService => SimpleIoc.Default.GetInstance<FileTypeMappingService> ();
-    public UpdateService UpdateService => SimpleIoc.Default.GetInstance<UpdateService> ();
+    public LogService LogService => SimpleIoc.Default.GetInstance<LogService>();
+    public TelemetryService TelemetryService => SimpleIoc.Default.GetInstance<TelemetryService>();
+    public SettingsService SettingsService => SimpleIoc.Default.GetInstance<SettingsService>();
+    public FileTypeMappingService FileTypeMappingService => SimpleIoc.Default.GetInstance<FileTypeMappingService>();
+    public UpdateService UpdateService => SimpleIoc.Default.GetInstance<UpdateService>();
 
     public PygmentsConverterService PygmentsConverterService =>
-        SimpleIoc.Default.GetInstance<PygmentsConverterService> ();
+        SimpleIoc.Default.GetInstance<PygmentsConverterService>();
 
-    public void Register<VM, V> ()
+    public void Register<VM, V>()
         where VM : class
     {
-        SimpleIoc.Default.Register<VM> ();
+        SimpleIoc.Default.Register<VM>();
     }
 
-    public static void Reset ()
+    public static void Reset()
     {
         _current = null;
-        SimpleIoc.Default.Unregister<SettingsService> ();
-        SimpleIoc.Default.Unregister<FileTypeMappingService> ();
-        SimpleIoc.Default.Unregister<LogService> ();
-        SimpleIoc.Default.Unregister<TelemetryService> ();
-        SimpleIoc.Default.Unregister<UpdateService> ();
-        SimpleIoc.Default.Unregister<PygmentsConverterService> ();
+        SimpleIoc.Default.Unregister<SettingsService>();
+        SimpleIoc.Default.Unregister<FileTypeMappingService>();
+        SimpleIoc.Default.Unregister<LogService>();
+        SimpleIoc.Default.Unregister<TelemetryService>();
+        SimpleIoc.Default.Unregister<UpdateService>();
+        SimpleIoc.Default.Unregister<PygmentsConverterService>();
     }
 }

--- a/src/WinPrint.Core/Services/SettingsService.cs
+++ b/src/WinPrint.Core/Services/SettingsService.cs
@@ -20,10 +20,10 @@ public class SettingsService
 
     private FileWatcher? _watcher;
 
-    public SettingsService ()
+    public SettingsService()
     {
         SettingsFileName = $"{SettingsPath}{Path.DirectorySeparatorChar}{SettingsFileName}";
-        Log.Debug ("Settings file path: {settingsFileName}", SettingsFileName);
+        Log.Debug("Settings file path: {settingsFileName}", SettingsFileName);
 
         _jsonOptions = new JsonSerializerOptions
         {
@@ -33,7 +33,7 @@ public class SettingsService
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             ReadCommentHandling = JsonCommentHandling.Skip
         };
-        _jsonOptions.Converters.Add (new JsonStringEnumConverter (JsonNamingPolicy.CamelCase));
+        _jsonOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
     }
 
     public string SettingsFileName { get; set; } = "WinPrint.config.json";
@@ -49,29 +49,29 @@ public class SettingsService
         get
         {
             // Get dir of .exe — use AppContext.BaseDirectory as fallback for MAUI/single-file apps
-            string assemblyLocation = Assembly.GetAssembly (typeof (SettingsService))!.Location;
-            string? path = !string.IsNullOrEmpty (assemblyLocation)
-                ? Path.GetDirectoryName (assemblyLocation)
-                : AppContext.BaseDirectory.TrimEnd (Path.DirectorySeparatorChar);
-            string appdata = Environment.GetFolderPath (Environment.SpecialFolder.ApplicationData);
+            string assemblyLocation = Assembly.GetAssembly(typeof(SettingsService))!.Location;
+            string? path = !string.IsNullOrEmpty(assemblyLocation)
+                ? Path.GetDirectoryName(assemblyLocation)
+                : AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar);
+            string appdata = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
 
-            if (RuntimeInformation.IsOSPlatform (OSPlatform.OSX))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 // Your OSX code here.
             }
-            else if (RuntimeInformation.IsOSPlatform (OSPlatform.Linux))
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 // 
             }
             else
             {
-                if (!string.IsNullOrEmpty (assemblyLocation))
+                if (!string.IsNullOrEmpty(assemblyLocation))
                 {
-                    var fvi = FileVersionInfo.GetVersionInfo (assemblyLocation);
+                    var fvi = FileVersionInfo.GetVersionInfo(assemblyLocation);
 
                     // is this in Kindel\winprint?
                     if (path is not null &&
-                        path.Contains ($@"{fvi.CompanyName}{Path.DirectorySeparatorChar}{fvi.ProductName}"))
+                        path.Contains($@"{fvi.CompanyName}{Path.DirectorySeparatorChar}{fvi.ProductName}"))
                     {
                         // We're running %programfiles%\Kindel\winprint; use %appdata%\Kindel\winprint.
                         path =
@@ -79,9 +79,9 @@ public class SettingsService
                     }
 
                     // TODO: Remove internal knowledge of Out-WinPrint from here
-                    if (path is not null && path.Contains ($@"Program Files{Path.DirectorySeparatorChar}PowerShell"))
+                    if (path is not null && path.Contains($@"Program Files{Path.DirectorySeparatorChar}PowerShell"))
                     {
-                        path = Path.GetDirectoryName (assemblyLocation);
+                        path = Path.GetDirectoryName(assemblyLocation);
                     }
                 }
             }
@@ -95,39 +95,39 @@ public class SettingsService
     ///     If file does not exist, it is created.
     /// </summary>
     /// <returns></returns>
-    public Settings? ReadSettings ()
+    public Settings? ReadSettings()
     {
         Settings? settings = null;
         try
         {
-            if (!File.Exists (SettingsFileName))
+            if (!File.Exists(SettingsFileName))
             {
-                Log.Information ("Settings file was not found; creating {settingsFileName} with defaults.",
+                Log.Information("Settings file was not found; creating {settingsFileName} with defaults.",
                     SettingsFileName);
-                settings = Settings.CreateDefaultSettings ();
+                settings = Settings.CreateDefaultSettings();
 
-                ServiceLocator.Current.TelemetryService.TrackEvent ("Create Default Settings",
-                    settings.GetTelemetryDictionary ());
+                ServiceLocator.Current.TelemetryService.TrackEvent("Create Default Settings",
+                    settings.GetTelemetryDictionary());
 
-                SaveSettings (settings);
+                SaveSettings(settings);
             }
             else
             {
-                Log.Debug ("ReadSettings: Binding {settingsFileName} with Microsoft.Extensions.Configuration",
+                Log.Debug("ReadSettings: Binding {settingsFileName} with Microsoft.Extensions.Configuration",
                     SettingsFileName);
-                settings = BindSettings ();
+                settings = BindSettings();
 
-                ServiceLocator.Current.TelemetryService.TrackEvent ("Read Settings",
-                    settings.GetTelemetryDictionary ());
+                ServiceLocator.Current.TelemetryService.TrackEvent("Read Settings",
+                    settings.GetTelemetryDictionary());
             }
         }
         catch (InvalidDataException ide)
         {
-            ReportConfigurationError (ide);
+            ReportConfigurationError(ide);
         }
         catch (Exception ex)
         {
-            ReportUnknownFileError (ex);
+            ReportUnknownFileError(ex);
         }
 
         // Enable file watcher
@@ -135,12 +135,12 @@ public class SettingsService
         if (_watcher != null)
         {
             _watcher.ChangedEvent -= Watcher_ChangedEvent;
-            _watcher.Dispose ();
+            _watcher.Dispose();
             _watcher = null;
         }
 
         // watch .command file for changes
-        _watcher = new FileWatcher (Path.GetFullPath (SettingsFileName));
+        _watcher = new FileWatcher(Path.GetFullPath(SettingsFileName));
         _watcher.ChangedEvent += Watcher_ChangedEvent;
 
         // TODO: Setup subscribing to all properties and automatically saving settings when they change
@@ -148,74 +148,74 @@ public class SettingsService
         return settings;
     }
 
-    private Settings BindSettings ()
+    private Settings BindSettings()
     {
-        var settings = Settings.CreateDefaultSettings ();
-        IConfigurationRoot configuration = BuildConfiguration ();
-        configuration.Bind (settings);
+        var settings = Settings.CreateDefaultSettings();
+        IConfigurationRoot configuration = BuildConfiguration();
+        configuration.Bind(settings);
         return settings;
     }
 
-    private IConfigurationRoot BuildConfiguration ()
+    private IConfigurationRoot BuildConfiguration()
     {
-        string fullPath = Path.GetFullPath (SettingsFileName);
-        string? directory = Path.GetDirectoryName (fullPath);
-        if (string.IsNullOrEmpty (directory))
+        string fullPath = Path.GetFullPath(SettingsFileName);
+        string? directory = Path.GetDirectoryName(fullPath);
+        if (string.IsNullOrEmpty(directory))
         {
-            directory = Directory.GetCurrentDirectory ();
+            directory = Directory.GetCurrentDirectory();
         }
 
-        return new ConfigurationBuilder ()
-            .SetBasePath (directory)
-            .AddJsonFile (Path.GetFileName (fullPath), false, false)
-            .Build ();
+        return new ConfigurationBuilder()
+            .SetBasePath(directory)
+            .AddJsonFile(Path.GetFileName(fullPath), false, false)
+            .Build();
     }
 
-    private void ReportUnknownFileError (Exception ex)
+    private void ReportUnknownFileError(Exception ex)
     {
         // TODO: Graceful error handling for .config file 
-        ServiceLocator.Current.TelemetryService.TrackException (ex);
-        Log.Error (ex, "SettingsService: Error with {settingsFileName}", SettingsFileName);
+        ServiceLocator.Current.TelemetryService.TrackException(ex);
+        Log.Error(ex, "SettingsService: Error with {settingsFileName}", SettingsFileName);
     }
 
-    private void ReportConfigurationError (InvalidDataException ex)
+    private void ReportConfigurationError(InvalidDataException ex)
     {
-        ServiceLocator.Current.TelemetryService.TrackException (ex);
-        Log.Error (ex, "Error parsing {file}", SettingsFileName);
+        ServiceLocator.Current.TelemetryService.TrackException(ex);
+        Log.Error(ex, "Error parsing {file}", SettingsFileName);
     }
 
-    private void Watcher_ChangedEvent (object? sender, EventArgs e)
+    private void Watcher_ChangedEvent(object? sender, EventArgs e)
     {
-        Log.Debug ("Settings file changed: {file}", SettingsFileName);
-        ServiceLocator.Current.TelemetryService.TrackEvent ("Settings File Changed");
+        Log.Debug("Settings file changed: {file}", SettingsFileName);
+        ServiceLocator.Current.TelemetryService.TrackEvent("Settings File Changed");
 
         try
         {
-            Settings changedSettings = BindSettings ();
+            Settings changedSettings = BindSettings();
 
             if (ModelLocator.Current?.Settings == null)
             {
                 // This can happen if settings failed to load when app started. 
-                SimpleIoc.Default.Unregister<Settings> ();
-                SimpleIoc.Default.Register<Settings> ();
+                SimpleIoc.Default.Unregister<Settings>();
+                SimpleIoc.Default.Register<Settings>();
             }
 
             // CopyPropertiesFrom does a deep, property-by property copy from the passed instance
-            ModelLocator.Current?.Settings.CopyPropertiesFrom (changedSettings);
+            ModelLocator.Current?.Settings.CopyPropertiesFrom(changedSettings);
         }
         catch (FileNotFoundException fnfe)
         {
             // TODO: Graceful error handling for .config file 
-            ServiceLocator.Current.TelemetryService.TrackException (fnfe);
-            Log.Error (fnfe, "Settings file changed but was then not found.", SettingsFileName);
+            ServiceLocator.Current.TelemetryService.TrackException(fnfe);
+            Log.Error(fnfe, "Settings file changed but was then not found.", SettingsFileName);
         }
         catch (InvalidDataException ide)
         {
-            ReportConfigurationError (ide);
+            ReportConfigurationError(ide);
         }
         catch (Exception ex)
         {
-            ReportUnknownFileError (ex);
+            ReportUnknownFileError(ex);
         }
     }
 
@@ -226,39 +226,39 @@ public class SettingsService
     /// <param name="settings"></param>
     /// <param name="saveCTESettings">If true Content Type Engine settings will be saved. </param>
     /// <param name="watchChanges">If true the file change watcher will be activated </param>
-    public void SaveSettings (Settings settings, bool saveCTESettings = true, bool watchChanges = false)
+    public void SaveSettings(Settings settings, bool saveCTESettings = true, bool watchChanges = false)
     {
-        ServiceLocator.Current.TelemetryService.TrackEvent ("Save Settings", settings.GetTelemetryDictionary ());
+        ServiceLocator.Current.TelemetryService.TrackEvent("Save Settings", settings.GetTelemetryDictionary());
 
         // Disable file watcher
         if (_watcher != null)
         {
             _watcher.ChangedEvent -= Watcher_ChangedEvent;
-            _watcher.Dispose ();
+            _watcher.Dispose();
             _watcher = null;
         }
 
-        string? directory = Path.GetDirectoryName (Path.GetFullPath (SettingsFileName));
-        if (!string.IsNullOrEmpty (directory))
+        string? directory = Path.GetDirectoryName(Path.GetFullPath(SettingsFileName));
+        if (!string.IsNullOrEmpty(directory))
         {
-            Directory.CreateDirectory (directory);
+            Directory.CreateDirectory(directory);
         }
 
-        File.WriteAllText (SettingsFileName, JsonSerializer.Serialize (settings, _jsonOptions) + Environment.NewLine);
+        File.WriteAllText(SettingsFileName, JsonSerializer.Serialize(settings, _jsonOptions) + Environment.NewLine);
 
         if (watchChanges)
         {
             // watch .command file for changes
-            _watcher = new FileWatcher (Path.GetFullPath (SettingsFileName));
+            _watcher = new FileWatcher(Path.GetFullPath(SettingsFileName));
             _watcher.ChangedEvent += Watcher_ChangedEvent;
         }
     }
 
     // Factory - creates 
-    public static Settings? Create ()
+    public static Settings? Create()
     {
-        LogService.TraceMessage ();
-        Settings? settingsService = ServiceLocator.Current.SettingsService.ReadSettings ();
+        LogService.TraceMessage();
+        Settings? settingsService = ServiceLocator.Current.SettingsService.ReadSettings();
         return settingsService;
     }
 }

--- a/src/WinPrint.Core/Services/TelemetryService.cs
+++ b/src/WinPrint.Core/Services/TelemetryService.cs
@@ -27,28 +27,28 @@ public class TelemetryService
     public bool TelemetryEnabled { get; set; }
 
 #if WINDOWS
-    public TelemetryClient GetTelemetryClient ()
+    public TelemetryClient GetTelemetryClient()
     {
         return telemetry;
     }
 #endif
 
-    public void Start (string appName, IDictionary<string, string?>? startProperties = null)
+    public void Start(string appName, IDictionary<string, string?>? startProperties = null)
     {
-        runtime = Stopwatch.StartNew ();
+        runtime = Stopwatch.StartNew();
 
 #if WINDOWS
-        object? val = Registry.GetValue (@"HKEY_LOCAL_MACHINE\SOFTWARE\Kindel\winprint", "Telemetry", 0);
-        TelemetryEnabled = val != null && val.ToString () == "1" ? true : false;
+        object? val = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Kindel\winprint", "Telemetry", 0);
+        TelemetryEnabled = val != null && val.ToString() == "1" ? true : false;
 
         // Setup telemetry via Azure Application Insights.
-        var config = TelemetryConfiguration.CreateDefault ();
+        var config = TelemetryConfiguration.CreateDefault();
 
         // Get key from UserSecrets in a way that never puts the key in source
 #if CI_BUILD
         config.InstrumentationKey = string.Empty;
 #else
-        config.InstrumentationKey = GetInstrumentationKey ();
+        config.InstrumentationKey = GetInstrumentationKey();
 #endif
 
         // Turn off Debug spew
@@ -59,101 +59,101 @@ public class TelemetryService
         config.TelemetryChannel.DeveloperMode = Debugger.IsAttached;
 #endif
 
-        telemetry = new TelemetryClient (config);
+        telemetry = new TelemetryClient(config);
         telemetry.Context.Component.Version = FileVersionInfo
-            .GetVersionInfo (Assembly.GetAssembly (typeof (TelemetryService))!.Location).FileVersion;
-        telemetry.Context.Session.Id = Guid.NewGuid ().ToString ();
-        telemetry.Context.Device.OperatingSystem = Environment.OSVersion.ToString ();
+            .GetVersionInfo(Assembly.GetAssembly(typeof(TelemetryService))!.Location).FileVersion;
+        telemetry.Context.Session.Id = Guid.NewGuid().ToString();
+        telemetry.Context.Device.OperatingSystem = Environment.OSVersion.ToString();
         // Anonymyize user ID
-        using var h = SHA256.Create ();
-        h.Initialize ();
-        byte[] userHash = h.ComputeHash (Encoding.UTF8.GetBytes ($"{Environment.UserName}/{Environment.MachineName}"));
-        telemetry.Context.User.Id = Convert.ToBase64String (userHash);
+        using var h = SHA256.Create();
+        h.Initialize();
+        byte[] userHash = h.ComputeHash(Encoding.UTF8.GetBytes($"{Environment.UserName}/{Environment.MachineName}"));
+        telemetry.Context.User.Id = Convert.ToBase64String(userHash);
         // See: https://stackoverflow.com/questions/42861344/how-to-overwrite-or-ignore-cloud-roleinstance-with-application-insights
         telemetry.Context.Cloud.RoleInstance = telemetry.Context.User.Id;
 
 
         if (startProperties == null)
         {
-            startProperties = new Dictionary<string, string?> ();
+            startProperties = new Dictionary<string, string?>();
         }
 
         // Merged passed in properites
-        _ = startProperties.Concat (new Dictionary<string, string?>
+        _ = startProperties.Concat(new Dictionary<string, string?>
         {
             ["app"] = appName,
             ["version"] = telemetry.Context.Component.Version,
-            ["os"] = Environment.OSVersion.ToString (),
+            ["os"] = Environment.OSVersion.ToString(),
             ["arch"] = Environment.Is64BitProcess ? "x64" : "x86",
-            ["dotNetVersion"] = Environment.Version.ToString ()
-        }).ToDictionary (kvp => kvp.Key, kvp => kvp.Value);
-        TrackEvent ("Application Started", startProperties);
+            ["dotNetVersion"] = Environment.Version.ToString()
+        }).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        TrackEvent("Application Started", startProperties);
 #else
         TelemetryEnabled = false;
 #endif
     }
 
-    public void Stop ()
+    public void Stop()
     {
 #if WINDOWS
-        TrackEvent ("Application Stopped", metrics: new Dictionary<string, double>
+        TrackEvent("Application Stopped", metrics: new Dictionary<string, double>
             { { "runTime", runtime.Elapsed.TotalMilliseconds } });
 
         // before exit, flush the remaining data
-        Flush ();
+        Flush();
         // Flush is not blocking so wait a bit
-        Task.Delay (1000).Wait ();
+        Task.Delay(1000).Wait();
 #endif
     }
 
-    public void SetUser (string user)
+    public void SetUser(string user)
     {
 #if WINDOWS
         telemetry.Context.User.AuthenticatedUserId = user;
 #endif
     }
 
-    public void TrackEvent (string key, IDictionary<string, string?>? properties = null,
+    public void TrackEvent(string key, IDictionary<string, string?>? properties = null,
         IDictionary<string, double>? metrics = null)
     {
 #if WINDOWS
         if (TelemetryEnabled && telemetry != null)
         {
-            telemetry.TrackEvent (key, properties, metrics);
+            telemetry.TrackEvent(key, properties, metrics);
         }
 #endif
     }
 
-    public void TrackException (Exception ex, bool log = false)
+    public void TrackException(Exception ex, bool log = false)
     {
         if (ex != null && log is true)
         {
-            Log.Error (ex, "{msg}", ex.Message);
+            Log.Error(ex, "{msg}", ex.Message);
         }
 
 #if WINDOWS
         if (telemetry != null && ex != null && TelemetryEnabled)
         {
-            var telex = new ExceptionTelemetry (ex);
-            telemetry.TrackException (telex);
-            Flush ();
+            var telex = new ExceptionTelemetry(ex);
+            telemetry.TrackException(telex);
+            Flush();
         }
 #endif
     }
 
-    internal void Flush ()
+    internal void Flush()
     {
 #if WINDOWS
         if (telemetry != null)
         {
-            telemetry.Flush ();
+            telemetry.Flush();
         }
 #endif
     }
 
-    internal static string GetInstrumentationKey ()
+    internal static string GetInstrumentationKey()
     {
-        return Environment.GetEnvironmentVariable ("winprint_telemetryId") ?? string.Empty;
+        return Environment.GetEnvironmentVariable("winprint_telemetryId") ?? string.Empty;
     }
 
     //private class CustomConverter : TraceTelemetryConverter {

--- a/src/WinPrint.Core/Services/UpdateService.cs
+++ b/src/WinPrint.Core/Services/UpdateService.cs
@@ -18,7 +18,7 @@ namespace WinPrint.Core.Services;
 /// </summary>
 public class UpdateService
 {
-    private static readonly HttpClient _httpClient = new ();
+    private static readonly HttpClient _httpClient = new();
     private string? _tempFilename;
 
     /// <summary>
@@ -30,12 +30,12 @@ public class UpdateService
     ///     Provides the current version number
     /// </summary>
     public static Version CurrentVersion =>
-        new (FileVersionInfo.GetVersionInfo (Assembly.GetAssembly (typeof (UpdateService))!.Location).FileVersion!);
+        new(FileVersionInfo.GetVersionInfo(Assembly.GetAssembly(typeof(UpdateService))!.Location).FileVersion!);
 
     /// <summary>
     ///     Contains the version number of the latest version found online (only valid after GotLatestVersion)
     /// </summary>
-    public Version LatestVersion { get; private set; } = new (0, 0);
+    public Version LatestVersion { get; private set; } = new(0, 0);
 
 
     /// <summary>
@@ -53,9 +53,9 @@ public class UpdateService
     /// </summary>
     public event EventHandler<Version>? GotLatestVersion;
 
-    protected void OnGotLatestVersion (Version latestVersion)
+    protected void OnGotLatestVersion(Version latestVersion)
     {
-        GotLatestVersion?.Invoke (this, latestVersion);
+        GotLatestVersion?.Invoke(this, latestVersion);
     }
 
     /// <summary>
@@ -63,16 +63,16 @@ public class UpdateService
     /// </summary>
     public event EventHandler<string>? DownloadComplete;
 
-    protected void OnDownloadComplete (string path)
+    protected void OnDownloadComplete(string path)
     {
-        DownloadComplete?.Invoke (this, path);
+        DownloadComplete?.Invoke(this, path);
     }
 
     public event EventHandler<DownloadProgressChangedEventArgs>? DownloadProgressChanged;
 
-    protected void OnDownloadProgressChanged (DownloadProgressChangedEventArgs e)
+    protected void OnDownloadProgressChanged(DownloadProgressChangedEventArgs e)
     {
-        DownloadProgressChanged?.Invoke (this, e);
+        DownloadProgressChanged?.Invoke(this, e);
     }
 
     /// <summary>
@@ -82,36 +82,38 @@ public class UpdateService
     ///     < 0 - A newer version available
     /// </summary>
     /// <returns></returns>
-    public int CompareVersions ()
+    public int CompareVersions()
     {
-        return CurrentVersion.CompareTo (LatestVersion);
+        return CurrentVersion.CompareTo(LatestVersion);
     }
 
     /// <summary>
     ///     Checks for updated version online.
     /// </summary>
     /// <returns></returns>
-    public async Task<Version> GetLatestVersionAsync (CancellationToken token)
+    public async Task<Version> GetLatestVersionAsync(CancellationToken token)
     {
-        LogService.TraceMessage ();
-        InstallerUri = new Uri ("https://github.com/tig/winprint/releases");
+        LogService.TraceMessage();
+        InstallerUri = new Uri("https://github.com/tig/winprint/releases");
         try
         {
-            var github = new GitHubClient (new ProductHeaderValue ("tig-winprint"));
+            var github = new GitHubClient(new ProductHeaderValue("tig-winprint"));
             IReadOnlyList<Release>? allReleases =
-                await github.Repository.Release.GetAll ("tig", "winprint").ConfigureAwait (false);
+                await github.Repository.Release.GetAll("tig", "winprint").ConfigureAwait(false);
 
             //#if DEBUG
             //                Debug.WriteLine("Pausing 2s to simulate version check taking a long time...");
             //                Thread.Sleep(2000);
             //                Debug.WriteLine("Done pausing.");
             //#endif
-            token.ThrowIfCancellationRequested ();
+            token.ThrowIfCancellationRequested();
 
             // Get all releases and pre-releases
 #if DEBUG
-            Release[] releases = allReleases.Where (r => r.Prerelease)
-                .OrderByDescending (r => new Version (r.TagName.Replace ('v', ' '))).ToArray ();
+            Release[] releases =
+            [
+                .. allReleases.Where(r => r.Prerelease).OrderByDescending(r => new Version(r.TagName.Replace('v', ' ')))
+            ];
 #else
                 var releases =
  allReleases.Where(r => !r.Prerelease).OrderByDescending(r => new Version(r.TagName.Replace('v', ' '))).ToArray();
@@ -119,13 +121,13 @@ public class UpdateService
             //Log.Debug("Releases {releases}", JsonSerializer.Serialize(releases, options: new JsonSerializerOptions() { WriteIndented = true }));
             if (releases.Length > 0)
             {
-                Log.Debug (
+                Log.Debug(
                     "The latest release is tagged at {TagName} and is named {Name}. Download Url: {BrowserDownloadUrl}",
                     releases[0].TagName, releases[0].Name, releases[0].Assets[0].BrowserDownloadUrl);
 
-                LatestVersion = new Version (releases[0].TagName.Replace ('v', ' '));
-                ReleasePageUri = new Uri (releases[0].HtmlUrl);
-                InstallerUri = new Uri (releases[0].Assets[0].BrowserDownloadUrl);
+                LatestVersion = new Version(releases[0].TagName.Replace('v', ' '));
+                ReleasePageUri = new Uri(releases[0].HtmlUrl);
+                InstallerUri = new Uri(releases[0].Assets[0].BrowserDownloadUrl);
             }
             else
             {
@@ -135,45 +137,45 @@ public class UpdateService
         catch (Exception e)
         {
             ErrorMessage = $"({ReleasePageUri}) {e.Message}";
-            Log.Warning ("Update: {msg}", ErrorMessage);
-            ServiceLocator.Current.TelemetryService.TrackException (e);
+            Log.Warning("Update: {msg}", ErrorMessage);
+            ServiceLocator.Current.TelemetryService.TrackException(e);
         }
 
-        OnGotLatestVersion (LatestVersion);
+        OnGotLatestVersion(LatestVersion);
         return LatestVersion;
     }
 
     /// <summary>
     ///     Starts an upgrade. Must be called after GotLatestVersion has been fired.
     /// </summary>
-    public async Task<string> StartUpgradeAsync ()
+    public async Task<string> StartUpgradeAsync()
     {
-        Debug.WriteLine ("StartUpgradeAsync");
+        Debug.WriteLine("StartUpgradeAsync");
         // Download file
-        _tempFilename = Path.GetTempFileName () + ".msi";
+        _tempFilename = Path.GetTempFileName() + ".msi";
         //Log.Information($"{this.GetType().Name}: Downloading {InstallerUri.AbsoluteUri} to {_tempFilename}...");
 
         if (InstallerUri is null)
         {
-            throw new InvalidOperationException ("Installer URI is not available.");
+            throw new InvalidOperationException("Installer URI is not available.");
         }
 
-        await File.WriteAllBytesAsync (_tempFilename,
-            await _httpClient.GetByteArrayAsync (InstallerUri).ConfigureAwait (false)).ConfigureAwait (false);
-        OnDownloadComplete (_tempFilename);
+        await File.WriteAllBytesAsync(_tempFilename,
+            await _httpClient.GetByteArrayAsync(InstallerUri).ConfigureAwait(false)).ConfigureAwait(false);
+        OnDownloadComplete(_tempFilename);
         return _tempFilename;
     }
 
-    private void Client_DownloadProgressChanged (object? sender, DownloadProgressChangedEventArgs e)
+    private void Client_DownloadProgressChanged(object? sender, DownloadProgressChangedEventArgs e)
     {
         //Log.Debug($"{this.GetType().Name}: Download progress {e.ProgressPercentage}%");
         //if (e.ProgressPercentage % 33 == 0) {
         //    Log.Information($"{this.GetType().Name}: Download progress {e.ProgressPercentage}%");
         //}
-        OnDownloadProgressChanged (e);
+        OnDownloadProgressChanged(e);
     }
 
-    private void Client_DownloadDataCompleted (object? sender, DownloadDataCompletedEventArgs e)
+    private void Client_DownloadDataCompleted(object? sender, DownloadDataCompletedEventArgs e)
     {
         //try {
         //    // If the request was not canceled and did not throw
@@ -189,6 +191,6 @@ public class UpdateService
         ////Log.Information($"{this.GetType().Name}: Exiting and running installer ({_tempFilename})...");
 
 
-        OnDownloadComplete (_tempFilename!);
+        OnDownloadComplete(_tempFilename!);
     }
 }

--- a/src/WinPrint.Core/ViewModels/AppViewModel.cs
+++ b/src/WinPrint.Core/ViewModels/AppViewModel.cs
@@ -43,7 +43,7 @@ public sealed class AppViewModel : INotifyPropertyChanged
     private readonly SheetViewModel _sheetVM;
     private readonly PrintPageSetup _pageSetup;
 
-    private readonly List<string> _sheetKeys = new ();
+    private readonly List<string> _sheetKeys = [];
     private SheetSettings? _currentSheet;
     private int _selectedSheetIndex = -1;
     private bool _suppressReflow;
@@ -57,11 +57,11 @@ public sealed class AppViewModel : INotifyPropertyChanged
     private string? _selectedPrinter;
     private string? _selectedPaperSize;
 
-    public AppViewModel (SheetViewModel sheetVM, PrintPageSetup pageSetup)
+    public AppViewModel(SheetViewModel sheetVM, PrintPageSetup pageSetup)
     {
-        _sheetVM = sheetVM ?? throw new ArgumentNullException (nameof (sheetVM));
-        _pageSetup = pageSetup ?? throw new ArgumentNullException (nameof (pageSetup));
-        SheetNames = new ObservableCollection<string> ();
+        _sheetVM = sheetVM ?? throw new ArgumentNullException(nameof(sheetVM));
+        _pageSetup = pageSetup ?? throw new ArgumentNullException(nameof(pageSetup));
+        SheetNames = [];
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;
@@ -93,51 +93,51 @@ public sealed class AppViewModel : INotifyPropertyChanged
     public int SelectedSheetIndex
     {
         get => _selectedSheetIndex;
-        set => SelectSheetByIndex (value);
+        set => SelectSheetByIndex(value);
     }
 
     public string ActiveFile
     {
         get => _activeFile;
-        private set => SetField (ref _activeFile, value);
+        private set => SetField(ref _activeFile, value);
     }
 
     public string StatusText
     {
         get => _statusText;
-        set => SetField (ref _statusText, value);
+        set => SetField(ref _statusText, value);
     }
 
     public bool IsBusy
     {
         get => _isBusy;
-        private set => SetField (ref _isBusy, value);
+        private set => SetField(ref _isBusy, value);
     }
 
-    public bool IsFileLoaded => !string.IsNullOrEmpty (_activeFile);
+    public bool IsFileLoaded => !string.IsNullOrEmpty(_activeFile);
 
     public int CurrentPage
     {
         get => _currentPage;
-        set => SetField (ref _currentPage, value);
+        set => SetField(ref _currentPage, value);
     }
 
     public int TotalPages
     {
         get => _totalPages;
-        private set => SetField (ref _totalPages, value);
+        private set => SetField(ref _totalPages, value);
     }
 
     public string? SelectedPrinter
     {
         get => _selectedPrinter;
-        set => SetField (ref _selectedPrinter, value);
+        set => SetField(ref _selectedPrinter, value);
     }
 
     public string? SelectedPaperSize
     {
         get => _selectedPaperSize;
-        set => SetField (ref _selectedPaperSize, value);
+        set => SetField(ref _selectedPaperSize, value);
     }
 
     // ----- Sheet enumeration / selection -----
@@ -146,18 +146,18 @@ public sealed class AppViewModel : INotifyPropertyChanged
     ///     Populates <see cref="SheetNames"/> / <see cref="SheetKeys"/> from
     ///     <see cref="Settings.Sheets"/> and applies <see cref="Settings.DefaultSheet"/>.
     /// </summary>
-    public void LoadSheets ()
+    public void LoadSheets()
     {
-        _sheetKeys.Clear ();
-        SheetNames.Clear ();
-        foreach (var kvp in Settings.Sheets)
+        _sheetKeys.Clear();
+        SheetNames.Clear();
+        foreach (KeyValuePair<string, SheetSettings> kvp in Settings.Sheets)
         {
-            _sheetKeys.Add (kvp.Key);
-            SheetNames.Add (kvp.Value.Name);
+            _sheetKeys.Add(kvp.Key);
+            SheetNames.Add(kvp.Value.Name);
         }
 
-        var defaultKey = Settings.DefaultSheet.ToString ();
-        int idx = _sheetKeys.IndexOf (defaultKey);
+        string defaultKey = Settings.DefaultSheet.ToString();
+        int idx = _sheetKeys.IndexOf(defaultKey);
         if (idx < 0 && _sheetKeys.Count > 0)
         {
             idx = 0;
@@ -165,7 +165,7 @@ public sealed class AppViewModel : INotifyPropertyChanged
 
         if (idx >= 0)
         {
-            SelectSheetByIndex (idx);
+            SelectSheetByIndex(idx);
         }
     }
 
@@ -177,14 +177,14 @@ public sealed class AppViewModel : INotifyPropertyChanged
     ///     and raises <see cref="SheetApplied"/>.
     /// </summary>
     /// <returns>true if a sheet was applied.</returns>
-    public bool SelectSheetByIndex (int index)
+    public bool SelectSheetByIndex(int index)
     {
         if (index < 0 || index >= _sheetKeys.Count)
         {
             return false;
         }
 
-        if (!Settings.Sheets.TryGetValue (_sheetKeys[index], out var sheetSettings))
+        if (!Settings.Sheets.TryGetValue(_sheetKeys[index], out SheetSettings? sheetSettings))
         {
             return false;
         }
@@ -194,7 +194,7 @@ public sealed class AppViewModel : INotifyPropertyChanged
         _currentSheet = sheetSettings;
 
         // Initialize the sheet VM (this resets ContentEngine, header/footer state, etc).
-        _sheetVM.SetSheet (sheetSettings);
+        _sheetVM.SetSheet(sheetSettings);
 
         // Sync page setup so the next reflow uses the new orientation/margins.
         _pageSetup.Landscape = sheetSettings.Landscape;
@@ -205,10 +205,11 @@ public sealed class AppViewModel : INotifyPropertyChanged
 
         if (changed)
         {
-            OnPropertyChanged (nameof (SelectedSheetIndex));
-            OnPropertyChanged (nameof (CurrentSheet));
+            OnPropertyChanged(nameof(SelectedSheetIndex));
+            OnPropertyChanged(nameof(CurrentSheet));
         }
-        SheetApplied?.Invoke (this, EventArgs.Empty);
+
+        SheetApplied?.Invoke(this, EventArgs.Empty);
         return true;
     }
 
@@ -216,24 +217,24 @@ public sealed class AppViewModel : INotifyPropertyChanged
     ///     Selects a sheet by friendly name or sheet ID (case-insensitive).
     ///     Used by <c>--sheet</c> on the command line.
     /// </summary>
-    public bool SelectSheetByNameOrId (string nameOrId)
+    public bool SelectSheetByNameOrId(string nameOrId)
     {
-        if (string.IsNullOrEmpty (nameOrId))
+        if (string.IsNullOrEmpty(nameOrId))
         {
             return false;
         }
 
         for (int i = 0; i < _sheetKeys.Count; i++)
         {
-            if (string.Equals (_sheetKeys[i], nameOrId, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(_sheetKeys[i], nameOrId, StringComparison.OrdinalIgnoreCase))
             {
-                return SelectSheetByIndex (i);
+                return SelectSheetByIndex(i);
             }
 
             if (i < SheetNames.Count &&
-                string.Equals (SheetNames[i], nameOrId, StringComparison.OrdinalIgnoreCase))
+                string.Equals(SheetNames[i], nameOrId, StringComparison.OrdinalIgnoreCase))
             {
-                return SelectSheetByIndex (i);
+                return SelectSheetByIndex(i);
             }
         }
 
@@ -252,56 +253,56 @@ public sealed class AppViewModel : INotifyPropertyChanged
     ///     for it to render the message as an overlay. WinForms displays it via the
     ///     status bar / message box path.
     /// </remarks>
-    public async Task<bool> LoadFileAsync (string filePath)
+    public async Task<bool> LoadFileAsync(string filePath)
     {
-        if (string.IsNullOrWhiteSpace (filePath))
+        if (string.IsNullOrWhiteSpace(filePath))
         {
             StatusText = "Error: No file specified.";
-            PreviewInvalidated?.Invoke (this, EventArgs.Empty);
+            PreviewInvalidated?.Invoke(this, EventArgs.Empty);
             return false;
         }
 
-        if (!File.Exists (filePath))
+        if (!File.Exists(filePath))
         {
             StatusText = $"Error: File not found: {filePath}";
-            PreviewInvalidated?.Invoke (this, EventArgs.Empty);
+            PreviewInvalidated?.Invoke(this, EventArgs.Empty);
             return false;
         }
 
         IsBusy = true;
-        StatusText = $"Loading {Path.GetFileName (filePath)}...";
+        StatusText = $"Loading {Path.GetFileName(filePath)}...";
 
         try
         {
             ActiveFile = filePath;
-            OnPropertyChanged (nameof (IsFileLoaded));
+            OnPropertyChanged(nameof(IsFileLoaded));
 
-            bool loaded = await _sheetVM.LoadFileAsync (filePath).ConfigureAwait (false);
+            bool loaded = await _sheetVM.LoadFileAsync(filePath).ConfigureAwait(false);
             if (!loaded)
             {
                 StatusText = $"Error: Failed to load file: {filePath}";
                 ActiveFile = string.Empty;
-                OnPropertyChanged (nameof (IsFileLoaded));
-                PreviewInvalidated?.Invoke (this, EventArgs.Empty);
+                OnPropertyChanged(nameof(IsFileLoaded));
+                PreviewInvalidated?.Invoke(this, EventArgs.Empty);
                 return false;
             }
 
-            _sheetVM.SetPrinterPageSettings (_pageSetup);
-            await _sheetVM.ReflowAsync ().ConfigureAwait (false);
+            _sheetVM.SetPrinterPageSettings(_pageSetup);
+            await _sheetVM.ReflowAsync().ConfigureAwait(false);
 
             TotalPages = _sheetVM.NumSheets;
             CurrentPage = TotalPages > 0 ? 1 : 0;
-            StatusText = $"{Path.GetFileName (filePath)} — {TotalPages} sheet{(TotalPages == 1 ? "" : "s")}";
-            PreviewInvalidated?.Invoke (this, EventArgs.Empty);
-            ReflowCompleted?.Invoke (this, EventArgs.Empty);
+            StatusText = $"{Path.GetFileName(filePath)} — {TotalPages} sheet{(TotalPages == 1 ? "" : "s")}";
+            PreviewInvalidated?.Invoke(this, EventArgs.Empty);
+            ReflowCompleted?.Invoke(this, EventArgs.Empty);
             return true;
         }
         catch (Exception ex)
         {
-            Log.Error (ex, "AppViewModel.LoadFileAsync failed for {file}", filePath);
+            Log.Error(ex, "AppViewModel.LoadFileAsync failed for {file}", filePath);
             StatusText = $"Error: {ex.Message}";
-            ServiceLocator.Current.TelemetryService.TrackException (ex, true);
-            PreviewInvalidated?.Invoke (this, EventArgs.Empty);
+            ServiceLocator.Current.TelemetryService.TrackException(ex, true);
+            PreviewInvalidated?.Invoke(this, EventArgs.Empty);
             return false;
         }
         finally
@@ -310,19 +311,20 @@ public sealed class AppViewModel : INotifyPropertyChanged
         }
     }
 
-    public async Task<bool> RefreshAsync ()
+    public async Task<bool> RefreshAsync()
     {
         if (!IsFileLoaded)
         {
             return false;
         }
-        return await LoadFileAsync (_activeFile).ConfigureAwait (false);
+
+        return await LoadFileAsync(_activeFile).ConfigureAwait(false);
     }
 
     /// <summary>
     ///     Re-applies the current page setup to the sheet view model and reflows.
     /// </summary>
-    public async Task ReflowAsync ()
+    public async Task ReflowAsync()
     {
         if (!IsFileLoaded || _suppressReflow)
         {
@@ -332,27 +334,28 @@ public sealed class AppViewModel : INotifyPropertyChanged
         IsBusy = true;
         try
         {
-            _sheetVM.SetPrinterPageSettings (_pageSetup);
+            _sheetVM.SetPrinterPageSettings(_pageSetup);
 
             // Sync sheet-level ContentSettings to the ContentEngine so changes like
             // LineNumbers are applied without requiring a full file reload.
             if (_sheetVM.ContentEngine?.ContentSettings != null && _sheetVM.ContentSettings != null)
             {
-                _sheetVM.ContentEngine.ContentSettings.CopyPropertiesFrom (_sheetVM.ContentSettings);
+                _sheetVM.ContentEngine.ContentSettings.CopyPropertiesFrom(_sheetVM.ContentSettings);
             }
 
-            await _sheetVM.ReflowAsync ().ConfigureAwait (false);
+            await _sheetVM.ReflowAsync().ConfigureAwait(false);
             TotalPages = _sheetVM.NumSheets;
             if (_currentPage > TotalPages)
             {
                 CurrentPage = TotalPages;
             }
-            PreviewInvalidated?.Invoke (this, EventArgs.Empty);
-            ReflowCompleted?.Invoke (this, EventArgs.Empty);
+
+            PreviewInvalidated?.Invoke(this, EventArgs.Empty);
+            ReflowCompleted?.Invoke(this, EventArgs.Empty);
         }
         catch (Exception ex)
         {
-            Log.Error (ex, "AppViewModel.ReflowAsync failed");
+            Log.Error(ex, "AppViewModel.ReflowAsync failed");
             StatusText = $"Reflow error: {ex.Message}";
         }
         finally
@@ -367,86 +370,150 @@ public sealed class AppViewModel : INotifyPropertyChanged
     // change persists on next save, and (c) raises a property-changed/preview event.
     // Frontends call these instead of duplicating the three-line pattern in each setter.
 
-    public void SetLandscape (bool value)
+    public void SetLandscape(bool value)
     {
         _sheetVM.Landscape = value;
         _pageSetup.Landscape = value;
-        if (_currentSheet != null) { _currentSheet.Landscape = value; }
-        _ = ReflowAsync ();
+        if (_currentSheet != null)
+        {
+            _currentSheet.Landscape = value;
+        }
+
+        _ = ReflowAsync();
     }
 
-    public void SetRows (int value)
+    public void SetRows(int value)
     {
         _sheetVM.Rows = value;
-        if (_currentSheet != null) { _currentSheet.Rows = value; }
-        _ = ReflowAsync ();
+        if (_currentSheet != null)
+        {
+            _currentSheet.Rows = value;
+        }
+
+        _ = ReflowAsync();
     }
 
-    public void SetColumns (int value)
+    public void SetColumns(int value)
     {
         _sheetVM.Columns = value;
-        if (_currentSheet != null) { _currentSheet.Columns = value; }
-        _ = ReflowAsync ();
+        if (_currentSheet != null)
+        {
+            _currentSheet.Columns = value;
+        }
+
+        _ = ReflowAsync();
     }
 
-    public void SetPadding (int paddingHundredths)
+    public void SetPadding(int paddingHundredths)
     {
         _sheetVM.Padding = paddingHundredths;
-        if (_currentSheet != null) { _currentSheet.Padding = paddingHundredths; }
-        _ = ReflowAsync ();
+        if (_currentSheet != null)
+        {
+            _currentSheet.Padding = paddingHundredths;
+        }
+
+        _ = ReflowAsync();
     }
 
-    public void SetPageSeparator (bool value)
+    public void SetPageSeparator(bool value)
     {
         _sheetVM.PageSeparator = value;
-        if (_currentSheet != null) { _currentSheet.PageSeparator = value; }
-        PreviewInvalidated?.Invoke (this, EventArgs.Empty);
+        if (_currentSheet != null)
+        {
+            _currentSheet.PageSeparator = value;
+        }
+
+        PreviewInvalidated?.Invoke(this, EventArgs.Empty);
     }
 
-    public void SetLineNumbers (bool value)
+    public void SetLineNumbers(bool value)
     {
-        if (_sheetVM.ContentSettings != null) { _sheetVM.ContentSettings.LineNumbers = value; }
-        if (_currentSheet?.ContentSettings != null) { _currentSheet.ContentSettings.LineNumbers = value; }
-        _ = ReflowAsync ();
+        if (_sheetVM.ContentSettings != null)
+        {
+            _sheetVM.ContentSettings.LineNumbers = value;
+        }
+
+        if (_currentSheet?.ContentSettings != null)
+        {
+            _currentSheet.ContentSettings.LineNumbers = value;
+        }
+
+        _ = ReflowAsync();
     }
 
-    public void SetMargins (PrintMargins margins)
+    public void SetMargins(PrintMargins margins)
     {
         _sheetVM.Margins = margins;
         _pageSetup.MarginTop = margins.Top;
         _pageSetup.MarginBottom = margins.Bottom;
         _pageSetup.MarginLeft = margins.Left;
         _pageSetup.MarginRight = margins.Right;
-        if (_currentSheet != null) { _currentSheet.Margins = margins; }
-        _ = ReflowAsync ();
+        if (_currentSheet != null)
+        {
+            _currentSheet.Margins = margins;
+        }
+
+        _ = ReflowAsync();
     }
 
-    public void SetHeaderEnabled (bool value)
+    public void SetHeaderEnabled(bool value)
     {
-        if (_sheetVM.Header != null) { _sheetVM.Header.Enabled = value; }
-        if (_currentSheet?.Header != null) { _currentSheet.Header.Enabled = value; }
-        _ = ReflowAsync ();
+        if (_sheetVM.Header != null)
+        {
+            _sheetVM.Header.Enabled = value;
+        }
+
+        if (_currentSheet?.Header != null)
+        {
+            _currentSheet.Header.Enabled = value;
+        }
+
+        _ = ReflowAsync();
     }
 
-    public void SetHeaderText (string value)
+    public void SetHeaderText(string value)
     {
-        if (_sheetVM.Header != null) { _sheetVM.Header.Text = value; }
-        if (_currentSheet?.Header != null) { _currentSheet.Header.Text = value; }
-        PreviewInvalidated?.Invoke (this, EventArgs.Empty);
+        if (_sheetVM.Header != null)
+        {
+            _sheetVM.Header.Text = value;
+        }
+
+        if (_currentSheet?.Header != null)
+        {
+            _currentSheet.Header.Text = value;
+        }
+
+        PreviewInvalidated?.Invoke(this, EventArgs.Empty);
     }
 
-    public void SetFooterEnabled (bool value)
+    public void SetFooterEnabled(bool value)
     {
-        if (_sheetVM.Footer != null) { _sheetVM.Footer.Enabled = value; }
-        if (_currentSheet?.Footer != null) { _currentSheet.Footer.Enabled = value; }
-        _ = ReflowAsync ();
+        if (_sheetVM.Footer != null)
+        {
+            _sheetVM.Footer.Enabled = value;
+        }
+
+        if (_currentSheet?.Footer != null)
+        {
+            _currentSheet.Footer.Enabled = value;
+        }
+
+        _ = ReflowAsync();
     }
 
-    public void SetFooterText (string value)
+    public void SetFooterText(string value)
     {
-        if (_sheetVM.Footer != null) { _sheetVM.Footer.Text = value; }
-        if (_currentSheet?.Footer != null) { _currentSheet.Footer.Text = value; }
-        PreviewInvalidated?.Invoke (this, EventArgs.Empty);
+        if (_sheetVM.Footer != null)
+        {
+            _sheetVM.Footer.Text = value;
+        }
+
+        if (_currentSheet?.Footer != null)
+        {
+            _currentSheet.Footer.Text = value;
+        }
+
+        PreviewInvalidated?.Invoke(this, EventArgs.Empty);
     }
 
     // ----- Printer / paper-size restore -----
@@ -455,7 +522,7 @@ public sealed class AppViewModel : INotifyPropertyChanged
     ///     Selects the persisted printer (<see cref="Settings.LastPrinter"/>),
     ///     falling back to the system default, then the first available.
     /// </summary>
-    public void RestorePrinterSelection (IList<string> availablePrinters, string? systemDefault)
+    public void RestorePrinterSelection(IList<string> availablePrinters, string? systemDefault)
     {
         if (availablePrinters == null || availablePrinters.Count == 0)
         {
@@ -464,11 +531,11 @@ public sealed class AppViewModel : INotifyPropertyChanged
         }
 
         string? saved = Settings.LastPrinter;
-        if (!string.IsNullOrEmpty (saved) && availablePrinters.Contains (saved))
+        if (!string.IsNullOrEmpty(saved) && availablePrinters.Contains(saved))
         {
             SelectedPrinter = saved;
         }
-        else if (!string.IsNullOrEmpty (systemDefault) && availablePrinters.Contains (systemDefault))
+        else if (!string.IsNullOrEmpty(systemDefault) && availablePrinters.Contains(systemDefault))
         {
             SelectedPrinter = systemDefault;
         }
@@ -483,10 +550,10 @@ public sealed class AppViewModel : INotifyPropertyChanged
     ///     appears in <paramref name="availablePaperSizes"/>. Leaves the current selection
     ///     untouched otherwise.
     /// </summary>
-    public void RestorePaperSize (IList<string> availablePaperSizes)
+    public void RestorePaperSize(IList<string> availablePaperSizes)
     {
         string? saved = Settings.LastPaperSize;
-        if (!string.IsNullOrEmpty (saved) && availablePaperSizes != null && availablePaperSizes.Contains (saved))
+        if (!string.IsNullOrEmpty(saved) && availablePaperSizes != null && availablePaperSizes.Contains(saved))
         {
             SelectedPaperSize = saved;
         }
@@ -502,7 +569,7 @@ public sealed class AppViewModel : INotifyPropertyChanged
     /// <param name="availablePrinters">Printer names known to the platform (may be null).</param>
     /// <param name="availablePaperSizes">Paper size names known to the platform (may be null).</param>
     /// <returns>The first file argument, or <c>null</c> if none was supplied.</returns>
-    public string? ApplyOptions (
+    public string? ApplyOptions(
         Options options,
         IList<string>? availablePrinters = null,
         IList<string>? availablePaperSizes = null)
@@ -513,9 +580,9 @@ public sealed class AppViewModel : INotifyPropertyChanged
         }
 
         // Apply sheet first so subsequent overrides land on the right sheet.
-        if (!string.IsNullOrEmpty (options.Sheet))
+        if (!string.IsNullOrEmpty(options.Sheet))
         {
-            SelectSheetByNameOrId (options.Sheet);
+            SelectSheetByNameOrId(options.Sheet);
         }
 
         // --landscape / --portrait. Suppress reflow until file load.
@@ -524,21 +591,21 @@ public sealed class AppViewModel : INotifyPropertyChanged
         {
             if (options.Landscape)
             {
-                SetLandscape (true);
+                SetLandscape(true);
             }
             else if (options.Portrait)
             {
-                SetLandscape (false);
+                SetLandscape(false);
             }
 
-            if (!string.IsNullOrEmpty (options.Printer) &&
-                (availablePrinters == null || availablePrinters.Contains (options.Printer)))
+            if (!string.IsNullOrEmpty(options.Printer) &&
+                (availablePrinters == null || availablePrinters.Contains(options.Printer)))
             {
                 SelectedPrinter = options.Printer;
             }
 
-            if (!string.IsNullOrEmpty (options.PaperSize) &&
-                (availablePaperSizes == null || availablePaperSizes.Contains (options.PaperSize)))
+            if (!string.IsNullOrEmpty(options.PaperSize) &&
+                (availablePaperSizes == null || availablePaperSizes.Contains(options.PaperSize)))
             {
                 SelectedPaperSize = options.PaperSize;
             }
@@ -548,7 +615,7 @@ public sealed class AppViewModel : INotifyPropertyChanged
             _suppressReflow = false;
         }
 
-        return options.Files?.FirstOrDefault ();
+        return options.Files?.FirstOrDefault();
     }
 
     // ----- Window state persistence -----
@@ -559,9 +626,9 @@ public sealed class AppViewModel : INotifyPropertyChanged
     ///     restoring from maximized returns the user to their last normal bounds —
     ///     this mirrors the WinForms <c>RestoreBounds</c> semantics.
     /// </summary>
-    public void SaveWindowState (double x, double y, double width, double height, bool isMaximized)
+    public void SaveWindowState(double x, double y, double width, double height, bool isMaximized)
     {
-        var settings = Settings;
+        Settings settings = Settings;
         settings.WindowState = isMaximized ? FormWindowState.Maximized : FormWindowState.Normal;
 
         if (!isMaximized)
@@ -572,7 +639,7 @@ public sealed class AppViewModel : INotifyPropertyChanged
 
         if (_selectedSheetIndex >= 0 && _selectedSheetIndex < _sheetKeys.Count)
         {
-            if (Guid.TryParse (_sheetKeys[_selectedSheetIndex], out var sheetGuid))
+            if (Guid.TryParse(_sheetKeys[_selectedSheetIndex], out Guid sheetGuid))
             {
                 settings.DefaultSheet = sheetGuid;
             }
@@ -581,7 +648,7 @@ public sealed class AppViewModel : INotifyPropertyChanged
         settings.LastPrinter = _selectedPrinter;
         settings.LastPaperSize = _selectedPaperSize;
 
-        ServiceLocator.Current.SettingsService.SaveSettings (settings, saveCTESettings: false);
+        ServiceLocator.Current.SettingsService.SaveSettings(settings, false);
     }
 
     /// <summary>
@@ -589,28 +656,29 @@ public sealed class AppViewModel : INotifyPropertyChanged
     ///     whenever the window moves or resizes while not maximized, so the values are
     ///     available when persisting under <see cref="SaveWindowState"/>.
     /// </summary>
-    public void SaveNormalBounds (double x, double y, double width, double height)
+    public void SaveNormalBounds(double x, double y, double width, double height)
     {
-        var settings = Settings;
+        Settings settings = Settings;
         settings.Location = new WindowLocation { X = (int)x, Y = (int)y };
         settings.Size = new WindowSize { Width = (int)width, Height = (int)height };
     }
 
     // ----- INotifyPropertyChanged plumbing -----
 
-    private bool SetField<T> (ref T field, T value, [CallerMemberName] string? propertyName = null)
+    private bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
     {
-        if (EqualityComparer<T>.Default.Equals (field, value))
+        if (EqualityComparer<T>.Default.Equals(field, value))
         {
             return false;
         }
+
         field = value;
-        OnPropertyChanged (propertyName);
+        OnPropertyChanged(propertyName);
         return true;
     }
 
-    private void OnPropertyChanged ([CallerMemberName] string? propertyName = null)
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
     {
-        PropertyChanged?.Invoke (this, new PropertyChangedEventArgs (propertyName));
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
 }

--- a/src/WinPrint.Core/ViewModels/FooterViewModel.cs
+++ b/src/WinPrint.Core/ViewModels/FooterViewModel.cs
@@ -6,28 +6,28 @@ using WinPrint.Core.Models;
 
 namespace WinPrint.Core;
 
-public class FooterViewModel (SheetViewModel svm, HeaderFooter hf) : HeaderFooterViewModel (svm, hf)
+public class FooterViewModel(SheetViewModel svm, HeaderFooter hf) : HeaderFooterViewModel(svm, hf)
 {
-    internal override RectangleF CalcBounds ()
+    internal override RectangleF CalcBounds()
     {
-        float h = SheetViewModel.GetFontHeight (Font) + VerticalPadding;
+        float h = SheetViewModel.GetFontHeight(Font) + VerticalPadding;
         if (!Enabled)
         {
-            return new RectangleF (0, 0, 0, 0);
+            return new RectangleF(0, 0, 0, 0);
         }
 
         if (_svm != null)
         {
-            return new RectangleF (_svm.Bounds.Left + _svm.Margins.Left,
+            return new RectangleF(_svm.Bounds.Left + _svm.Margins.Left,
                 _svm.Bounds.Bottom - _svm.Margins.Bottom - h,
                 _svm.Bounds.Width - _svm.Margins.Left - _svm.Margins.Right,
                 h);
         }
 
-        return new RectangleF (0, 0, 0, 0);
+        return new RectangleF(0, 0, 0, 0);
     }
 
-    internal override bool IsAlignTop ()
+    internal override bool IsAlignTop()
     {
         return false;
     }

--- a/src/WinPrint.Core/ViewModels/HeaderFooterViewModel.cs
+++ b/src/WinPrint.Core/ViewModels/HeaderFooterViewModel.cs
@@ -34,14 +34,14 @@ public abstract class HeaderFooterViewModel : ViewModelBase, IDisposable
     private int _verticalPadding = 10; // Vertical padding below/above header/footer in 100ths of inch
 
     /// <inheritdoc />
-    protected HeaderFooterViewModel (SheetViewModel? svm, HeaderFooter? hf)
+    protected HeaderFooterViewModel(SheetViewModel? svm, HeaderFooter? hf)
     {
         if (hf is null)
         {
-            throw new ArgumentNullException (nameof (hf));
+            throw new ArgumentNullException(nameof(hf));
         }
 
-        _svm = svm ?? throw new ArgumentNullException (nameof (svm));
+        _svm = svm ?? throw new ArgumentNullException(nameof(svm));
 
         Text = hf.Text;
         LeftBorder = hf.LeftBorder;
@@ -52,7 +52,7 @@ public abstract class HeaderFooterViewModel : ViewModelBase, IDisposable
         // Font can be null (provided by Sheet definition)
         if (hf.Font != null)
         {
-            Font = (Font)hf.Font.Clone ();
+            Font = (Font)hf.Font.Clone();
         }
 
         Enabled = hf.Enabled;
@@ -92,17 +92,17 @@ public abstract class HeaderFooterViewModel : ViewModelBase, IDisposable
                     reflow = true;
                     break;
                 default:
-                    throw new InvalidOperationException ($"Property change not handled: {e.PropertyName}");
+                    throw new InvalidOperationException($"Property change not handled: {e.PropertyName}");
             }
 
-            OnSettingsChanged (reflow);
+            OnSettingsChanged(reflow);
         };
     }
 
     public string? Text
     {
         get => _text;
-        set => SetField (ref _text, value);
+        set => SetField(ref _text, value);
     }
 
     /// <summary>
@@ -111,7 +111,7 @@ public abstract class HeaderFooterViewModel : ViewModelBase, IDisposable
     public Font? Font
     {
         get => _font;
-        set => SetField (ref _font, value);
+        set => SetField(ref _font, value);
     }
 
     /// <summary>
@@ -120,7 +120,7 @@ public abstract class HeaderFooterViewModel : ViewModelBase, IDisposable
     public bool LeftBorder
     {
         get => _leftBorder;
-        set => SetField (ref _leftBorder, value);
+        set => SetField(ref _leftBorder, value);
     }
 
     /// <summary>
@@ -129,7 +129,7 @@ public abstract class HeaderFooterViewModel : ViewModelBase, IDisposable
     public bool TopBorder
     {
         get => _topBorder;
-        set => SetField (ref _topBorder, value);
+        set => SetField(ref _topBorder, value);
     }
 
     /// <summary>
@@ -138,7 +138,7 @@ public abstract class HeaderFooterViewModel : ViewModelBase, IDisposable
     public bool RightBorder
     {
         get => _rightBorder;
-        set => SetField (ref _rightBorder, value);
+        set => SetField(ref _rightBorder, value);
     }
 
     /// <summary>
@@ -147,7 +147,7 @@ public abstract class HeaderFooterViewModel : ViewModelBase, IDisposable
     public bool BottomBorder
     {
         get => _bottomBorder;
-        set => SetField (ref _bottomBorder, value);
+        set => SetField(ref _bottomBorder, value);
     }
 
     /// <summary>
@@ -156,27 +156,27 @@ public abstract class HeaderFooterViewModel : ViewModelBase, IDisposable
     public bool Enabled
     {
         get => _enabled;
-        set => SetField (ref _enabled, value);
+        set => SetField(ref _enabled, value);
     }
 
     public int VerticalPadding
     {
         get => _verticalPadding;
-        set => SetField (ref _verticalPadding, value);
+        set => SetField(ref _verticalPadding, value);
     }
 
     /// <summary>
     ///     Header/Footer bounds (page minus margins)
     /// </summary>
-    public RectangleF Bounds => CalcBounds ();
+    public RectangleF Bounds => CalcBounds();
 
-    public void Dispose ()
+    public void Dispose()
     {
-        Dispose (true);
-        GC.SuppressFinalize (this);
+        Dispose(true);
+        GC.SuppressFinalize(this);
     }
 
-    protected virtual void Dispose (bool disposing)
+    protected virtual void Dispose(bool disposing)
     {
         if (_disposed)
         {
@@ -195,44 +195,44 @@ public abstract class HeaderFooterViewModel : ViewModelBase, IDisposable
     ///     Calculate the Header or Footer bounds (position and size on sheet) based on containing document and font size.
     /// </summary>
     /// <returns></returns>
-    internal abstract RectangleF CalcBounds ();
+    internal abstract RectangleF CalcBounds();
 
-    internal abstract bool IsAlignTop ();
+    internal abstract bool IsAlignTop();
 
-    public void Paint (IGraphicsContext g, int sheetNum)
+    public void Paint(IGraphicsContext g, int sheetNum)
     {
         if (!Enabled)
         {
             return;
         }
 
-        RectangleF boundsHF = CalcBounds ();
-        boundsHF.Y += IsAlignTop () ? 0 : _verticalPadding;
+        RectangleF boundsHF = CalcBounds();
+        boundsHF.Y += IsAlignTop() ? 0 : _verticalPadding;
         boundsHF.Height -= _verticalPadding;
 
         if (LeftBorder)
         {
-            g.DrawLine (g.BlackPen, boundsHF.Left, boundsHF.Top, boundsHF.Left, boundsHF.Bottom);
+            g.DrawLine(g.BlackPen, boundsHF.Left, boundsHF.Top, boundsHF.Left, boundsHF.Bottom);
         }
 
         if (TopBorder)
         {
-            g.DrawLine (g.BlackPen, boundsHF.Left, boundsHF.Top, boundsHF.Right, boundsHF.Top);
+            g.DrawLine(g.BlackPen, boundsHF.Left, boundsHF.Top, boundsHF.Right, boundsHF.Top);
         }
 
         if (RightBorder)
         {
-            g.DrawLine (g.BlackPen, boundsHF.Right, boundsHF.Top, boundsHF.Right, boundsHF.Bottom);
+            g.DrawLine(g.BlackPen, boundsHF.Right, boundsHF.Top, boundsHF.Right, boundsHF.Bottom);
         }
 
         if (BottomBorder)
         {
-            g.DrawLine (g.BlackPen, boundsHF.Left, boundsHF.Bottom, boundsHF.Right, boundsHF.Bottom);
+            g.DrawLine(g.BlackPen, boundsHF.Left, boundsHF.Bottom, boundsHF.Right, boundsHF.Bottom);
         }
 
-        Log.Debug ($"{GetType ().Name}: Expanding Macros - {Text}");
-        var macros = new Macros (_svm) { Page = sheetNum };
-        string[] parts = macros.ReplaceMacros (Text ?? string.Empty).Split ('\t', '|');
+        Log.Debug($"{GetType().Name}: Expanding Macros - {Text}");
+        var macros = new Macros(_svm) { Page = sheetNum };
+        string[] parts = macros.ReplaceMacros(Text ?? string.Empty).Split('\t', '|');
 
         // Left\tCenter\tRight
         if (parts.Length == 0)
@@ -240,7 +240,7 @@ public abstract class HeaderFooterViewModel : ViewModelBase, IDisposable
             return;
         }
 
-        using IGraphicsFont tempFont = CreateTempFont (g);
+        using IGraphicsFont tempFont = CreateTempFont(g);
 
         var fmt = new GraphicsStringFormat
         {
@@ -251,36 +251,36 @@ public abstract class HeaderFooterViewModel : ViewModelBase, IDisposable
                           GraphicsStringFormatFlags.NoClip
         };
 
-        fmt.LineAlignment = IsAlignTop () ? GraphicsTextAlignment.Near : GraphicsTextAlignment.Far;
+        fmt.LineAlignment = IsAlignTop() ? GraphicsTextAlignment.Near : GraphicsTextAlignment.Far;
 
         // Center goes first - it has priority - ensure it gets drawn completely where
         // Left & Right can be trimmed
-        var sizeCenter = new GraphicsSizeF (0, 0);
-        var boundsRect = new GraphicsRectF (boundsHF.X, boundsHF.Y, boundsHF.Width, boundsHF.Height);
+        var sizeCenter = new GraphicsSizeF(0, 0);
+        var boundsRect = new GraphicsRectF(boundsHF.X, boundsHF.Y, boundsHF.Width, boundsHF.Height);
 
         if (parts.Length > 1)
         {
             fmt.Alignment = GraphicsTextAlignment.Center;
-            sizeCenter = g.MeasureString (parts[1], tempFont, (int)boundsHF.Width, fmt);
+            sizeCenter = g.MeasureString(parts[1], tempFont, (int)boundsHF.Width, fmt);
             // g.DrawRectangle(Pens.Purple, boundsHF.Left, boundsHF.Top, boundsHF.Width, boundsHF.Height);
-            g.DrawString (parts[1], tempFont, g.BlackBrush, boundsRect, fmt);
+            g.DrawString(parts[1], tempFont, g.BlackBrush, boundsRect, fmt);
         }
 
         // Left
         // Remove the space taken up by the center from the bounds
         float textCenterBounds = (boundsHF.Width - sizeCenter.Width) / 2;
 
-        var boundsLeft = new RectangleF (boundsHF.X, boundsHF.Y, textCenterBounds, boundsHF.Height);
-        GraphicsSizeF sizeLeft = g.MeasureString (parts[0], tempFont, (int)textCenterBounds, fmt);
+        var boundsLeft = new RectangleF(boundsHF.X, boundsHF.Y, textCenterBounds, boundsHF.Height);
+        GraphicsSizeF sizeLeft = g.MeasureString(parts[0], tempFont, (int)textCenterBounds, fmt);
 
         fmt.Alignment = GraphicsTextAlignment.Near;
         fmt.Trimming = GraphicsStringTrimming.None;
         //g.DrawRectangle(Pens.Orange, boundsLeft.X, boundsLeft.Y, boundsLeft.Width, boundsLeft.Height);
-        g.DrawString (parts[0], tempFont, g.BlackBrush,
-            new GraphicsRectF (boundsLeft.X, boundsLeft.Y, boundsLeft.Width, boundsLeft.Height), fmt);
+        g.DrawString(parts[0], tempFont, g.BlackBrush,
+            new GraphicsRectF(boundsLeft.X, boundsLeft.Y, boundsLeft.Width, boundsLeft.Height), fmt);
 
         //Right
-        var boundsRight = new RectangleF (boundsHF.X + (boundsHF.Width - textCenterBounds), boundsHF.Y,
+        var boundsRight = new RectangleF(boundsHF.X + (boundsHF.Width - textCenterBounds), boundsHF.Y,
             textCenterBounds,
             boundsHF.Height);
         if (parts.Length > 2)
@@ -288,8 +288,8 @@ public abstract class HeaderFooterViewModel : ViewModelBase, IDisposable
             fmt.Alignment = GraphicsTextAlignment.Far;
             fmt.Trimming = GraphicsStringTrimming.None;
             //g.DrawRectangle(Pens.Blue, boundsRight.X, boundsRight.Y, boundsRight.Width, boundsRight.Height);
-            g.DrawString (parts[2], tempFont, g.BlackBrush,
-                new GraphicsRectF (boundsRight.X, boundsRight.Y, boundsRight.Width, boundsRight.Height), fmt);
+            g.DrawString(parts[2], tempFont, g.BlackBrush,
+                new GraphicsRectF(boundsRight.X, boundsRight.Y, boundsRight.Width, boundsRight.Height), fmt);
         }
     }
 
@@ -298,17 +298,17 @@ public abstract class HeaderFooterViewModel : ViewModelBase, IDisposable
     /// </summary>
     /// <param name="g"></param>
     /// <returns></returns>
-    private IGraphicsFont CreateTempFont (IGraphicsContext g)
+    private IGraphicsFont CreateTempFont(IGraphicsContext g)
     {
         if (Font == null)
         {
-            return g.CreateFont ("sansserif", 8F, GraphicsFontStyle.Regular, GraphicsFontUnit.Point);
+            return g.CreateFont("sansserif", 8F, GraphicsFontStyle.Regular, GraphicsFontUnit.Point);
         }
 
         IGraphicsFont tempFont = g.IsDisplayUnit
-            ? g.CreateFont (Font.Family, Font.Size, (GraphicsFontStyle)Font.Style,
+            ? g.CreateFont(Font.Family, Font.Size, (GraphicsFontStyle)Font.Style,
                 GraphicsFontUnit.Point)
-            : g.CreateFont (Font.Family, Font.Size / 72F * 96F, (GraphicsFontStyle)Font.Style,
+            : g.CreateFont(Font.Family, Font.Size / 72F * 96F, (GraphicsFontStyle)Font.Style,
                 GraphicsFontUnit.Pixel);
 
         return tempFont;
@@ -318,8 +318,8 @@ public abstract class HeaderFooterViewModel : ViewModelBase, IDisposable
     // if bool is true, reflow. Otherwise just paint
     public event EventHandler<bool>? SettingsChanged;
 
-    protected void OnSettingsChanged (bool reflow)
+    protected void OnSettingsChanged(bool reflow)
     {
-        SettingsChanged?.Invoke (this, reflow);
+        SettingsChanged?.Invoke(this, reflow);
     }
 }

--- a/src/WinPrint.Core/ViewModels/HeaderViewModel.cs
+++ b/src/WinPrint.Core/ViewModels/HeaderViewModel.cs
@@ -6,23 +6,23 @@ using WinPrint.Core.Models;
 
 namespace WinPrint.Core;
 
-public class HeaderViewModel (SheetViewModel? svm, HeaderFooter? hf) : HeaderFooterViewModel (svm, hf)
+public class HeaderViewModel(SheetViewModel? svm, HeaderFooter? hf) : HeaderFooterViewModel(svm, hf)
 {
-    internal override RectangleF CalcBounds ()
+    internal override RectangleF CalcBounds()
     {
-        float h = SheetViewModel.GetFontHeight (Font) + VerticalPadding;
+        float h = SheetViewModel.GetFontHeight(Font) + VerticalPadding;
         if (Enabled && _svm is not null)
         {
-            return new RectangleF (_svm.Bounds.Left + _svm.Margins.Left,
+            return new RectangleF(_svm.Bounds.Left + _svm.Margins.Left,
                 _svm.Bounds.Top + _svm.Margins.Top,
                 _svm.Bounds.Width - _svm.Margins.Left - _svm.Margins.Right,
                 h);
         }
 
-        return new RectangleF (0, 0, 0, 0);
+        return new RectangleF(0, 0, 0, 0);
     }
 
-    internal override bool IsAlignTop ()
+    internal override bool IsAlignTop()
     {
         return true;
     }

--- a/src/WinPrint.Core/ViewModels/SheetViewModel.cs
+++ b/src/WinPrint.Core/ViewModels/SheetViewModel.cs
@@ -33,7 +33,7 @@ public class SheetViewModel : ViewModelBase
     private int _cols;
     private RectangleF _contentBounds;
     private ContentTypeEngineBase? _contentEngine;
-    private ContentSettings _contentSettings = new ();
+    private ContentSettings _contentSettings = new();
     private string? _contentType;
     private Encoding? _encoding;
     private string? _file;
@@ -47,7 +47,7 @@ public class SheetViewModel : ViewModelBase
     private bool _loading;
 
     // These properties are all defined by user and sync'd with the Sheet model
-    private PrintMargins _margins = new (0, 0, 0, 0);
+    private PrintMargins _margins = new(0, 0, 0, 0);
 
     private int _numPages;
     private int _padding;
@@ -66,61 +66,61 @@ public class SheetViewModel : ViewModelBase
     public PrintMargins Margins
     {
         get => _margins;
-        set => SetField (ref _margins, value);
+        set => SetField(ref _margins, value);
     }
 
     public bool Landscape
     {
         get => _landscape;
-        set => SetField (ref _landscape, value);
+        set => SetField(ref _landscape, value);
     }
 
     public Font? DiagnosticRulesFont
     {
         get => _rulesFont;
-        set => SetField (ref _rulesFont, value);
+        set => SetField(ref _rulesFont, value);
     }
 
     public HeaderViewModel Header
     {
         get => _headerVM;
-        set => SetField (ref _headerVM, value);
+        set => SetField(ref _headerVM, value);
     }
 
     public FooterViewModel Footer
     {
         get => _footerVM;
-        set => SetField (ref _footerVM, value);
+        set => SetField(ref _footerVM, value);
     }
 
     public int Rows
     {
         get => _rows;
-        set => SetField (ref _rows, value);
+        set => SetField(ref _rows, value);
     }
 
     public int Columns
     {
         get => _cols;
-        set => SetField (ref _cols, value);
+        set => SetField(ref _cols, value);
     }
 
     public int Padding
     {
         get => _padding;
-        set => SetField (ref _padding, value);
+        set => SetField(ref _padding, value);
     }
 
     public bool PageSeparator
     {
         get => _pageSeparator;
-        set => SetField (ref _pageSeparator, value);
+        set => SetField(ref _pageSeparator, value);
     }
 
     public ContentSettings ContentSettings
     {
         get => _contentSettings;
-        set => SetField (ref _contentSettings, value);
+        set => SetField(ref _contentSettings, value);
     }
 
     /// <summary>
@@ -129,7 +129,7 @@ public class SheetViewModel : ViewModelBase
     public string File
     {
         get => _file ?? string.Empty;
-        set => SetField (ref _file, value);
+        set => SetField(ref _file, value);
     }
 
     /// <summary>
@@ -138,7 +138,7 @@ public class SheetViewModel : ViewModelBase
     public string Title
     {
         get => _title ?? string.Empty;
-        set => SetField (ref _title, value);
+        set => SetField(ref _title, value);
     }
 
     /// <summary>
@@ -147,7 +147,7 @@ public class SheetViewModel : ViewModelBase
     public string? ContentType
     {
         get => _contentType;
-        set => SetField (ref _contentType, value);
+        set => SetField(ref _contentType, value);
     }
 
     /// <summary>
@@ -156,7 +156,7 @@ public class SheetViewModel : ViewModelBase
     public string Language
     {
         get => _language ?? string.Empty;
-        set => SetField (ref _language, value);
+        set => SetField(ref _language, value);
     }
 
     /// <summary>
@@ -165,7 +165,7 @@ public class SheetViewModel : ViewModelBase
     public Encoding? Encoding
     {
         get => _encoding;
-        set => SetField (ref _encoding, value);
+        set => SetField(ref _encoding, value);
     }
 
     /// <summary>
@@ -180,14 +180,14 @@ public class SheetViewModel : ViewModelBase
                 return 0;
             }
 
-            return (int)Math.Ceiling ((double)_numPages / (Rows * Columns));
+            return (int)Math.Ceiling((double)_numPages / (Rows * Columns));
         }
     }
 
     public ContentTypeEngineBase? ContentEngine
     {
         get => _contentEngine;
-        set => SetField (ref _contentEngine, value);
+        set => SetField(ref _contentEngine, value);
     }
 
     // These properties are all either calculated or dependent on printer settings
@@ -241,10 +241,10 @@ public class SheetViewModel : ViewModelBase
         {
             if (value != _loading)
             {
-                OnLoaded (value);
+                OnLoaded(value);
             }
 
-            SetField (ref _loading, value);
+            SetField(ref _loading, value);
         }
     }
 
@@ -258,10 +258,10 @@ public class SheetViewModel : ViewModelBase
         {
             if (value != _ready)
             {
-                OnReadyChanged (value);
+                OnReadyChanged(value);
             }
 
-            SetField (ref _ready, value);
+            SetField(ref _ready, value);
         }
     }
 
@@ -270,9 +270,9 @@ public class SheetViewModel : ViewModelBase
     /// </summary>
     public event EventHandler<bool>? Loaded;
 
-    protected void OnLoaded (bool l)
+    protected void OnLoaded(bool l)
     {
-        Loaded?.Invoke (this, l);
+        Loaded?.Invoke(this, l);
     }
 
     /// <summary>
@@ -280,9 +280,9 @@ public class SheetViewModel : ViewModelBase
     /// </summary>
     public event EventHandler<bool>? ReadyChanged;
 
-    protected void OnReadyChanged (bool r)
+    protected void OnReadyChanged(bool r)
     {
-        ReadyChanged?.Invoke (this, r);
+        ReadyChanged?.Invoke(this, r);
     }
 
     /// <summary>
@@ -290,43 +290,43 @@ public class SheetViewModel : ViewModelBase
     /// </summary>
     public event EventHandler? PageSettingsSet;
 
-    protected void OnPageSettingsSet ()
+    protected void OnPageSettingsSet()
     {
-        PageSettingsSet?.Invoke (this, EventArgs.Empty);
+        PageSettingsSet?.Invoke(this, EventArgs.Empty);
     }
 
     public event EventHandler<string>? ReflowProgress;
 
-    protected void OnReflowProgress (string msg)
+    protected void OnReflowProgress(string msg)
     {
-        ReflowProgress?.Invoke (this, msg);
+        ReflowProgress?.Invoke(this, msg);
     }
 
     // if bool is true, reflow. Otherwise just paint
     public event EventHandler<SheetViewModelSettingsChangedEvent>? SettingsChanged;
 
-    protected void OnSettingsChanged (bool reflow, string propertyName)
+    protected void OnSettingsChanged(bool reflow, string propertyName)
     {
-        LogService.TraceMessage ();
+        LogService.TraceMessage();
 
-        SettingsChanged?.Invoke (this,
+        SettingsChanged?.Invoke(this,
             new SheetViewModelSettingsChangedEvent { Reflow = reflow, PropertyName = propertyName });
     }
 
-    protected override void OnPropertyChanged ([CallerMemberName] string? propertyName = null)
+    protected override void OnPropertyChanged([CallerMemberName] string? propertyName = null)
     {
-        base.OnPropertyChanged (propertyName);
+        base.OnPropertyChanged(propertyName);
     }
 
     /// <summary>
     ///     Call this to reset the SVM before loading a new file (enables painting print preview status cleanly)
     /// </summary>
-    public void Reset ()
+    public void Reset()
     {
         Ready = false;
         if (ContentEngine != null)
         {
-            ContentEngine.PropertyChanged -= OnContentEnginePropertyChanged ();
+            ContentEngine.PropertyChanged -= OnContentEnginePropertyChanged();
             ContentEngine = null;
         }
 
@@ -337,53 +337,53 @@ public class SheetViewModel : ViewModelBase
     ///     Call SetSheet when the Sheet has changed.
     /// </summary>
     /// <param name="newSheet">new Sheet definition to use</param>
-    public void SetSheet (SheetSettings? newSheet)
+    public void SetSheet(SheetSettings? newSheet)
     {
         if (newSheet == null)
         {
             return;
         }
 
-        LogService.TraceMessage ($"{newSheet.Name}");
+        LogService.TraceMessage($"{newSheet.Name}");
         // TODO: Add font info 
         // TODO: Add header footer details (borders etc...). 
-        ServiceLocator.Current.TelemetryService.TrackEvent ("Set Sheet Settings", newSheet.GetTelemetryDictionary ());
+        ServiceLocator.Current.TelemetryService.TrackEvent("Set Sheet Settings", newSheet.GetTelemetryDictionary());
 
         if (newSheet is null)
         {
-            throw new ArgumentNullException (nameof (newSheet));
+            throw new ArgumentNullException(nameof(newSheet));
         }
 
-        Reset ();
+        Reset();
 
         if (_sheet != null)
         {
-            _sheet.PropertyChanged -= OnSheetPropertyChanged ();
+            _sheet.PropertyChanged -= OnSheetPropertyChanged();
         }
 
         _sheet = newSheet;
         Landscape = newSheet.Landscape;
-        DiagnosticRulesFont = (Font)ModelLocator.Current!.Settings.DiagnosticRulesFont.Clone ();
+        DiagnosticRulesFont = (Font)ModelLocator.Current!.Settings.DiagnosticRulesFont.Clone();
         Rows = newSheet.Rows;
         Columns = newSheet.Columns;
         Padding = newSheet.Padding;
         PageSeparator = newSheet.PageSeparator;
-        Margins = (PrintMargins)newSheet.Margins.Clone ();
+        Margins = (PrintMargins)newSheet.Margins.Clone();
 
         if (_contentSettings != null)
         {
-            _contentSettings.PropertyChanged -= OnContentSettingsPropertyChanged ();
+            _contentSettings.PropertyChanged -= OnContentSettingsPropertyChanged();
         }
 
-        ContentSettings = newSheet.ContentSettings ?? new ContentSettings ();
-        ContentSettings.PropertyChanged += OnContentSettingsPropertyChanged ();
+        ContentSettings = newSheet.ContentSettings ?? new ContentSettings();
+        ContentSettings.PropertyChanged += OnContentSettingsPropertyChanged();
 
         if (_headerVM != null)
         {
             _headerVM.SettingsChanged -= OnHeaderVmOnSettingsChanged;
         }
 
-        _headerVM = new HeaderViewModel (this, newSheet.Header);
+        _headerVM = new HeaderViewModel(this, newSheet.Header);
 
         _headerVM.SettingsChanged += OnHeaderVmOnSettingsChanged;
         if (_footerVM != null)
@@ -391,23 +391,23 @@ public class SheetViewModel : ViewModelBase
             _footerVM.SettingsChanged -= OnFooterVmOnSettingsChanged;
         }
 
-        _footerVM = new FooterViewModel (this, newSheet.Footer);
+        _footerVM = new FooterViewModel(this, newSheet.Footer);
 
         _footerVM.SettingsChanged += OnFooterVmOnSettingsChanged;
 
         // Subscribe to all settings properties
-        newSheet.PropertyChanged += OnSheetPropertyChanged ();
+        newSheet.PropertyChanged += OnSheetPropertyChanged();
 
         return;
 
-        void OnHeaderVmOnSettingsChanged (object? s, bool reflow)
+        void OnHeaderVmOnSettingsChanged(object? s, bool reflow)
         {
-            OnSettingsChanged (reflow, "Header");
+            OnSettingsChanged(reflow, "Header");
         }
 
-        void OnFooterVmOnSettingsChanged (object? s, bool reflow)
+        void OnFooterVmOnSettingsChanged(object? s, bool reflow)
         {
-            OnSettingsChanged (reflow, "Footer");
+            OnSettingsChanged(reflow, "Footer");
         }
     }
 
@@ -417,18 +417,18 @@ public class SheetViewModel : ViewModelBase
     /// <param name="filePath">Fully qualified path to File to load.</param>
     /// <param name="contentType">If null or empty, the file extension will be used to determine content type engine.</param>
     /// <returns>True if content type engine was initialized. False otherwise.</returns>
-    public async Task<bool> LoadFileAsync (string filePath, string? contentType = null)
+    public async Task<bool> LoadFileAsync(string filePath, string? contentType = null)
     {
-        LogService.TraceMessage ($"{filePath} - {contentType}");
+        LogService.TraceMessage($"{filePath} - {contentType}");
         File = filePath ?? "";
 
         //filePath = Path.GetFullPath(filePath);
         //Log.Debug("full path = {path}", filePath);
 
-        if (string.IsNullOrEmpty (contentType))
+        if (string.IsNullOrEmpty(contentType))
         {
             // Use file extension to determine contentType
-            contentType = ContentTypeEngineBase.GetContentType (File);
+            contentType = ContentTypeEngineBase.GetContentType(File);
         }
 
 
@@ -436,50 +436,50 @@ public class SheetViewModel : ViewModelBase
         // print preview during startup.
         string document = "";
         Encoding = Encoding.UTF8;
-        if (string.IsNullOrEmpty (File))
+        if (string.IsNullOrEmpty(File))
         {
-            return await LoadStringAsync (document, contentType).ConfigureAwait (true);
+            return await LoadStringAsync(document, contentType).ConfigureAwait(true);
         }
         // LoadAsync will throw FNFE if file was not found. Loading will remain true in this case...
 
-        using FileStream fileStream = System.IO.File.OpenRead (File);
-        DetectionDetail? detected = CharsetDetector.DetectFromStream (fileStream).Detected;
+        using FileStream fileStream = System.IO.File.OpenRead(File);
+        DetectionDetail? detected = CharsetDetector.DetectFromStream(fileStream).Detected;
         if (detected != null)
         {
-            Log.Debug ("File encoding detected: {encoding}", detected);
+            Log.Debug("File encoding detected: {encoding}", detected);
             Encoding = detected.Encoding;
         }
         else
         {
             // Not detected. We know CharsetDetector gets confused on ANSI encoded files (rightfully so).
             // Does this file have ESC[ sequences?
-            if (fileStream.Length != 0 && !StreamHasAnsiEsc (fileStream))
+            if (fileStream.Length != 0 && !StreamHasAnsiEsc(fileStream))
             {
-                throw new InvalidOperationException (
-                    $"This file is not supported by winprint; could not determine the file encoding of '{Path.GetFullPath (File)}'.");
+                throw new InvalidOperationException(
+                    $"This file is not supported by winprint; could not determine the file encoding of '{Path.GetFullPath(File)}'.");
             }
 
-            Log.Debug ("File encoding NOT detected, looks ANSI; using default: {encoding}", Encoding);
+            Log.Debug("File encoding NOT detected, looks ANSI; using default: {encoding}", Encoding);
         }
 
         fileStream.Position = 0;
-        using var streamReader = new StreamReader (fileStream, Encoding);
-        document = await streamReader.ReadToEndAsync ().ConfigureAwait (true);
+        using var streamReader = new StreamReader(fileStream, Encoding);
+        document = await streamReader.ReadToEndAsync().ConfigureAwait(true);
 
-        return await LoadStringAsync (document, contentType).ConfigureAwait (true);
+        return await LoadStringAsync(document, contentType).ConfigureAwait(true);
     }
 
-    private bool StreamHasAnsiEsc (Stream stream)
+    private bool StreamHasAnsiEsc(Stream stream)
     {
         bool containsStr = false;
         byte[] streamBytes = new byte[stream.Length];
         stream.Position = 0;
-        stream.ReadExactly (streamBytes);
-        string stringOfStream = Encoding.UTF8.GetString (streamBytes);
+        stream.ReadExactly(streamBytes);
+        string stringOfStream = Encoding.UTF8.GetString(streamBytes);
         // Look for the Default foreground color esc sequence
         // Note, just looking for the ESC[ sequence is not enough as PDF files
         // include.
-        if (stringOfStream.Contains ("\u001B[39;00m"))
+        if (stringOfStream.Contains("\u001B[39;00m"))
         {
             containsStr = true;
         }
@@ -493,64 +493,64 @@ public class SheetViewModel : ViewModelBase
     /// <param name="document">Document contents to load.</param>
     /// <param name="contentType">The content type engine to use.</param>
     /// <returns>True if content type engine was initialized. False otherwise.</returns>
-    public async Task<bool> LoadStringAsync (string document, string? contentType)
+    public async Task<bool> LoadStringAsync(string document, string? contentType)
     {
         bool retval = false;
-        LogService.TraceMessage ();
+        LogService.TraceMessage();
         if (document == null)
         {
             // TODO: Determine what could cause this and what user-friendly message would be
-            throw new ArgumentNullException ("Document can't be null.");
+            throw new ArgumentNullException("Document can't be null.");
         }
 
-        Reset ();
+        Reset();
         Loading = true;
 
         try
         {
-            (ContentEngine, ContentType, Language) = ContentTypeEngineBase.CreateContentTypeEngine (contentType);
+            (ContentEngine, ContentType, Language) = ContentTypeEngineBase.CreateContentTypeEngine(contentType);
             if (ContentEngine is null)
             {
-                throw new InvalidOperationException ($"Content type engine not found for '{contentType}'.");
+                throw new InvalidOperationException($"Content type engine not found for '{contentType}'.");
             }
 
 #if WINDOWS
             if (ContentEngine is TextMateCte textMateCte)
             {
-                textMateCte.Configure (ContentType, Language, File);
+                textMateCte.Configure(ContentType, Language, File);
             }
 #endif
 
             // Content settings in Sheet take precidence over Engine
             if (ContentEngine.ContentSettings is null)
             {
-                ContentEngine.ContentSettings = new ContentSettings ();
+                ContentEngine.ContentSettings = new ContentSettings();
                 // TODO: set some defaults
             }
 
-            ContentEngine.ContentSettings.CopyPropertiesFrom (ContentSettings);
+            ContentEngine.ContentSettings.CopyPropertiesFrom(ContentSettings);
 
-            if (ContentEngine.SupportedContentTypes.Contains ("text/ansi") &&
-                !ContentEngine.SupportedContentTypes.Contains (ContentType))
+            if (ContentEngine.SupportedContentTypes.Contains("text/ansi") &&
+                !ContentEngine.SupportedContentTypes.Contains(ContentType))
             {
                 (bool pygmentsInstalled, string message) =
-                    ServiceLocator.Current.PygmentsConverterService.CheckInstall ();
+                    ServiceLocator.Current.PygmentsConverterService.CheckInstall();
                 if (pygmentsInstalled)
                 {
                     // Convert the document to ANSI using Pygments
                     // TODO: Spin up a thread
-                    Log.Information ("Applying source code formatting.");
+                    Log.Information("Applying source code formatting.");
                     document = await ServiceLocator.Current.PygmentsConverterService
-                        .ConvertAsync (document, ContentEngine.ContentSettings.Style, Language).ConfigureAwait (true);
+                        .ConvertAsync(document, ContentEngine.ContentSettings.Style, Language).ConfigureAwait(true);
                 }
                 else
                 {
-                    Log.Information ("Treating file as plain text.");
+                    Log.Information("Treating file as plain text.");
                 }
             }
 
             ContentEngine.Encoding = Encoding;
-            retval = await ContentEngine.SetDocumentAsync (document).ConfigureAwait (true);
+            retval = await ContentEngine.SetDocumentAsync(document).ConfigureAwait(true);
         }
         catch
         {
@@ -569,12 +569,12 @@ public class SheetViewModel : ViewModelBase
     /// <summary>
     ///     Set the page settings from a cross-platform PrintPageSetup instance.
     /// </summary>
-    public void SetPrinterPageSettings (PrintPageSetup pageSetup)
+    public void SetPrinterPageSettings(PrintPageSetup pageSetup)
     {
-        LogService.TraceMessage ();
+        LogService.TraceMessage();
         if (pageSetup is null)
         {
-            throw new ArgumentNullException (nameof (pageSetup));
+            throw new ArgumentNullException(nameof(pageSetup));
         }
 
         LandscapeAngle = pageSetup.Landscape ? 90 : 0;
@@ -606,41 +606,41 @@ public class SheetViewModel : ViewModelBase
             _paperSize.Height = pageSetup.PaperHeight;
         }
 
-        PrinterResolution = new PrintResolution (pageSetup.DpiX, pageSetup.DpiY);
+        PrinterResolution = new PrintResolution(pageSetup.DpiX, pageSetup.DpiY);
         PrintInColor = true;
 
-        Bounds = new Rectangle (0, 0, _paperSize.Width, _paperSize.Height);
+        Bounds = new Rectangle(0, 0, _paperSize.Width, _paperSize.Height);
 
         // Content bounds represents printable area, minus margins and header/footer.
         if (_sheet is null)
         {
-            throw new InvalidOperationException ("Sheet settings must be set before page settings.");
+            throw new InvalidOperationException("Sheet settings must be set before page settings.");
         }
 
-        _contentBounds.Location = new PointF (_sheet.Margins.Left, _sheet.Margins.Top + _headerVM.Bounds.Height);
+        _contentBounds.Location = new PointF(_sheet.Margins.Left, _sheet.Margins.Top + _headerVM.Bounds.Height);
         _contentBounds.Width = Bounds.Width - _sheet.Margins.Left - _sheet.Margins.Right;
         _contentBounds.Height = Bounds.Height - _sheet.Margins.Top - _sheet.Margins.Bottom - _headerVM.Bounds.Height -
                                 _footerVM.Bounds.Height;
         if (ContentEngine is null)
         {
-            LogService.TraceMessage ("SheetViewModel.ReflowAsync - Content is null");
+            LogService.TraceMessage("SheetViewModel.ReflowAsync - Content is null");
         }
         else
         {
-            ContentEngine.PageSize = new SizeF (GetPageWidth (), GetPageHeight ());
+            ContentEngine.PageSize = new SizeF(GetPageWidth(), GetPageHeight());
         }
 
-        Log.Debug ("Printer Resolution: {w} x {h}DPI", PrinterResolution.X, PrinterResolution.Y);
-        Log.Debug ("Paper Size: {w} x {h}\"", PaperSize.Width / 100F, PaperSize.Height / 100F);
-        Log.Debug ("Bounds: {left}\", {top}\", {right}\", {bottom}\" ({w}x{h}\")",
+        Log.Debug("Printer Resolution: {w} x {h}DPI", PrinterResolution.X, PrinterResolution.Y);
+        Log.Debug("Paper Size: {w} x {h}\"", PaperSize.Width / 100F, PaperSize.Height / 100F);
+        Log.Debug("Bounds: {left}\", {top}\", {right}\", {bottom}\" ({w}x{h}\")",
             Bounds.Left / 100F, Bounds.Top / 100F, Bounds.Right / 100F, Bounds.Bottom / 100F, Bounds.Width / 100F,
             Bounds.Height / 100F);
-        Log.Debug ("Content Bounds: {left}\", {top}\", {right}\", {bottom}\" ({w} x {h}\")",
+        Log.Debug("Content Bounds: {left}\", {top}\", {right}\", {bottom}\" ({w} x {h}\")",
             ContentBounds.Left / 100F, ContentBounds.Top / 100F, ContentBounds.Right / 100F,
             ContentBounds.Bottom / 100F, ContentBounds.Width / 100F, ContentBounds.Height / 100F);
-        Log.Debug ("Page Size: {w} x {h}\"", GetPageWidth () / 100F, GetPageHeight () / 100F);
+        Log.Debug("Page Size: {w} x {h}\"", GetPageWidth() / 100F, GetPageHeight() / 100F);
 
-        OnPageSettingsSet ();
+        OnPageSettingsSet();
     }
 
 #if WINDOWS
@@ -651,19 +651,19 @@ public class SheetViewModel : ViewModelBase
     /// </summary>
     /// <param name="pageSettings"></param>
     /// <returns></returns>
-    public void SetPrinterPageSettings (PageSettings pageSettings)
+    public void SetPrinterPageSettings(PageSettings pageSettings)
     {
-        LogService.TraceMessage ();
+        LogService.TraceMessage();
         if (pageSettings is null)
         {
-            throw new ArgumentNullException (nameof (pageSettings));
+            throw new ArgumentNullException(nameof(pageSettings));
         }
 
         // On Linux, PageSettings.Bounds is determined from PageSettings.Margins. 
         // On Windows, it has no effect. Regardelss, here we set Bounds to 0 to work around this.
-        if (RuntimeInformation.IsOSPlatform (OSPlatform.Linux))
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            pageSettings.Margins = new Margins (0, 0, 0, 0);
+            pageSettings.Margins = new Margins(0, 0, 0, 0);
         }
 
         // The following elements of PageSettings are dependent
@@ -722,7 +722,7 @@ public class SheetViewModel : ViewModelBase
             _paperSize.Height = pageSettings.PaperSize.Height;
         }
 
-        PrinterResolution = new PrintResolution (pageSettings.PrinterResolution.X, pageSettings.PrinterResolution.Y);
+        PrinterResolution = new PrintResolution(pageSettings.PrinterResolution.X, pageSettings.PrinterResolution.Y);
 
         // TODO: Do something if printer is set to color or bw?
         PrintInColor = pageSettings.Color;
@@ -735,7 +735,7 @@ public class SheetViewModel : ViewModelBase
         // 
         // BUGBUG: On Linux, PageSettings.PrintableArea is all 0s. 
         // BUGBUG: On Linux, not seeing HardMargins > 0 ever (e.g. HP laser should have 0.16". No idea how to fix this.
-        if (RuntimeInformation.IsOSPlatform (OSPlatform.Linux))
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
             _printableArea.X = Bounds.X - HardMarginX;
             _printableArea.Y = Bounds.Y - HardMarginY;
@@ -746,38 +746,38 @@ public class SheetViewModel : ViewModelBase
         // Content bounds represents printable area, minus margins and header/footer.
         if (_sheet is null)
         {
-            throw new InvalidOperationException ("Sheet settings must be set before page settings.");
+            throw new InvalidOperationException("Sheet settings must be set before page settings.");
         }
 
-        _contentBounds.Location = new PointF (_sheet.Margins.Left, _sheet.Margins.Top + _headerVM.Bounds.Height);
+        _contentBounds.Location = new PointF(_sheet.Margins.Left, _sheet.Margins.Top + _headerVM.Bounds.Height);
         _contentBounds.Width = Bounds.Width - _sheet.Margins.Left - _sheet.Margins.Right;
         _contentBounds.Height = Bounds.Height - _sheet.Margins.Top - _sheet.Margins.Bottom - _headerVM.Bounds.Height -
                                 _footerVM.Bounds.Height;
         if (ContentEngine is null)
         {
-            LogService.TraceMessage ("SheetViewModel.ReflowAsync - Content is null");
+            LogService.TraceMessage("SheetViewModel.ReflowAsync - Content is null");
         }
         else
         {
             // TODO: Figure out a better way for the content engine to get page size.
-            ContentEngine.PageSize = new SizeF (GetPageWidth (), GetPageHeight ());
+            ContentEngine.PageSize = new SizeF(GetPageWidth(), GetPageHeight());
         }
 
-        Log.Debug ("Printer Resolution: {w} x {h}DPI", PrinterResolution.X, PrinterResolution.Y);
-        Log.Debug ("Paper Size: {w} x {h}\"", PaperSize.Width / 100F, PaperSize.Height / 100F);
-        Log.Debug ("Hard Margins: {w} x {h}\"", HardMarginX / 100F, HardMarginY / 100F);
-        Log.Debug ("Printable Area: {left}\", {top}\", {right}\", {bottom}\" ({w} x {h}\")",
+        Log.Debug("Printer Resolution: {w} x {h}DPI", PrinterResolution.X, PrinterResolution.Y);
+        Log.Debug("Paper Size: {w} x {h}\"", PaperSize.Width / 100F, PaperSize.Height / 100F);
+        Log.Debug("Hard Margins: {w} x {h}\"", HardMarginX / 100F, HardMarginY / 100F);
+        Log.Debug("Printable Area: {left}\", {top}\", {right}\", {bottom}\" ({w} x {h}\")",
             _printableArea.Left / 100F, _printableArea.Top / 100F, _printableArea.Right / 100,
             _printableArea.Bottom / 100, _printableArea.Width / 100, _printableArea.Height / 100);
-        Log.Debug ("Bounds: {left}\", {top}\", {right}\", {bottom}\" ({w}x{h}\")",
+        Log.Debug("Bounds: {left}\", {top}\", {right}\", {bottom}\" ({w}x{h}\")",
             Bounds.Left / 100F, Bounds.Top / 100F, Bounds.Right / 100F, Bounds.Bottom / 100F, Bounds.Width / 100F,
             Bounds.Height / 100F);
-        Log.Debug ("Content Bounds: {left}\", {top}\", {right}\", {bottom}\" ({w} x {h}\")",
+        Log.Debug("Content Bounds: {left}\", {top}\", {right}\", {bottom}\" ({w} x {h}\")",
             ContentBounds.Left / 100F, ContentBounds.Top / 100F, ContentBounds.Right / 100F,
             ContentBounds.Bottom / 100F, ContentBounds.Width / 100F, ContentBounds.Height / 100F);
-        Log.Debug ("Page Size: {w} x {h}\"", GetPageWidth () / 100F, GetPageHeight () / 100F);
+        Log.Debug("Page Size: {w} x {h}\"", GetPageWidth() / 100F, GetPageHeight() / 100F);
 
-        OnPageSettingsSet ();
+        OnPageSettingsSet();
     }
 #endif
 
@@ -785,12 +785,12 @@ public class SheetViewModel : ViewModelBase
     ///     Reflows the sheet based on page settings. Caches those settings
     ///     for performance (and for platform independence).
     /// </summary>
-    public async Task ReflowAsync ()
+    public async Task ReflowAsync()
     {
-        LogService.TraceMessage ();
+        LogService.TraceMessage();
         if (Loading)
         {
-            Log.Debug ("SheetViewModel.ReflowAsync - Still loading; can't reflow, returning");
+            Log.Debug("SheetViewModel.ReflowAsync - Still loading; can't reflow, returning");
             return;
         }
 
@@ -798,28 +798,28 @@ public class SheetViewModel : ViewModelBase
 
         if (ContentEngine is null)
         {
-            LogService.TraceMessage ("SheetViewModel.ReflowAsync - ContentEngine is null");
+            LogService.TraceMessage("SheetViewModel.ReflowAsync - ContentEngine is null");
             return;
         }
 
-        _numPages = await ContentEngine.RenderAsync (PrinterResolution, ReflowProgress).ConfigureAwait (false);
+        _numPages = await ContentEngine.RenderAsync(PrinterResolution, ReflowProgress).ConfigureAwait(false);
 
-        CheckPrintOutsideHardMargins ();
-        Log.Debug ("SheetView Model is ready. {n} pages {w}x{h}\"", _numPages, Bounds.Width / 100F,
+        CheckPrintOutsideHardMargins();
+        Log.Debug("SheetView Model is ready. {n} pages {w}x{h}\"", _numPages, Bounds.Width / 100F,
             Bounds.Height / 100F);
         Ready = true;
     }
 
-    public bool CheckPrintOutsideHardMargins ()
+    public bool CheckPrintOutsideHardMargins()
     {
-        int leftMax = (int)Math.Round (_printableArea.X);
-        int topMax = (int)Math.Round (_printableArea.Top);
-        int rightMax = (int)Math.Round (_bounds.Width - _printableArea.Right);
-        int bottomMax = (int)Math.Round (_bounds.Height - _printableArea.Bottom);
+        int leftMax = (int)Math.Round(_printableArea.X);
+        int topMax = (int)Math.Round(_printableArea.Top);
+        int rightMax = (int)Math.Round(_bounds.Width - _printableArea.Right);
+        int bottomMax = (int)Math.Round(_bounds.Height - _printableArea.Bottom);
 
         if (Margins.Left < leftMax || Margins.Top < topMax || Margins.Right < rightMax || Margins.Bottom < bottomMax)
         {
-            Log.Warning (
+            Log.Warning(
                 $"Margins are set outside of printable area - Maximum values: Left: {leftMax / 100F}\", Right: {rightMax / 100F}\", Top: {topMax / 100F}\", Bottom: {bottomMax / 100F}\"");
             return false;
         }
@@ -827,28 +827,28 @@ public class SheetViewModel : ViewModelBase
         return true;
     }
 
-    public SheetSettings FindSheet (string sheetName, out string sheetID)
+    public SheetSettings FindSheet(string sheetName, out string sheetID)
     {
         SheetSettings? sheet = null;
         if (ModelLocator.Current.Settings == null)
         {
-            throw new InvalidOperationException ("Find Sheet failed. Settings are invalid.");
+            throw new InvalidOperationException("Find Sheet failed. Settings are invalid.");
         }
 
-        sheetID = ModelLocator.Current.Settings.DefaultSheet.ToString ();
-        if (!string.IsNullOrEmpty (sheetName) &&
-            !sheetName.Equals ("default", StringComparison.InvariantCultureIgnoreCase))
+        sheetID = ModelLocator.Current.Settings.DefaultSheet.ToString();
+        if (!string.IsNullOrEmpty(sheetName) &&
+            !sheetName.Equals("default", StringComparison.InvariantCultureIgnoreCase))
         {
-            if (!ModelLocator.Current.Settings.Sheets.TryGetValue (sheetName, out sheet))
+            if (!ModelLocator.Current.Settings.Sheets.TryGetValue(sheetName, out sheet))
             {
                 // Wasn't a GUID or isn't valid
                 KeyValuePair<string, SheetSettings> s = ModelLocator.Current.Settings.Sheets
-                    .Where (s => s.Value.Name.Equals (sheetName, StringComparison.InvariantCultureIgnoreCase))
-                    .FirstOrDefault ();
+                    .Where(s => s.Value.Name.Equals(sheetName, StringComparison.InvariantCultureIgnoreCase))
+                    .FirstOrDefault();
 
                 if (s.Value is null)
                 {
-                    throw new InvalidOperationException ($"Sheet definiton not found ({sheetName}).");
+                    throw new InvalidOperationException($"Sheet definiton not found ({sheetName}).");
                 }
 
                 sheetID = s.Key;
@@ -857,18 +857,18 @@ public class SheetViewModel : ViewModelBase
         }
         else
         {
-            sheet = ModelLocator.Current.Settings.Sheets.GetValueOrDefault (sheetID);
+            sheet = ModelLocator.Current.Settings.Sheets.GetValueOrDefault(sheetID);
         }
 
-        return sheet ?? throw new InvalidOperationException ($"Sheet definiton not found ({sheetName}).");
+        return sheet ?? throw new InvalidOperationException($"Sheet definiton not found ({sheetName}).");
     }
 
-    private PropertyChangedEventHandler OnSheetPropertyChanged ()
+    private PropertyChangedEventHandler OnSheetPropertyChanged()
     {
         return (s, e) =>
         {
             bool reflow = false;
-            LogService.TraceMessage ($"sheet.PropertyChanged: {e.PropertyName}");
+            LogService.TraceMessage($"sheet.PropertyChanged: {e.PropertyName}");
             switch (e.PropertyName)
             {
                 case "Landscape":
@@ -905,19 +905,19 @@ public class SheetViewModel : ViewModelBase
                     break;
 
                 default:
-                    throw new InvalidOperationException ($"Property change not handled: {e.PropertyName}");
+                    throw new InvalidOperationException($"Property change not handled: {e.PropertyName}");
             }
 
-            OnSettingsChanged (reflow, e.PropertyName);
+            OnSettingsChanged(reflow, e.PropertyName);
         };
     }
 
-    private PropertyChangedEventHandler OnContentSettingsPropertyChanged ()
+    private PropertyChangedEventHandler OnContentSettingsPropertyChanged()
     {
         return (s, e) =>
         {
             bool reflow = false;
-            LogService.TraceMessage ($"{e.PropertyName}");
+            LogService.TraceMessage($"{e.PropertyName}");
             switch (e.PropertyName)
             {
                 case "Font":
@@ -976,47 +976,36 @@ public class SheetViewModel : ViewModelBase
                     break;
 
                 default:
-                    throw new InvalidOperationException ($"Property change not handled: {e.PropertyName}");
+                    throw new InvalidOperationException($"Property change not handled: {e.PropertyName}");
             }
 
-            OnSettingsChanged (reflow, e.PropertyName);
+            OnSettingsChanged(reflow, e.PropertyName);
         };
     }
 
-    private PropertyChangedEventHandler OnContentEnginePropertyChanged ()
+    private PropertyChangedEventHandler OnContentEnginePropertyChanged()
     {
         return (s, e) =>
         {
             bool reflow = false;
-            LogService.TraceMessage ($"SheetViewModel.PropertyChanged: {e.PropertyName}");
-            switch (e.PropertyName)
+            LogService.TraceMessage($"SheetViewModel.PropertyChanged: {e.PropertyName}");
+            reflow = e.PropertyName switch
             {
-                case "TabSpaces":
-                    reflow = true;
-                    break;
-
-                case "NewPageOnFormFeed":
-                    reflow = true;
-                    break;
-
-                case "ContentSettings":
-                    reflow = true;
-                    break;
-
-                default:
-                    throw new InvalidOperationException ($"Property change not handled: {e.PropertyName}");
-            }
-
+                "TabSpaces" => true,
+                "NewPageOnFormFeed" => true,
+                "ContentSettings" => true,
+                _ => throw new InvalidOperationException($"Property change not handled: {e.PropertyName}"),
+            };
             if (e.PropertyName == "NumPages")
             {
                 return;
             }
 
-            OnSettingsChanged (reflow, e.PropertyName);
+            OnSettingsChanged(reflow, e.PropertyName);
         };
     }
 
-    public static float GetFontHeight (Font? font)
+    public static float GetFontHeight(Font? font)
     {
 #if WINDOWS
         //if (font is null) throw new ArgumentNullException(nameof(font));
@@ -1028,24 +1017,26 @@ public class SheetViewModel : ViewModelBase
         {
             if (font != null)
             {
-                f = new System.Drawing.Font (font.Family, font.Size, (System.Drawing.FontStyle)font.Style, GraphicsUnit.Point);
+                f =
+                    new System.Drawing.Font(font.Family, font.Size, (System.Drawing.FontStyle)font.Style,
+                        GraphicsUnit.Point);
             }
             else
             {
                 f = SystemFonts.DefaultFont;
             }
 
-            h = f.GetHeight (100);
+            h = f.GetHeight(100);
         }
         catch (Exception e)
         {
             // TODO: We shouldn't keep this exception here
-            Log.Error (e, "Failed to create font. {msg} ({font})", e.Message,
+            Log.Error(e, "Failed to create font. {msg} ({font})", e.Message,
                 font is null ? string.Empty : $"{font.Family}, {font.Size}, {font.Style}");
         }
         finally
         {
-            f?.Dispose ();
+            f?.Dispose();
         }
 
         return h;
@@ -1054,51 +1045,51 @@ public class SheetViewModel : ViewModelBase
 #endif
     }
 
-    public int GetPageColumn (int n)
+    public int GetPageColumn(int n)
     {
         return (n - 1) % Columns;
     }
 
-    public int GetPageRow (int n)
+    public int GetPageRow(int n)
     {
         return (n - 1) % (Rows * Columns) / Columns;
     }
 
-    internal float GetXPadding (int n)
+    internal float GetXPadding(int n)
     {
-        return GetPageColumn (n) == 0 ? 0F : _padding / Columns;
+        return GetPageColumn(n) == 0 ? 0F : _padding / Columns;
     }
 
-    internal float GetYPadding (int n)
+    internal float GetYPadding(int n)
     {
-        return GetPageRow (n) == 0 ? 0F : _padding / Rows;
+        return GetPageRow(n) == 0 ? 0F : _padding / Rows;
     }
 
-    public float GetPageX (int n)
+    public float GetPageX(int n)
     {
         //Log.Debug(LogService.GetTraceMsg("{n}. {p}"), n, Padding);
 
-        float f = ContentBounds.Left + GetPageWidth () * GetPageColumn (n);
-        f += Padding * GetPageColumn (n);
+        float f = ContentBounds.Left + GetPageWidth() * GetPageColumn(n);
+        f += Padding * GetPageColumn(n);
         return f;
     }
 
-    public float GetPageY (int n)
+    public float GetPageY(int n)
     {
         //Log.Debug(LogService.GetTraceMsg("{n}. {p}"), n, Padding);
 
-        float f = ContentBounds.Top + GetPageHeight () * GetPageRow (n);
-        f += Padding * GetPageRow (n);
+        float f = ContentBounds.Top + GetPageHeight() * GetPageRow(n);
+        f += Padding * GetPageRow(n);
         return f;
     }
 
     // If Columns == 1 there's no padding. But if Columns > 1 padding applies. Width is width - (padding/columns-1) (10/2 = 5)
-    public float GetPageWidth ()
+    public float GetPageWidth()
     {
         return ContentBounds.Width / Columns - Padding * (Columns - 1) / Columns;
     }
 
-    public float GetPageHeight ()
+    public float GetPageHeight()
     {
         return ContentBounds.Height / Rows - Padding * (Rows - 1) / Rows;
     }
@@ -1109,34 +1100,34 @@ public class SheetViewModel : ViewModelBase
     /// <param name="graphicsContext">Graphics context to render on</param>
     /// <param name="sheetNum">Sheet to print. 1-based.</param>
     /// <param name="isDisplayUnit">True when rendering for print (Display unit); false for preview.</param>
-    public void PrintSheet (IGraphicsContext graphicsContext, int sheetNum, bool isDisplayUnit = false)
+    public void PrintSheet(IGraphicsContext graphicsContext, int sheetNum, bool isDisplayUnit = false)
     {
-        IGraphicsState state = graphicsContext.Save ();
+        IGraphicsState state = graphicsContext.Save();
         if (isDisplayUnit)
         {
-            graphicsContext.TranslateTransform (-_printableArea.Left, -_printableArea.Top);
+            graphicsContext.TranslateTransform(-_printableArea.Left, -_printableArea.Top);
         }
 
-        PaintSheet (graphicsContext, sheetNum);
-        graphicsContext.Restore (state);
+        PaintSheet(graphicsContext, sheetNum);
+        graphicsContext.Restore(state);
     }
 
-    private void PaintSheet (IGraphicsContext g, int sheetNum)
+    private void PaintSheet(IGraphicsContext g, int sheetNum)
     {
-        LogService.TraceMessage ($"{sheetNum}");
+        LogService.TraceMessage($"{sheetNum}");
 
-        _headerVM.Paint (g, sheetNum);
-        _footerVM.Paint (g, sheetNum);
+        _headerVM.Paint(g, sheetNum);
+        _footerVM.Paint(g, sheetNum);
 
         if (Loading)
         {
-            Log.Debug ("SheetViewModel.PaintSheet - Loading; can't paint");
+            Log.Debug("SheetViewModel.PaintSheet - Loading; can't paint");
             return;
         }
 
         if (!Ready)
         {
-            Log.Debug ("SheetViewModel.PaintSheet - Not Ready; can't paint");
+            Log.Debug("SheetViewModel.PaintSheet - Not Ready; can't paint");
             return;
         }
 
@@ -1146,32 +1137,32 @@ public class SheetViewModel : ViewModelBase
 
         for (int pageOnSheet = startPage; pageOnSheet <= endPage; pageOnSheet++)
         {
-            float xPos = GetPageX (pageOnSheet);
-            float yPos = GetPageY (pageOnSheet);
-            float w = GetPageWidth ();
-            float h = GetPageHeight ();
+            float xPos = GetPageX(pageOnSheet);
+            float yPos = GetPageY(pageOnSheet);
+            float w = GetPageWidth();
+            float h = GetPageHeight();
 
-            g.TranslateTransform (xPos, yPos);
+            g.TranslateTransform(xPos, yPos);
 
             if (_pageSeparator)
             {
-                if (Columns > 1 && GetPageColumn (pageOnSheet) < Columns - 1)
+                if (Columns > 1 && GetPageColumn(pageOnSheet) < Columns - 1)
                 {
-                    g.DrawLine (g.BlackPen, w + Padding / 2, Padding / 2, w + Padding / 2, h - Padding);
+                    g.DrawLine(g.BlackPen, w + Padding / 2, Padding / 2, w + Padding / 2, h - Padding);
                 }
 
-                if (Rows > 1 && GetPageRow (pageOnSheet) < Rows - 1)
+                if (Rows > 1 && GetPageRow(pageOnSheet) < Rows - 1)
                 {
-                    g.DrawLine (g.BlackPen, Padding / 2, h + Padding / 2, w - Padding, h + Padding / 2);
+                    g.DrawLine(g.BlackPen, Padding / 2, h + Padding / 2, w - Padding, h + Padding / 2);
                 }
             }
 
             if (ContentEngine != null)
             {
-                ContentEngine.PaintPage (g, pageOnSheet);
+                ContentEngine.PaintPage(g, pageOnSheet);
             }
 
-            g.TranslateTransform (-xPos, -yPos);
+            g.TranslateTransform(-xPos, -yPos);
         }
     }
 
@@ -1181,44 +1172,44 @@ public class SheetViewModel : ViewModelBase
     /// </summary>
     /// <param name="g">Graphics to print on</param>
     /// <param name="sheetNum">Sheet to print. 1-based.</param>
-    public void PrintSheet (Graphics graphics, int sheetNum)
+    public void PrintSheet(Graphics graphics, int sheetNum)
     {
-        var graphicsContext = new SystemDrawingGraphicsContext (graphics);
-        GraphicsState state = graphics.Save ();
+        var graphicsContext = new SystemDrawingGraphicsContext(graphics);
+        GraphicsState state = graphics.Save();
         //Log.Debug(LogService.GetTraceMsg("{n} PageUnit: {pu}"), sheetNum, graphics.PageUnit);
         if (graphics.PageUnit == GraphicsUnit.Display)
         {
             // In print mode, adjust origin to account for hard margins
             // In print mode, 0,0 is top, left - hard margins
-            graphics.TranslateTransform (-_printableArea.Left, -_printableArea.Top);
-            PaintSheet (graphics, graphicsContext, sheetNum);
+            graphics.TranslateTransform(-_printableArea.Left, -_printableArea.Top);
+            PaintSheet(graphics, graphicsContext, sheetNum);
         }
         else
         {
-            PaintSheet (graphics, graphicsContext, sheetNum);
+            PaintSheet(graphics, graphicsContext, sheetNum);
         }
 
-        graphics.Restore (state);
+        graphics.Restore(state);
     }
 
-    private void PaintSheet (Graphics g, IGraphicsContext graphicsContext, int sheetNum)
+    private void PaintSheet(Graphics g, IGraphicsContext graphicsContext, int sheetNum)
     {
-        LogService.TraceMessage ($"{sheetNum}");
+        LogService.TraceMessage($"{sheetNum}");
         // background needs to be filled image scaling to work right
         //g.FillRectangle(Brushes.White, Bounds.X, Bounds.Y, Bounds.Width, Bounds.Height);
 
-        _headerVM.Paint (graphicsContext, sheetNum);
-        _footerVM.Paint (graphicsContext, sheetNum);
+        _headerVM.Paint(graphicsContext, sheetNum);
+        _footerVM.Paint(graphicsContext, sheetNum);
 
         if (Loading)
         {
-            Log.Debug ("SheetViewModel.PaintSheet - Loading; can't paint");
+            Log.Debug("SheetViewModel.PaintSheet - Loading; can't paint");
             return;
         }
 
         if (!Ready)
         {
-            Log.Debug ("SheetViewModel.PaintSheet - Not Ready; can't paint");
+            Log.Debug("SheetViewModel.PaintSheet - Not Ready; can't paint");
             return;
         }
 
@@ -1229,101 +1220,102 @@ public class SheetViewModel : ViewModelBase
 
         for (int pageOnSheet = startPage; pageOnSheet <= endPage; pageOnSheet++)
         {
-            float xPos = GetPageX (pageOnSheet);
-            float yPos = GetPageY (pageOnSheet);
-            float w = GetPageWidth ();
-            float h = GetPageHeight ();
+            float xPos = GetPageX(pageOnSheet);
+            float yPos = GetPageY(pageOnSheet);
+            float w = GetPageWidth();
+            float h = GetPageHeight();
 
             // Move origin to page's x & y
-            g.TranslateTransform (xPos, yPos);
+            g.TranslateTransform(xPos, yPos);
 
             if (ModelLocator.Current.Settings.PrintPageBounds || ModelLocator.Current.Settings.PreviewPageBounds)
             {
-                PaintPageNum (g, pageOnSheet);
+                PaintPageNum(g, pageOnSheet);
             }
 
             if (_pageSeparator)
             {
                 // If there will be a page to the left of this page, draw vert separator
-                if (Columns > 1 && GetPageColumn (pageOnSheet) < Columns - 1)
+                if (Columns > 1 && GetPageColumn(pageOnSheet) < Columns - 1)
                 {
-                    g.DrawLine (Pens.Black, w + Padding / 2, Padding / 2, w + Padding / 2, h - Padding);
+                    g.DrawLine(Pens.Black, w + Padding / 2, Padding / 2, w + Padding / 2, h - Padding);
                 }
 
                 // If there will be a page below this one, draw a horz separator
-                if (Rows > 1 && GetPageRow (pageOnSheet) < Rows - 1)
+                if (Rows > 1 && GetPageRow(pageOnSheet) < Rows - 1)
                 {
-                    g.DrawLine (Pens.Black, Padding / 2, h + Padding / 2, w - Padding, h + Padding / 2);
+                    g.DrawLine(Pens.Black, Padding / 2, h + Padding / 2, w - Padding, h + Padding / 2);
                 }
             }
 
             if (ContentEngine != null)
             {
-                ContentEngine.PaintPage (graphicsContext, pageOnSheet);
+                ContentEngine.PaintPage(graphicsContext, pageOnSheet);
             }
 
             // Translate back
-            g.TranslateTransform (-xPos, -yPos);
+            g.TranslateTransform(-xPos, -yPos);
         }
 
         // If margins are too big, warn by printing a red border
         if (g.PageUnit != GraphicsUnit.Display)
         {
-            using var errorPen = new Pen (Color.Gray) { DashStyle = DashStyle.Dash, Width = 4 };
+            using var errorPen = new Pen(Color.Gray) { DashStyle = DashStyle.Dash, Width = 4 };
 
-            int leftMax = (int)Math.Round (_printableArea.X);
-            int topMax = (int)Math.Round (_printableArea.Top);
-            int rightMax = (int)Math.Round (_bounds.Width - _printableArea.Right);
-            int bottomMax = (int)Math.Round (_bounds.Height - _printableArea.Bottom);
+            int leftMax = (int)Math.Round(_printableArea.X);
+            int topMax = (int)Math.Round(_printableArea.Top);
+            int rightMax = (int)Math.Round(_bounds.Width - _printableArea.Right);
+            int bottomMax = (int)Math.Round(_bounds.Height - _printableArea.Bottom);
 
             if (Margins.Left < leftMax)
             {
-                g.DrawLine (errorPen, _printableArea.X, 0, _printableArea.X, _bounds.Height);
+                g.DrawLine(errorPen, _printableArea.X, 0, _printableArea.X, _bounds.Height);
             }
 
             if (Margins.Top < topMax)
             {
-                g.DrawLine (errorPen, 0, _printableArea.Top, _bounds.Width, _printableArea.Top);
+                g.DrawLine(errorPen, 0, _printableArea.Top, _bounds.Width, _printableArea.Top);
             }
 
             if (Margins.Right < rightMax)
             {
-                g.DrawLine (errorPen, _printableArea.Right, 0, _printableArea.Right, _bounds.Height);
+                g.DrawLine(errorPen, _printableArea.Right, 0, _printableArea.Right, _bounds.Height);
             }
 
             if (Margins.Bottom < bottomMax)
             {
-                g.DrawLine (errorPen, 0, _printableArea.Bottom, _bounds.Width, _printableArea.Bottom);
+                g.DrawLine(errorPen, 0, _printableArea.Bottom, _bounds.Width, _printableArea.Bottom);
             }
 
             if (Margins.Left < leftMax || Margins.Top < topMax || Margins.Right < rightMax ||
                 Margins.Bottom < bottomMax)
             {
-                using var font = new System.Drawing.Font (FontFamily.GenericSansSerif, 14, System.Drawing.FontStyle.Bold,
-                    GraphicsUnit.Point);
+                using var font =
+                    new System.Drawing.Font(FontFamily.GenericSansSerif, 14, System.Drawing.FontStyle.Bold,
+                        GraphicsUnit.Point);
                 string msg =
                     $"Margins are set outside of printable area {Environment.NewLine}Maximum values: Left: {leftMax / 100F}\", Right: {rightMax / 100F}\", Top: {topMax / 100F}\", Bottom: {bottomMax / 100F}\"";
-                ServiceLocator.Current.TelemetryService.TrackEvent ("Margins of of bounds",
+                ServiceLocator.Current.TelemetryService.TrackEvent("Margins of of bounds",
                     new Dictionary<string, string?> { ["Message"] = msg });
-                SizeF size = g.MeasureString (msg, font);
-                using var fmt = new StringFormat (StringFormat.GenericDefault)
+                SizeF size = g.MeasureString(msg, font);
+                using var fmt = new StringFormat(StringFormat.GenericDefault)
                 {
                     Alignment = StringAlignment.Center,
                     LineAlignment = StringAlignment.Center
                 };
-                g.DrawString (msg, font, Brushes.Gray, _bounds, fmt);
+                g.DrawString(msg, font, Brushes.Gray, _bounds, fmt);
 
                 // Draw hatch outside printable area
-                g.SetClip (_bounds);
-                var r = new Rectangle ((int)Math.Floor (_printableArea.Left), (int)Math.Floor (_printableArea.Top),
-                    (int)Math.Ceiling (_printableArea.Width) + 1, (int)Math.Ceiling (_printableArea.Height) + 1);
-                g.ExcludeClip (r);
-                using var brush = new HatchBrush (HatchStyle.LightUpwardDiagonal, Color.Gray, Color.White);
-                g.FillRectangle (brush, _bounds);
+                g.SetClip(_bounds);
+                var r = new Rectangle((int)Math.Floor(_printableArea.Left), (int)Math.Floor(_printableArea.Top),
+                    (int)Math.Ceiling(_printableArea.Width) + 1, (int)Math.Ceiling(_printableArea.Height) + 1);
+                g.ExcludeClip(r);
+                using var brush = new HatchBrush(HatchStyle.LightUpwardDiagonal, Color.Gray, Color.White);
+                g.FillRectangle(brush, _bounds);
             }
         }
 
-        PaintRules (g);
+        PaintRules(g);
     }
 
     /// <summary>
@@ -1331,7 +1323,7 @@ public class SheetViewModel : ViewModelBase
     /// </summary>
     /// <param name="g"></param>
     /// <param name="pageNum"></param>
-    internal void PaintPageNum (Graphics g, int pageNum)
+    internal void PaintPageNum(Graphics g, int pageNum)
     {
         Settings settings = ModelLocator.Current.Settings;
 
@@ -1339,62 +1331,65 @@ public class SheetViewModel : ViewModelBase
 
         if (g.PageUnit == GraphicsUnit.Display)
         {
-            font = new System.Drawing.Font (settings.DiagnosticRulesFont.Family, 48, (System.Drawing.FontStyle)settings.DiagnosticRulesFont.Style,
-                GraphicsUnit.Point);
+            font =
+                new System.Drawing.Font(settings.DiagnosticRulesFont.Family, 48,
+                    (System.Drawing.FontStyle)settings.DiagnosticRulesFont.Style,
+                    GraphicsUnit.Point);
         }
         else
         {
             // Convert font to pixel units if we're in preview
-            font = new System.Drawing.Font (settings.DiagnosticRulesFont.Family, 48 / 72F * 96F,
+            font = new System.Drawing.Font(settings.DiagnosticRulesFont.Family, 48 / 72F * 96F,
                 (System.Drawing.FontStyle)settings.DiagnosticRulesFont.Style, GraphicsUnit.Pixel);
         }
 
         float xPos = 0; // GetPageX(pageNum);
         float yPos = 0; // GetPageY(pageNum);
 
-        g.DrawRectangle (Pens.DarkGray, xPos, yPos, GetPageWidth (), GetPageHeight ());
+        g.DrawRectangle(Pens.DarkGray, xPos, yPos, GetPageWidth(), GetPageHeight());
 
         // Draw row,col in top, left
         // % (Rows * Columns)
         //g.DrawString($"{GetPageColumn(pageNum)},{GetPageRow(pageNum)}", font, Brushes.Orange, xPos, yPos, StringFormat.GenericTypographic);
 
         // Draw page # in center
-        SizeF size = g.MeasureString ($"{pageNum}", font);
-        g.DrawString ($"{pageNum}", font, Brushes.DarkGray, xPos + (GetPageWidth () / 2 - size.Width / 2),
-            yPos + (GetPageHeight () / 2 - size.Height / 2), StringFormat.GenericTypographic);
-        font.Dispose ();
+        SizeF size = g.MeasureString($"{pageNum}", font);
+        g.DrawString($"{pageNum}", font, Brushes.DarkGray, xPos + (GetPageWidth() / 2 - size.Width / 2),
+            yPos + (GetPageHeight() / 2 - size.Height / 2), StringFormat.GenericTypographic);
+        font.Dispose();
     }
 
     /// <summary>
     ///     Paint diagnostic rules on Sheet
     /// </summary>
     /// <param name="g"></param>
-    internal void PaintRules (Graphics g)
+    internal void PaintRules(Graphics g)
     {
         Settings settings = ModelLocator.Current.Settings;
         bool preview = g.PageUnit != GraphicsUnit.Display;
         System.Drawing.Font font;
         if (g.PageUnit == GraphicsUnit.Display)
         {
-            font = new System.Drawing.Font (settings.DiagnosticRulesFont.Family, settings.DiagnosticRulesFont.Size,
+            font = new System.Drawing.Font(settings.DiagnosticRulesFont.Family, settings.DiagnosticRulesFont.Size,
                 (System.Drawing.FontStyle)settings.DiagnosticRulesFont.Style, GraphicsUnit.Point);
         }
         else
         {
             // Convert font to pixel units if we're in preview
-            font = new System.Drawing.Font (settings.DiagnosticRulesFont.Family,
-                settings.DiagnosticRulesFont.Size / 72F * 96F, (System.Drawing.FontStyle)settings.DiagnosticRulesFont.Style, GraphicsUnit.Pixel);
+            font = new System.Drawing.Font(settings.DiagnosticRulesFont.Family,
+                settings.DiagnosticRulesFont.Size / 72F * 96F,
+                (System.Drawing.FontStyle)settings.DiagnosticRulesFont.Style, GraphicsUnit.Pixel);
         }
 
         // Draw Rules that are physical
         if ((settings.PrintPaperSize && !preview) || (settings.PreviewPaperSize && preview))
         {
             // Draw paper size
-            DrawRule (g, font, Color.Gray, "", new Point (PaperSize.Width / 4, preview ? 0 : (int)-_printableArea.Y),
-                new Point (PaperSize.Width / 4, PaperSize.Height), 4F, true);
-            DrawRule (g, font, Color.Gray, $"{PaperSize.Width / 100F}\"x{PaperSize.Height / 100F}\"",
-                new Point (preview ? 0 : (int)-_printableArea.X, PaperSize.Height / 4),
-                new Point (PaperSize.Width, PaperSize.Height / 4), 4F, true);
+            DrawRule(g, font, Color.Gray, "", new Point(PaperSize.Width / 4, preview ? 0 : (int)-_printableArea.Y),
+                new Point(PaperSize.Width / 4, PaperSize.Height), 4F, true);
+            DrawRule(g, font, Color.Gray, $"{PaperSize.Width / 100F}\"x{PaperSize.Height / 100F}\"",
+                new Point(preview ? 0 : (int)-_printableArea.X, PaperSize.Height / 4),
+                new Point(PaperSize.Width, PaperSize.Height / 4), 4F, true);
         }
 
         // Hard Margins
@@ -1406,38 +1401,38 @@ public class SheetViewModel : ViewModelBase
             //g.TranslateTransform(-HardMarginX, -HardMarginY);
             if (_sheet.Landscape)
             {
-                g.DrawString ($"Landscape Angle = {LandscapeAngle}°", font, Brushes.YellowGreen, HardMarginX,
+                g.DrawString($"Landscape Angle = {LandscapeAngle}°", font, Brushes.YellowGreen, HardMarginX,
                     HardMarginY);
                 if (LandscapeAngle == 270)
                 {
                     // 270 degrees - marginX is on bottom and marginY is left
-                    DrawRule (g, font, Color.YellowGreen, $"HardMarginX - {HardMarginX / 100F}\"",
-                        new Point (_sheet.Margins.Left, PaperSize.Height - (int)HardMarginX),
-                        new Point (PaperSize.Width - _sheet.Margins.Right, PaperSize.Height - (int)HardMarginX), 5F);
-                    DrawRule (g, font, Color.YellowGreen, $"HardMarginY - {HardMarginY / 100F}\"",
-                        new Point ((int)HardMarginY, _sheet.Margins.Top),
-                        new Point ((int)HardMarginY, PaperSize.Height - _sheet.Margins.Bottom), 5F);
+                    DrawRule(g, font, Color.YellowGreen, $"HardMarginX - {HardMarginX / 100F}\"",
+                        new Point(_sheet.Margins.Left, PaperSize.Height - (int)HardMarginX),
+                        new Point(PaperSize.Width - _sheet.Margins.Right, PaperSize.Height - (int)HardMarginX), 5F);
+                    DrawRule(g, font, Color.YellowGreen, $"HardMarginY - {HardMarginY / 100F}\"",
+                        new Point((int)HardMarginY, _sheet.Margins.Top),
+                        new Point((int)HardMarginY, PaperSize.Height - _sheet.Margins.Bottom), 5F);
                 }
                 else
                 {
                     // 90 degrees - marginX is on top and marginY is on right
-                    DrawRule (g, font, Color.YellowGreen, $"HardMarginX - {HardMarginX / 100F}\"",
-                        new Point (_sheet.Margins.Left, (int)HardMarginX),
-                        new Point (PaperSize.Width - _sheet.Margins.Right, (int)HardMarginX), 5F);
-                    DrawRule (g, font, Color.YellowGreen, $"HardMarginY - {HardMarginY / 100F}\"",
-                        new Point (PaperSize.Width - (int)HardMarginY, _sheet.Margins.Top),
-                        new Point (PaperSize.Width - (int)HardMarginY, PaperSize.Height - _sheet.Margins.Bottom), 5F);
+                    DrawRule(g, font, Color.YellowGreen, $"HardMarginX - {HardMarginX / 100F}\"",
+                        new Point(_sheet.Margins.Left, (int)HardMarginX),
+                        new Point(PaperSize.Width - _sheet.Margins.Right, (int)HardMarginX), 5F);
+                    DrawRule(g, font, Color.YellowGreen, $"HardMarginY - {HardMarginY / 100F}\"",
+                        new Point(PaperSize.Width - (int)HardMarginY, _sheet.Margins.Top),
+                        new Point(PaperSize.Width - (int)HardMarginY, PaperSize.Height - _sheet.Margins.Bottom), 5F);
                 }
             }
             else
             {
                 // 0 degrees - marginX is left and marginY is top
-                DrawRule (g, font, Color.YellowGreen, $"HardMarginX - {HardMarginX / 100F}\"",
-                    new Point ((int)HardMarginX, 0),
-                    new Point ((int)HardMarginX, PaperSize.Height), 5F);
-                DrawRule (g, font, Color.YellowGreen, $"HardMarginY - {HardMarginY / 100F}\"",
-                    new Point (0, (int)HardMarginY),
-                    new Point (PaperSize.Width, (int)HardMarginY), 5F);
+                DrawRule(g, font, Color.YellowGreen, $"HardMarginX - {HardMarginX / 100F}\"",
+                    new Point((int)HardMarginX, 0),
+                    new Point((int)HardMarginX, PaperSize.Height), 5F);
+                DrawRule(g, font, Color.YellowGreen, $"HardMarginY - {HardMarginY / 100F}\"",
+                    new Point(0, (int)HardMarginY),
+                    new Point(PaperSize.Width, (int)HardMarginY), 5F);
             }
             //g.Restore(state);
         }
@@ -1445,46 +1440,46 @@ public class SheetViewModel : ViewModelBase
         // Margins       
         if ((settings.PrintMargins && !preview) || (settings.PreviewMargins && preview))
         {
-            DrawRule (g, font, Color.Blue, $"Left Margin - {_sheet.Margins.Left / 100F}\"",
-                new Point (_sheet.Margins.Left, _sheet.Margins.Top),
-                new Point (_sheet.Margins.Left, Bounds.Bottom - _sheet.Margins.Bottom), 2F);
-            DrawRule (g, font, Color.Blue, $"Right Margin - {_sheet.Margins.Right / 100F}\"",
-                new Point (Bounds.Right - _sheet.Margins.Right, _sheet.Margins.Top),
-                new Point (Bounds.Right - _sheet.Margins.Right, Bounds.Bottom - _sheet.Margins.Bottom), 2F);
-            DrawRule (g, font, Color.Blue, $"Top Margin - {_sheet.Margins.Top / 100F}\"",
-                new Point (_sheet.Margins.Left, _sheet.Margins.Top),
-                new Point (Bounds.Right - _sheet.Margins.Right, _sheet.Margins.Top), 2F);
-            DrawRule (g, font, Color.Blue, $"Bottom Margin - {_sheet.Margins.Bottom / 100F}\"",
-                new Point (_sheet.Margins.Left, Bounds.Bottom - _sheet.Margins.Bottom),
-                new Point (Bounds.Right - _sheet.Margins.Right, Bounds.Bottom - _sheet.Margins.Bottom), 2F);
+            DrawRule(g, font, Color.Blue, $"Left Margin - {_sheet.Margins.Left / 100F}\"",
+                new Point(_sheet.Margins.Left, _sheet.Margins.Top),
+                new Point(_sheet.Margins.Left, Bounds.Bottom - _sheet.Margins.Bottom), 2F);
+            DrawRule(g, font, Color.Blue, $"Right Margin - {_sheet.Margins.Right / 100F}\"",
+                new Point(Bounds.Right - _sheet.Margins.Right, _sheet.Margins.Top),
+                new Point(Bounds.Right - _sheet.Margins.Right, Bounds.Bottom - _sheet.Margins.Bottom), 2F);
+            DrawRule(g, font, Color.Blue, $"Top Margin - {_sheet.Margins.Top / 100F}\"",
+                new Point(_sheet.Margins.Left, _sheet.Margins.Top),
+                new Point(Bounds.Right - _sheet.Margins.Right, _sheet.Margins.Top), 2F);
+            DrawRule(g, font, Color.Blue, $"Bottom Margin - {_sheet.Margins.Bottom / 100F}\"",
+                new Point(_sheet.Margins.Left, Bounds.Bottom - _sheet.Margins.Bottom),
+                new Point(Bounds.Right - _sheet.Margins.Right, Bounds.Bottom - _sheet.Margins.Bottom), 2F);
         }
 
         // These rules depend on Hard Margins
         // Bounds
         if ((settings.PrintBounds && !preview) || (settings.PreviewBounds && preview))
         {
-            DrawRule (g, font, Color.Green, $"Left Bounds - {Bounds.Left / 100F}\"",
-                new Point (Bounds.Left, Bounds.Top),
-                new Point (Bounds.Left, Bounds.Bottom), 3F);
-            DrawRule (g, font, Color.Green, $"Right Bounds - {Bounds.Right / 100F}\"",
-                new Point (Bounds.Right, Bounds.Top), new Point (Bounds.Right, Bounds.Bottom), 3F);
-            DrawRule (g, font, Color.Green, $"Top Bounds - {Bounds.Top / 100F}\"", new Point (Bounds.Left, Bounds.Top),
-                new Point (Bounds.Right, Bounds.Top), 3F);
-            DrawRule (g, font, Color.Green, $"Bottom Bounds - {Bounds.Bottom / 100F}\"",
-                new Point (Bounds.Left, Bounds.Bottom), new Point (Bounds.Right, Bounds.Bottom), 3F);
+            DrawRule(g, font, Color.Green, $"Left Bounds - {Bounds.Left / 100F}\"",
+                new Point(Bounds.Left, Bounds.Top),
+                new Point(Bounds.Left, Bounds.Bottom), 3F);
+            DrawRule(g, font, Color.Green, $"Right Bounds - {Bounds.Right / 100F}\"",
+                new Point(Bounds.Right, Bounds.Top), new Point(Bounds.Right, Bounds.Bottom), 3F);
+            DrawRule(g, font, Color.Green, $"Top Bounds - {Bounds.Top / 100F}\"", new Point(Bounds.Left, Bounds.Top),
+                new Point(Bounds.Right, Bounds.Top), 3F);
+            DrawRule(g, font, Color.Green, $"Bottom Bounds - {Bounds.Bottom / 100F}\"",
+                new Point(Bounds.Left, Bounds.Bottom), new Point(Bounds.Right, Bounds.Bottom), 3F);
         }
 
         // Header
         if ((settings.PreviewHeaderFooterBounds && preview) || (settings.PrintHeaderFooterBounds && !preview))
         {
-            g.FillRectangle (Brushes.Gray, _headerVM.Bounds);
-            g.FillRectangle (Brushes.Gray, _footerVM.Bounds);
+            g.FillRectangle(Brushes.Gray, _headerVM.Bounds);
+            g.FillRectangle(Brushes.Gray, _footerVM.Bounds);
         }
 
         // ContentBounds - between headers & footers
         if ((settings.PrintContentBounds && !preview) || (settings.PreviewContentBounds && preview))
         {
-            g.FillRectangle (Brushes.LightGray, _contentBounds);
+            g.FillRectangle(Brushes.LightGray, _contentBounds);
         }
 
         // Printable area 
@@ -1495,13 +1490,13 @@ public class SheetViewModel : ViewModelBase
         //    }
         //}
 
-        font.Dispose ();
+        font.Dispose();
     }
 
-    internal static void DrawRule (Graphics g, System.Drawing.Font font, Color color, string text, Point start,
+    internal static void DrawRule(Graphics g, System.Drawing.Font font, Color color, string text, Point start,
         Point end, float labelDiv, bool arrow = false)
     {
-        using var pen = new Pen (color);
+        using var pen = new Pen(color);
 
         if (arrow)
         {
@@ -1510,35 +1505,35 @@ public class SheetViewModel : ViewModelBase
             pen.EndCap = LineCap.ArrowAnchor;
         }
 
-        g.DrawLine (pen, start, end);
-        SizeF textSize = g.MeasureString (text, font);
-        using Brush brush = new SolidBrush (color);
+        g.DrawLine(pen, start, end);
+        SizeF textSize = g.MeasureString(text, font);
+        using Brush brush = new SolidBrush(color);
         if (start.X == end.X)
         {
             // Vertical
 
-            GraphicsState state = g.Save ();
-            g.RotateTransform (90);
+            GraphicsState state = g.Save();
+            g.RotateTransform(90);
             float x = start.X + textSize.Height / 2F;
             float y = (start.Y + end.Y) / labelDiv - textSize.Width / 2F;
 
             // Weird hack - If we're zoomed, we need to multiply by the zoom factor (element[1]).
             using Matrix tx = g.Transform;
-            g.TranslateTransform (x * tx.Elements[1], y * tx.Elements[1], MatrixOrder.Append);
+            g.TranslateTransform(x * tx.Elements[1], y * tx.Elements[1], MatrixOrder.Append);
 
-            var textRect = new RectangleF (new PointF (0, 0), textSize);
-            g.FillRectangles (Brushes.White, textRect);
-            g.DrawString (text, font, brush, 0, 0);
-            g.Restore (state);
+            var textRect = new RectangleF(new PointF(0, 0), textSize);
+            g.FillRectangles(Brushes.White, textRect);
+            g.DrawString(text, font, brush, 0, 0);
+            g.Restore(state);
         }
         else
         {
             // Horizontal
             float x = (start.X + end.X) / labelDiv - textSize.Width / 2F;
             float y = start.Y - textSize.Height / 2F;
-            var textRect = new RectangleF (new PointF (x, y), textSize);
-            g.FillRectangles (Brushes.White, textRect);
-            g.DrawString (text, font, brush, x, y);
+            var textRect = new RectangleF(new PointF(x, y), textSize);
+            g.FillRectangles(Brushes.White, textRect);
+            g.DrawString(text, font, brush, x, y);
         }
     }
 #endif

--- a/src/WinPrint.Core/ViewModels/ViewModelBase.cs
+++ b/src/WinPrint.Core/ViewModels/ViewModelBase.cs
@@ -8,20 +8,20 @@ public abstract class ViewModelBase : INotifyPropertyChanged
 {
     public event PropertyChangedEventHandler? PropertyChanged;
 
-    protected virtual void OnPropertyChanged ([CallerMemberName] string? propertyName = null)
+    protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
     {
-        PropertyChanged?.Invoke (this, new PropertyChangedEventArgs (propertyName));
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
 
-    protected bool SetField<T> (ref T field, T value, [CallerMemberName] string? propertyName = null)
+    protected bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
     {
-        if (EqualityComparer<T>.Default.Equals (field, value))
+        if (EqualityComparer<T>.Default.Equals(field, value))
         {
             return false;
         }
 
         field = value;
-        OnPropertyChanged (propertyName);
+        OnPropertyChanged(propertyName);
         return true;
     }
 }

--- a/src/WinPrint.Core/WinPrint.Core.csproj
+++ b/src/WinPrint.Core/WinPrint.Core.csproj
@@ -39,8 +39,7 @@
         <Compile Remove="Abstractions\SystemDrawingGraphicsContext.cs" />
         <Compile Remove="Abstractions\SystemDrawingPen.cs" />
         <Compile Remove="Abstractions\SystemDrawingState.cs" />
-        <Compile Remove="ContentTypeEngines\TextCte.cs" />
-        <Compile Remove="ContentTypeEngines\MarkdownCte.cs" />
+        <Compile Remove="ContentTypeEngines\WindowsMeasurementContext.cs" />
         <Compile Remove="ContentTypeEngines\TextMateCte.cs" />
         <Compile Remove="ContentTypeEngines\TextMateWrappedLine.cs" />
         <Compile Remove="ContentTypeEngines\TextMateWrappedRun.cs" />

--- a/src/WinPrint.Core/WinPrint.Core.csproj
+++ b/src/WinPrint.Core/WinPrint.Core.csproj
@@ -40,9 +40,6 @@
         <Compile Remove="Abstractions\SystemDrawingPen.cs" />
         <Compile Remove="Abstractions\SystemDrawingState.cs" />
         <Compile Remove="ContentTypeEngines\WindowsMeasurementContext.cs" />
-        <Compile Remove="ContentTypeEngines\TextMateCte.cs" />
-        <Compile Remove="ContentTypeEngines\TextMateWrappedLine.cs" />
-        <Compile Remove="ContentTypeEngines\TextMateWrappedRun.cs" />
         <Compile Remove="Print.cs" />
     </ItemGroup>
 

--- a/src/WinPrint.Core/WinPrint.Core.csproj
+++ b/src/WinPrint.Core/WinPrint.Core.csproj
@@ -40,6 +40,7 @@
         <Compile Remove="Abstractions\SystemDrawingPen.cs" />
         <Compile Remove="Abstractions\SystemDrawingState.cs" />
         <Compile Remove="ContentTypeEngines\TextCte.cs" />
+        <Compile Remove="ContentTypeEngines\MarkdownCte.cs" />
         <Compile Remove="ContentTypeEngines\TextMateCte.cs" />
         <Compile Remove="ContentTypeEngines\TextMateWrappedLine.cs" />
         <Compile Remove="ContentTypeEngines\TextMateWrappedRun.cs" />
@@ -70,6 +71,7 @@
 
     <ItemGroup>
         <PackageReference Include="CommandLineParser" Version="2.9.1" />
+        <PackageReference Include="Markdig" Version="1.2.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />

--- a/src/WinPrint.Maui/App.xaml.cs
+++ b/src/WinPrint.Maui/App.xaml.cs
@@ -2,14 +2,14 @@ namespace WinPrint.Maui;
 
 public partial class App : Application
 {
-    public App ()
+    public App()
     {
-        InitializeComponent ();
+        InitializeComponent();
     }
 
-    protected override Window CreateWindow (IActivationState? activationState)
+    protected override Window CreateWindow(IActivationState? activationState)
     {
-        var window = new Window (new AppShell ());
+        var window = new Window(new AppShell());
         window.Title = "WinPrint";
         return window;
     }

--- a/src/WinPrint.Maui/AppShell.xaml.cs
+++ b/src/WinPrint.Maui/AppShell.xaml.cs
@@ -2,8 +2,8 @@ namespace WinPrint.Maui;
 
 public partial class AppShell : Shell
 {
-    public AppShell ()
+    public AppShell()
     {
-        InitializeComponent ();
+        InitializeComponent();
     }
 }

--- a/src/WinPrint.Maui/Graphics/MauiBrush.cs
+++ b/src/WinPrint.Maui/Graphics/MauiBrush.cs
@@ -5,12 +5,14 @@ namespace WinPrint.Maui.Graphics;
 
 internal sealed class MauiBrush : IGraphicsBrush
 {
-    public MauiBrush (Color color)
+    public MauiBrush(Color color)
     {
         Color = color;
     }
 
     public Color Color { get; }
 
-    public void Dispose () { }
+    public void Dispose()
+    {
+    }
 }

--- a/src/WinPrint.Maui/Graphics/MauiFont.cs
+++ b/src/WinPrint.Maui/Graphics/MauiFont.cs
@@ -15,5 +15,13 @@ internal sealed class MauiFont : IGraphicsFont
     public float Size { get; }
     public GraphicsFontStyle Style { get; }
 
+    public float GetHeight (float dpi)
+    {
+        // MauiGraphicsContext measures in point space (canvas.FontSize = Size), so line height is
+        // approximated from the point size using a typical 1.2x line-spacing factor. This mirrors the
+        // height returned by the context's MeasureString for a single line.
+        return Size * 1.2f;
+    }
+
     public void Dispose () { }
 }

--- a/src/WinPrint.Maui/Graphics/MauiFont.cs
+++ b/src/WinPrint.Maui/Graphics/MauiFont.cs
@@ -4,7 +4,7 @@ namespace WinPrint.Maui.Graphics;
 
 internal sealed class MauiFont : IGraphicsFont
 {
-    public MauiFont (string family, float size, GraphicsFontStyle style)
+    public MauiFont(string family, float size, GraphicsFontStyle style)
     {
         Family = family;
         Size = size;
@@ -15,7 +15,7 @@ internal sealed class MauiFont : IGraphicsFont
     public float Size { get; }
     public GraphicsFontStyle Style { get; }
 
-    public float GetHeight (float dpi)
+    public float GetHeight(float dpi)
     {
         // MauiGraphicsContext measures in point space (canvas.FontSize = Size), so line height is
         // approximated from the point size using a typical 1.2x line-spacing factor. This mirrors the
@@ -23,5 +23,7 @@ internal sealed class MauiFont : IGraphicsFont
         return Size * 1.2f;
     }
 
-    public void Dispose () { }
+    public void Dispose()
+    {
+    }
 }

--- a/src/WinPrint.Maui/Graphics/MauiGraphicsContext.cs
+++ b/src/WinPrint.Maui/Graphics/MauiGraphicsContext.cs
@@ -9,11 +9,11 @@ namespace WinPrint.Maui.Graphics;
 public sealed class MauiGraphicsContext : IGraphicsContext
 {
     private readonly ICanvas _canvas;
-    private readonly Stack<MauiGraphicsState> _stateStack = new ();
+    private readonly Stack<MauiGraphicsState> _stateStack = new();
     private float _translateX;
     private float _translateY;
 
-    public MauiGraphicsContext (ICanvas canvas, float dpiX, float dpiY, bool isDisplayUnit)
+    public MauiGraphicsContext(ICanvas canvas, float dpiX, float dpiY, bool isDisplayUnit)
     {
         _canvas = canvas;
         DpiX = dpiX;
@@ -25,120 +25,120 @@ public sealed class MauiGraphicsContext : IGraphicsContext
     public float DpiY { get; }
     public bool IsDisplayUnit { get; }
 
-    public IGraphicsBrush BlackBrush { get; } = new MauiBrush (Colors.Black);
-    public IGraphicsBrush GrayBrush { get; } = new MauiBrush (Colors.Gray);
-    public IGraphicsBrush DarkGrayBrush { get; } = new MauiBrush (Colors.DarkGray);
+    public IGraphicsBrush BlackBrush { get; } = new MauiBrush(Colors.Black);
+    public IGraphicsBrush GrayBrush { get; } = new MauiBrush(Colors.Gray);
+    public IGraphicsBrush DarkGrayBrush { get; } = new MauiBrush(Colors.DarkGray);
 
-    public IGraphicsPen BlackPen { get; } = new MauiPen (Colors.Black, 1f);
-    public IGraphicsPen GrayPen { get; } = new MauiPen (Colors.Gray, 1f);
-    public IGraphicsPen RedPen { get; } = new MauiPen (Colors.Red, 1f);
+    public IGraphicsPen BlackPen { get; } = new MauiPen(Colors.Black, 1f);
+    public IGraphicsPen GrayPen { get; } = new MauiPen(Colors.Gray, 1f);
+    public IGraphicsPen RedPen { get; } = new MauiPen(Colors.Red, 1f);
 
-    public IGraphicsState Save ()
+    public IGraphicsState Save()
     {
-        _canvas.SaveState ();
-        var state = new MauiGraphicsState (_translateX, _translateY);
-        _stateStack.Push (state);
+        _canvas.SaveState();
+        var state = new MauiGraphicsState(_translateX, _translateY);
+        _stateStack.Push(state);
         return state;
     }
 
-    public void Restore (IGraphicsState state)
+    public void Restore(IGraphicsState state)
     {
-        _canvas.RestoreState ();
+        _canvas.RestoreState();
         if (_stateStack.Count > 0)
         {
-            var saved = _stateStack.Pop ();
+            MauiGraphicsState saved = _stateStack.Pop();
             _translateX = saved.TranslateX;
             _translateY = saved.TranslateY;
         }
     }
 
-    public void TranslateTransform (float dx, float dy)
+    public void TranslateTransform(float dx, float dy)
     {
-        _canvas.Translate (dx, dy);
+        _canvas.Translate(dx, dy);
         _translateX += dx;
         _translateY += dy;
     }
 
-    public void ScaleTransform (float sx, float sy)
+    public void ScaleTransform(float sx, float sy)
     {
-        _canvas.Scale (sx, sy);
+        _canvas.Scale(sx, sy);
     }
 
-    public void SetClip (GraphicsRectF rect)
+    public void SetClip(GraphicsRectF rect)
     {
-        _canvas.ClipRectangle (rect.X, rect.Y, rect.Width, rect.Height);
+        _canvas.ClipRectangle(rect.X, rect.Y, rect.Width, rect.Height);
     }
 
-    public void ExcludeClip (GraphicsRectF rect)
+    public void ExcludeClip(GraphicsRectF rect)
     {
         // MAUI Graphics doesn't support exclude clip directly; no-op
     }
 
-    public void ResetClip ()
+    public void ResetClip()
     {
         // MAUI Graphics doesn't have ResetClip; manage via Save/Restore pattern
     }
 
-    public void SetTextRenderingMode (GraphicsTextRenderingMode mode)
+    public void SetTextRenderingMode(GraphicsTextRenderingMode mode)
     {
         // MAUI handles text rendering quality automatically
     }
 
-    public IGraphicsFont CreateFont (string family, float size, GraphicsFontStyle style, GraphicsFontUnit unit)
+    public IGraphicsFont CreateFont(string family, float size, GraphicsFontStyle style, GraphicsFontUnit unit)
     {
         float sizeInPoints = unit == GraphicsFontUnit.Pixel ? size * 72f / DpiY : size;
-        return new MauiFont (family, sizeInPoints, style);
+        return new MauiFont(family, sizeInPoints, style);
     }
 
-    public IGraphicsBrush CreateSolidBrush (GraphicsColor color)
+    public IGraphicsBrush CreateSolidBrush(GraphicsColor color)
     {
-        return new MauiBrush (new Color (color.R / 255f, color.G / 255f, color.B / 255f, color.A / 255f));
+        return new MauiBrush(new Color(color.R / 255f, color.G / 255f, color.B / 255f, color.A / 255f));
     }
 
-    public IGraphicsPen CreatePen (GraphicsColor color, float width = 1f)
+    public IGraphicsPen CreatePen(GraphicsColor color, float width = 1f)
     {
-        return new MauiPen (new Color (color.R / 255f, color.G / 255f, color.B / 255f, color.A / 255f), width);
+        return new MauiPen(new Color(color.R / 255f, color.G / 255f, color.B / 255f, color.A / 255f), width);
     }
 
-    public GraphicsSizeF MeasureString (string text, IGraphicsFont font)
-    {
-        var mauiFont = (MauiFont)font;
-        var mFont = new Microsoft.Maui.Graphics.Font (mauiFont.Family, GetFontWeight (mauiFont.Style),
-            GetFontStyleType (mauiFont.Style));
-        _canvas.Font = mFont;
-        _canvas.FontSize = mauiFont.Size;
-        SizeF size = MeasurePreservingWhitespace (text, mFont, mauiFont.Size);
-        return new GraphicsSizeF (size.Width, size.Height);
-    }
-
-    public GraphicsSizeF MeasureString (string text, IGraphicsFont font, int width, GraphicsStringFormat format)
+    public GraphicsSizeF MeasureString(string text, IGraphicsFont font)
     {
         var mauiFont = (MauiFont)font;
-        var mFont = new Microsoft.Maui.Graphics.Font (mauiFont.Family, GetFontWeight (mauiFont.Style),
-            GetFontStyleType (mauiFont.Style));
+        var mFont = new Microsoft.Maui.Graphics.Font(mauiFont.Family, GetFontWeight(mauiFont.Style),
+            GetFontStyleType(mauiFont.Style));
         _canvas.Font = mFont;
         _canvas.FontSize = mauiFont.Size;
-        SizeF size = MeasurePreservingWhitespace (text, mFont, mauiFont.Size);
-        return new GraphicsSizeF (Math.Min (size.Width, width), size.Height);
+        SizeF size = MeasurePreservingWhitespace(text, mFont, mauiFont.Size);
+        return new GraphicsSizeF(size.Width, size.Height);
     }
 
-    public GraphicsSizeF MeasureString (string text, IGraphicsFont font, GraphicsSizeF proposedSize,
+    public GraphicsSizeF MeasureString(string text, IGraphicsFont font, int width, GraphicsStringFormat format)
+    {
+        var mauiFont = (MauiFont)font;
+        var mFont = new Microsoft.Maui.Graphics.Font(mauiFont.Family, GetFontWeight(mauiFont.Style),
+            GetFontStyleType(mauiFont.Style));
+        _canvas.Font = mFont;
+        _canvas.FontSize = mauiFont.Size;
+        SizeF size = MeasurePreservingWhitespace(text, mFont, mauiFont.Size);
+        return new GraphicsSizeF(Math.Min(size.Width, width), size.Height);
+    }
+
+    public GraphicsSizeF MeasureString(string text, IGraphicsFont font, GraphicsSizeF proposedSize,
         GraphicsStringFormat format, out int charsFitted, out int linesFilled)
     {
         var mauiFont = (MauiFont)font;
-        var mFont = new Microsoft.Maui.Graphics.Font (mauiFont.Family, GetFontWeight (mauiFont.Style),
-            GetFontStyleType (mauiFont.Style));
+        var mFont = new Microsoft.Maui.Graphics.Font(mauiFont.Family, GetFontWeight(mauiFont.Style),
+            GetFontStyleType(mauiFont.Style));
         _canvas.Font = mFont;
         _canvas.FontSize = mauiFont.Size;
-        SizeF size = MeasurePreservingWhitespace (text, mFont, mauiFont.Size);
+        SizeF size = MeasurePreservingWhitespace(text, mFont, mauiFont.Size);
 
-        float charWidth = size.Width / Math.Max (1, text.Length);
+        float charWidth = size.Width / Math.Max(1, text.Length);
         charsFitted = charWidth > 0 ? (int)(proposedSize.Width / charWidth) : text.Length;
-        charsFitted = Math.Min (charsFitted, text.Length);
+        charsFitted = Math.Min(charsFitted, text.Length);
         linesFilled = size.Height > 0 ? (int)(proposedSize.Height / size.Height) : 1;
 
-        return new GraphicsSizeF (Math.Min (size.Width, proposedSize.Width),
-            Math.Min (size.Height, proposedSize.Height));
+        return new GraphicsSizeF(Math.Min(size.Width, proposedSize.Width),
+            Math.Min(size.Height, proposedSize.Height));
     }
 
     /// <summary>
@@ -158,26 +158,26 @@ public sealed class MauiGraphicsContext : IGraphicsContext
     ///     GDI+ adds as overhang). This makes the MAUI preview spacing match the
     ///     WinForms preview and the actual printed output.
     /// </summary>
-    private SizeF MeasurePreservingWhitespace (string text, Microsoft.Maui.Graphics.Font mFont, float fontSize)
+    private SizeF MeasurePreservingWhitespace(string text, Microsoft.Maui.Graphics.Font mFont, float fontSize)
     {
-        if (string.IsNullOrEmpty (text))
+        if (string.IsNullOrEmpty(text))
         {
-            return new SizeF (0, 0);
+            return new SizeF(0, 0);
         }
 
         SizeF size;
-        bool needsSentinels = char.IsWhiteSpace (text[0]) || char.IsWhiteSpace (text[text.Length - 1]);
+        bool needsSentinels = char.IsWhiteSpace(text[0]) || char.IsWhiteSpace(text[text.Length - 1]);
         if (!needsSentinels)
         {
-            size = _canvas.GetStringSize (text, mFont, fontSize);
+            size = _canvas.GetStringSize(text, mFont, fontSize);
         }
         else
         {
             // Bookend with a non-collapsible sentinel so spaces/tabs round-trip.
             const string sentinel = "|";
-            var withText = _canvas.GetStringSize (sentinel + text + sentinel, mFont, fontSize);
-            var bookends = _canvas.GetStringSize (sentinel + sentinel, mFont, fontSize);
-            size = new SizeF (Math.Max (0, withText.Width - bookends.Width), withText.Height);
+            SizeF withText = _canvas.GetStringSize(sentinel + text + sentinel, mFont, fontSize);
+            SizeF bookends = _canvas.GetStringSize(sentinel + sentinel, mFont, fontSize);
+            size = new SizeF(Math.Max(0, withText.Width - bookends.Width), withText.Height);
         }
 
         // Return the tight advance width (whitespace preserved via the sentinels above). The text engine
@@ -188,14 +188,14 @@ public sealed class MauiGraphicsContext : IGraphicsContext
         return size;
     }
 
-    public void DrawString (string text, IGraphicsFont font, IGraphicsBrush brush, float x, float y,
+    public void DrawString(string text, IGraphicsFont font, IGraphicsBrush brush, float x, float y,
         GraphicsStringFormat? format = null)
     {
         var mauiFont = (MauiFont)font;
         var mauiBrush = (MauiBrush)brush;
 
-        var mFont = new Microsoft.Maui.Graphics.Font (mauiFont.Family, GetFontWeight (mauiFont.Style),
-            GetFontStyleType (mauiFont.Style));
+        var mFont = new Microsoft.Maui.Graphics.Font(mauiFont.Family, GetFontWeight(mauiFont.Style),
+            GetFontStyleType(mauiFont.Style));
         _canvas.FontColor = mauiBrush.Color;
         _canvas.Font = mFont;
         _canvas.FontSize = mauiFont.Size;
@@ -208,80 +208,80 @@ public sealed class MauiGraphicsContext : IGraphicsContext
         // path. The rect-based overload clips to width/height, so use a very large
         // width to avoid truncating the last character (WinUI's GetStringSize tends to
         // under-measure by a sub-pixel which would otherwise chop e.g. "using" -> "usin").
-        float h = Math.Max (mauiFont.Size * 1.5f, 1f);
-        _canvas.DrawString (text, x, y, 100000f, h, HorizontalAlignment.Left, VerticalAlignment.Top);
+        float h = Math.Max(mauiFont.Size * 1.5f, 1f);
+        _canvas.DrawString(text, x, y, 100000f, h, HorizontalAlignment.Left, VerticalAlignment.Top);
     }
 
-    public void DrawString (string text, IGraphicsFont font, IGraphicsBrush brush, GraphicsRectF rect,
+    public void DrawString(string text, IGraphicsFont font, IGraphicsBrush brush, GraphicsRectF rect,
         GraphicsStringFormat? format = null)
     {
         var mauiFont = (MauiFont)font;
         var mauiBrush = (MauiBrush)brush;
 
         _canvas.FontColor = mauiBrush.Color;
-        _canvas.Font = new Microsoft.Maui.Graphics.Font (mauiFont.Family, GetFontWeight (mauiFont.Style),
-            GetFontStyleType (mauiFont.Style));
+        _canvas.Font = new Microsoft.Maui.Graphics.Font(mauiFont.Family, GetFontWeight(mauiFont.Style),
+            GetFontStyleType(mauiFont.Style));
         _canvas.FontSize = mauiFont.Size;
 
-        var hAlign = format?.Alignment switch
+        HorizontalAlignment hAlign = format?.Alignment switch
         {
             GraphicsTextAlignment.Center => HorizontalAlignment.Center,
             GraphicsTextAlignment.Far => HorizontalAlignment.Right,
             _ => HorizontalAlignment.Left
         };
-        var vAlign = format?.LineAlignment switch
+        VerticalAlignment vAlign = format?.LineAlignment switch
         {
             GraphicsTextAlignment.Center => VerticalAlignment.Center,
             GraphicsTextAlignment.Far => VerticalAlignment.Bottom,
             _ => VerticalAlignment.Top
         };
 
-        _canvas.DrawString (text, rect.X, rect.Y, rect.Width, rect.Height, hAlign, vAlign);
+        _canvas.DrawString(text, rect.X, rect.Y, rect.Width, rect.Height, hAlign, vAlign);
     }
 
-    public void DrawLine (IGraphicsPen pen, float x1, float y1, float x2, float y2)
+    public void DrawLine(IGraphicsPen pen, float x1, float y1, float x2, float y2)
     {
-        ApplyPen (pen);
-        _canvas.DrawLine (x1, y1, x2, y2);
+        ApplyPen(pen);
+        _canvas.DrawLine(x1, y1, x2, y2);
     }
 
-    public void DrawLine (IGraphicsPen pen, GraphicsPointF start, GraphicsPointF end)
+    public void DrawLine(IGraphicsPen pen, GraphicsPointF start, GraphicsPointF end)
     {
-        DrawLine (pen, start.X, start.Y, end.X, end.Y);
+        DrawLine(pen, start.X, start.Y, end.X, end.Y);
     }
 
-    public void DrawRectangle (IGraphicsPen pen, float x, float y, float width, float height)
+    public void DrawRectangle(IGraphicsPen pen, float x, float y, float width, float height)
     {
-        ApplyPen (pen);
-        _canvas.DrawRectangle (x, y, width, height);
+        ApplyPen(pen);
+        _canvas.DrawRectangle(x, y, width, height);
     }
 
-    public void FillRectangle (IGraphicsBrush brush, GraphicsRectF rect)
+    public void FillRectangle(IGraphicsBrush brush, GraphicsRectF rect)
     {
-        FillRectangle (brush, rect.X, rect.Y, rect.Width, rect.Height);
+        FillRectangle(brush, rect.X, rect.Y, rect.Width, rect.Height);
     }
 
-    public void FillRectangle (IGraphicsBrush brush, float x, float y, float width, float height)
+    public void FillRectangle(IGraphicsBrush brush, float x, float y, float width, float height)
     {
         var mauiBrush = (MauiBrush)brush;
         _canvas.FillColor = mauiBrush.Color;
-        _canvas.FillRectangle (x, y, width, height);
+        _canvas.FillRectangle(x, y, width, height);
     }
 
-    private void ApplyPen (IGraphicsPen pen)
+    private void ApplyPen(IGraphicsPen pen)
     {
         var mauiPen = (MauiPen)pen;
         _canvas.StrokeColor = mauiPen.Color;
         _canvas.StrokeSize = mauiPen.Width;
     }
 
-    private static int GetFontWeight (GraphicsFontStyle style)
+    private static int GetFontWeight(GraphicsFontStyle style)
     {
-        return style.HasFlag (GraphicsFontStyle.Bold) ? FontWeights.Bold : FontWeights.Normal;
+        return style.HasFlag(GraphicsFontStyle.Bold) ? FontWeights.Bold : FontWeights.Normal;
     }
 
-    private static Microsoft.Maui.Graphics.FontStyleType GetFontStyleType (GraphicsFontStyle style)
+    private static FontStyleType GetFontStyleType(GraphicsFontStyle style)
     {
-        return style.HasFlag (GraphicsFontStyle.Italic) ? FontStyleType.Italic : FontStyleType.Normal;
+        return style.HasFlag(GraphicsFontStyle.Italic) ? FontStyleType.Italic : FontStyleType.Normal;
     }
 }

--- a/src/WinPrint.Maui/Graphics/MauiGraphicsContext.cs
+++ b/src/WinPrint.Maui/Graphics/MauiGraphicsContext.cs
@@ -180,12 +180,11 @@ public sealed class MauiGraphicsContext : IGraphicsContext
             size = new SizeF (Math.Max (0, withText.Width - bookends.Width), withText.Height);
         }
 
-        // Match GDI+ Graphics.MeasureString's overhang padding so the WinPrint text
-        // engine (which uses width-to-advance) reproduces the same token spacing
-        // the WinForms preview and the print path produce. GDI+ adds roughly
-        // 1/6 em on each side of the measured run; one full em is a safe
-        // approximation that matches the WinForms preview visually.
-        size.Width += fontSize / 3f;
+        // Return the tight advance width (whitespace preserved via the sentinels above). The text engine
+        // advances xPos by this width between per-token runs, so it must equal the width DrawString actually
+        // paints — adding extra overhang here would leave a visible gap before every token. (This previously
+        // padded ~1/3 em to mimic GDI+'s padded MeasureString; that GDI+ padding was itself the bug and has
+        // been removed from the System.Drawing path, so MAUI matches by measuring tight here too.)
         return size;
     }
 

--- a/src/WinPrint.Maui/Graphics/MauiGraphicsState.cs
+++ b/src/WinPrint.Maui/Graphics/MauiGraphicsState.cs
@@ -4,7 +4,7 @@ namespace WinPrint.Maui.Graphics;
 
 internal sealed class MauiGraphicsState : IGraphicsState
 {
-    public MauiGraphicsState (float translateX, float translateY)
+    public MauiGraphicsState(float translateX, float translateY)
     {
         TranslateX = translateX;
         TranslateY = translateY;

--- a/src/WinPrint.Maui/Graphics/MauiPen.cs
+++ b/src/WinPrint.Maui/Graphics/MauiPen.cs
@@ -5,7 +5,7 @@ namespace WinPrint.Maui.Graphics;
 
 internal sealed class MauiPen : IGraphicsPen
 {
-    public MauiPen (Color color, float width)
+    public MauiPen(Color color, float width)
     {
         Color = color;
         Width = width;
@@ -14,5 +14,7 @@ internal sealed class MauiPen : IGraphicsPen
     public Color Color { get; }
     public float Width { get; }
 
-    public void Dispose () { }
+    public void Dispose()
+    {
+    }
 }

--- a/src/WinPrint.Maui/MainPage.xaml.cs
+++ b/src/WinPrint.Maui/MainPage.xaml.cs
@@ -1,7 +1,13 @@
+#if WINDOWS
+using Microsoft.UI.Input;
+using Microsoft.UI.Windowing;
+#endif
 using WinPrint.Core.Abstractions;
+using WinPrint.Core.Models;
 using WinPrint.Maui.Services;
 using WinPrint.Maui.ViewModels;
 using WinPrint.Maui.Views;
+using TappedEventArgs = Microsoft.Maui.Controls.TappedEventArgs;
 
 namespace WinPrint.Maui;
 
@@ -11,20 +17,20 @@ public partial class MainPage : ContentPage
     private readonly PrintPreviewDrawable _drawable;
     private readonly IPrintService _printService;
 
-    public MainPage ()
+    public MainPage()
     {
-        _viewModel = new MainViewModel ();
-        _drawable = new PrintPreviewDrawable (_viewModel);
-        _printService = CreatePlatformPrintService ();
+        _viewModel = new MainViewModel();
+        _drawable = new PrintPreviewDrawable(_viewModel);
+        _printService = CreatePlatformPrintService();
 
-        InitializeComponent ();
+        InitializeComponent();
 
         BindingContext = _viewModel;
         PreviewGraphicsView.Drawable = _drawable;
 
         // Wire up invalidation callback
         _viewModel.InvalidatePreview = () =>
-            MainThread.BeginInvokeOnMainThread (() => PreviewGraphicsView.Invalidate ());
+            MainThread.BeginInvokeOnMainThread(() => PreviewGraphicsView.Invalidate());
 
         // Wire up file picker
         _viewModel.PickFileAsync = PickFileAsync;
@@ -38,28 +44,28 @@ public partial class MainPage : ContentPage
         // Sync window title with ViewModel title
         _viewModel.PropertyChanged += (s, e) =>
         {
-            if (e.PropertyName == nameof (_viewModel.Title) && Window != null)
+            if (e.PropertyName == nameof(_viewModel.Title) && Window != null)
             {
-                MainThread.BeginInvokeOnMainThread (() => Window.Title = _viewModel.Title);
+                MainThread.BeginInvokeOnMainThread(() => Window.Title = _viewModel.Title);
             }
         };
 
         // Populate printer list from platform service
-        PopulatePrinters ();
+        PopulatePrinters();
 
         // Apply command-line options (same pattern as WinForms)
-        ApplyCommandLineOptions ();
+        ApplyCommandLineOptions();
 
         // Subscribe to window lifecycle for state save
         Unloaded += OnPageUnloaded;
     }
 
-    protected override void OnHandlerChanged ()
+    protected override void OnHandlerChanged()
     {
-        base.OnHandlerChanged ();
+        base.OnHandlerChanged();
 
         // Restore saved window size and state (mirrors WinForms pattern)
-        var settings = WinPrint.Core.Models.ModelLocator.Current.Settings;
+        Settings settings = ModelLocator.Current.Settings;
 
         // First set the normal size/location (this is the "restore bounds" if maximized)
         if (settings.Size is { Width: > 0, Height: > 0 } && Window != null)
@@ -67,6 +73,7 @@ public partial class MainPage : ContentPage
             Window.Width = settings.Size.Width;
             Window.Height = settings.Size.Height;
         }
+
         if (settings.Location != null && Window != null)
         {
             Window.X = settings.Location.X;
@@ -75,79 +82,82 @@ public partial class MainPage : ContentPage
 
 #if WINDOWS
         // Then apply maximized state if saved
-        if (settings.WindowState == WinPrint.Core.Models.FormWindowState.Maximized)
+        if (settings.WindowState == Core.Models.FormWindowState.Maximized)
         {
             // Defer maximization until the native window is ready
-            MainThread.BeginInvokeOnMainThread (() =>
+            MainThread.BeginInvokeOnMainThread(() =>
             {
                 if (Window?.Handler?.PlatformView is Microsoft.UI.Xaml.Window nativeWindow)
                 {
-                    var appWindow = nativeWindow.AppWindow;
+                    AppWindow? appWindow = nativeWindow.AppWindow;
                     if (appWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter presenter)
                     {
-                        presenter.Maximize ();
+                        presenter.Maximize();
                     }
                 }
             });
         }
 
         // Hook native WinUI keyboard and pointer wheel events
-        HookNativeWindowEvents ();
+        HookNativeWindowEvents();
 
         // Track window size changes to capture normal bounds
-        HookWindowStateTracking ();
+        HookWindowStateTracking();
 #endif
     }
 
     /// <summary>
     ///     Handle keyboard shortcuts (F5, PgUp, PgDn, Home, End, +, -).
     /// </summary>
-    public void HandleKeyDown (string key, bool ctrl, bool shift)
+    public void HandleKeyDown(string key, bool ctrl, bool shift)
     {
         switch (key)
         {
             case "F5":
-                _viewModel.RefreshCommand.Execute (null);
+                _viewModel.RefreshCommand.Execute(null);
                 break;
             case "PageDown":
             case "Next":
-                _viewModel.NextPageCommand.Execute (null);
+                _viewModel.NextPageCommand.Execute(null);
                 break;
             case "PageUp":
             case "Prior":
-                _viewModel.PreviousPageCommand.Execute (null);
+                _viewModel.PreviousPageCommand.Execute(null);
                 break;
             case "Home":
-                _viewModel.FirstPageCommand.Execute (null);
+                _viewModel.FirstPageCommand.Execute(null);
                 break;
             case "End":
-                _viewModel.LastPageCommand.Execute (null);
+                _viewModel.LastPageCommand.Execute(null);
                 break;
             case "OemPlus":
             case "Add":
                 if (ctrl)
                 {
-                    _viewModel.ZoomInCommand.Execute (null);
+                    _viewModel.ZoomInCommand.Execute(null);
                 }
+
                 break;
             case "OemMinus":
             case "Subtract":
                 if (ctrl)
                 {
-                    _viewModel.ZoomOutCommand.Execute (null);
+                    _viewModel.ZoomOutCommand.Execute(null);
                 }
+
                 break;
             case "D0":
             case "NumPad0":
                 if (ctrl)
                 {
-                    _viewModel.ZoomFitCommand.Execute (null);
+                    _viewModel.ZoomFitCommand.Execute(null);
                 }
+
                 break;
         }
     }
 
-    private void OnPageUnloaded (object? sender, EventArgs e)
+    private void OnPageUnloaded(object? sender, EventArgs e)
     {
         if (Window != null)
         {
@@ -155,31 +165,31 @@ public partial class MainPage : ContentPage
 #if WINDOWS
             if (Window.Handler?.PlatformView is Microsoft.UI.Xaml.Window nativeWindow)
             {
-                var appWindow = nativeWindow.AppWindow;
+                AppWindow? appWindow = nativeWindow.AppWindow;
                 if (appWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter presenter)
                 {
                     isMaximized = presenter.State == Microsoft.UI.Windowing.OverlappedPresenterState.Maximized;
                 }
             }
 #endif
-            _viewModel.SaveWindowState (Window.X, Window.Y, Window.Width, Window.Height, isMaximized);
+            _viewModel.SaveWindowState(Window.X, Window.Y, Window.Width, Window.Height, isMaximized);
         }
     }
 
-    private async Task PerformPrintAsync ()
+    private async Task PerformPrintAsync()
     {
-        await PrintOrchestrator.PrintAsync (_printService, _viewModel, showDialog: true);
+        await PrintOrchestrator.PrintAsync(_printService, _viewModel);
     }
 
-    private void PopulatePrinters ()
+    private void PopulatePrinters()
     {
-        var printers = _printService.GetAvailablePrinters ();
-        _viewModel.PrinterNames.Clear ();
+        IReadOnlyList<PrinterInfo> printers = _printService.GetAvailablePrinters();
+        _viewModel.PrinterNames.Clear();
         string? defaultPrinter = null;
 
-        foreach (var printer in printers)
+        foreach (PrinterInfo printer in printers)
         {
-            _viewModel.PrinterNames.Add (printer.Name);
+            _viewModel.PrinterNames.Add(printer.Name);
             if (printer.IsDefault)
             {
                 defaultPrinter = printer.Name;
@@ -187,8 +197,8 @@ public partial class MainPage : ContentPage
         }
 
         // Restore persisted printer/paper-size via shared AppViewModel logic.
-        _viewModel.App.RestorePrinterSelection (_viewModel.PrinterNames, defaultPrinter);
-        _viewModel.App.RestorePaperSize (_viewModel.PaperSizes);
+        _viewModel.App.RestorePrinterSelection(_viewModel.PrinterNames, defaultPrinter);
+        _viewModel.App.RestorePaperSize(_viewModel.PaperSizes);
     }
 
     /// <summary>
@@ -197,83 +207,80 @@ public partial class MainPage : ContentPage
     ///     <c>--portrait</c>, <c>--paper-size</c>, <c>--sheet</c>, and file
     ///     arguments identically.
     /// </summary>
-    private void ApplyCommandLineOptions ()
+    private void ApplyCommandLineOptions()
     {
-        var options = WinPrint.Core.Models.ModelLocator.Current.Options;
-        string? file = _viewModel.App.ApplyOptions (options, _viewModel.PrinterNames, _viewModel.PaperSizes);
+        Options options = ModelLocator.Current.Options;
+        string? file = _viewModel.App.ApplyOptions(options, _viewModel.PrinterNames, _viewModel.PaperSizes);
 
-        if (!string.IsNullOrEmpty (file))
+        if (!string.IsNullOrEmpty(file))
         {
-            MainThread.BeginInvokeOnMainThread (async () =>
-            {
-                await _viewModel.LoadFileAsync (file);
-            });
+            MainThread.BeginInvokeOnMainThread(async () => { await _viewModel.LoadFileAsync(file); });
         }
     }
 
-    private static IPrintService CreatePlatformPrintService ()
+    private static IPrintService CreatePlatformPrintService()
     {
 #if WINDOWS
-        return new WindowsPrintService ();
+        return new WindowsPrintService();
 #elif MACCATALYST
-        return new MacPrintService ();
+        return new MacPrintService();
 #else
         throw new PlatformNotSupportedException ("Printing is not supported on this platform.");
 #endif
     }
 
-    private async Task<string?> PickFileAsync ()
+    private async Task<string?> PickFileAsync()
     {
-        var result = await FilePicker.Default.PickAsync (new PickOptions
+        FileResult? result = await FilePicker.Default.PickAsync(new PickOptions
         {
             PickerTitle = "Select a file to print"
         });
         return result?.FullPath;
     }
 
-    private async Task<(string Family, float Size, string Style)?> PickFontAsync (
+    private async Task<(string Family, float Size, string Style)?> PickFontAsync(
         string currentFamily, float currentSize, string currentStyle)
     {
         // MAUI doesn't have a built-in font picker dialog.
         // Use a simple prompt as a placeholder — platform-specific dialogs
         // can be added later via dependency injection.
-        string? input = await DisplayPromptAsync (
+        string? input = await DisplayPromptAsync(
             "Font",
             $"Current: {currentFamily}, {currentSize}pt, {currentStyle}\nEnter: Family, Size",
             initialValue: $"{currentFamily}, {currentSize}");
 
-        if (string.IsNullOrWhiteSpace (input))
+        if (string.IsNullOrWhiteSpace(input))
         {
             return null;
         }
 
-        var parts = input.Split (',', StringSplitOptions.TrimEntries);
+        string[] parts = input.Split(',', StringSplitOptions.TrimEntries);
         string family = parts.Length > 0 ? parts[0] : currentFamily;
-        float size = parts.Length > 1 && float.TryParse (parts[1], out var s) ? s : currentSize;
+        float size = parts.Length > 1 && float.TryParse(parts[1], out float s) ? s : currentSize;
         return (family, size, currentStyle);
     }
 
     /// <summary>
     ///     When preview is tapped and no file is loaded, open file dialog (per spec).
     /// </summary>
-    private async void OnPreviewTapped (object? sender, TappedEventArgs e)
+    private async void OnPreviewTapped(object? sender, TappedEventArgs e)
     {
         if (!_viewModel.IsFileLoaded)
         {
-            await _viewModel.OpenFileAsync ();
+            await _viewModel.OpenFileAsync();
         }
     }
 
     // --- Collapsible section handlers ---
 
-    private void OnSheetDefHeaderTapped (object? sender, TappedEventArgs e)
+    private void OnSheetDefHeaderTapped(object? sender, TappedEventArgs e)
     {
-        ToggleSection (SheetDefContent, SheetDefHeader, "Sheet Definition");
+        ToggleSection(SheetDefContent, SheetDefHeader, "Sheet Definition");
     }
 
-    private void OnMarginsHeaderTapped (object? sender, TappedEventArgs e)
+    private void OnMarginsHeaderTapped(object? sender, TappedEventArgs e)
     {
-        ToggleSection (MarginsContent, MarginsHeader, "Margins (inches)");
+        ToggleSection(MarginsContent, MarginsHeader, "Margins (inches)");
     }
 
     /// <summary>
@@ -283,7 +290,7 @@ public partial class MainPage : ContentPage
     ///     the label toggles the sibling CheckBox -- the behavior users (rightly)
     ///     expect on every other platform.
     /// </summary>
-    private void OnCheckBoxLabelTapped (object? sender, TappedEventArgs e)
+    private void OnCheckBoxLabelTapped(object? sender, TappedEventArgs e)
     {
         if (sender is not Label label || label.Parent is not Layout layout)
         {
@@ -291,7 +298,7 @@ public partial class MainPage : ContentPage
         }
 
         // Find the first CheckBox sibling in the same layout and toggle it.
-        foreach (var child in layout.Children)
+        foreach (IView? child in layout.Children)
         {
             if (child is CheckBox cb)
             {
@@ -299,27 +306,28 @@ public partial class MainPage : ContentPage
                 {
                     cb.IsChecked = !cb.IsChecked;
                 }
+
                 return;
             }
         }
     }
 
-    private void OnPagesUpHeaderTapped (object? sender, TappedEventArgs e)
+    private void OnPagesUpHeaderTapped(object? sender, TappedEventArgs e)
     {
-        ToggleSection (PagesUpContent, PagesUpHeader, "Pages Up");
+        ToggleSection(PagesUpContent, PagesUpHeader, "Pages Up");
     }
 
-    private void OnPrinterHeaderTapped (object? sender, TappedEventArgs e)
+    private void OnPrinterHeaderTapped(object? sender, TappedEventArgs e)
     {
-        ToggleSection (PrinterContent, PrinterHeader, "Printer");
+        ToggleSection(PrinterContent, PrinterHeader, "Printer");
     }
 
-    private void OnFontsHeaderTapped (object? sender, TappedEventArgs e)
+    private void OnFontsHeaderTapped(object? sender, TappedEventArgs e)
     {
-        ToggleSection (FontsContent, FontsHeader, "Fonts");
+        ToggleSection(FontsContent, FontsHeader, "Fonts");
     }
 
-    private static void ToggleSection (VisualElement content, Label header, string title)
+    private static void ToggleSection(VisualElement content, Label header, string title)
     {
         content.IsVisible = !content.IsVisible;
         header.Text = (content.IsVisible ? "▼ " : "▶ ") + title;
@@ -327,12 +335,12 @@ public partial class MainPage : ContentPage
 
     private bool _leftPanelVisible = true;
 
-    private async void OnHelpTapped (object? sender, TappedEventArgs e)
+    private async void OnHelpTapped(object? sender, TappedEventArgs e)
     {
         await Launcher.OpenAsync("https://tig.github.io/winprint");
     }
 
-    private void OnPanelToggleTapped (object? sender, TappedEventArgs e)
+    private void OnPanelToggleTapped(object? sender, TappedEventArgs e)
     {
         _leftPanelVisible = !_leftPanelVisible;
         LeftPanel.IsVisible = _leftPanelVisible;
@@ -340,15 +348,15 @@ public partial class MainPage : ContentPage
     }
 
 #if WINDOWS
-    private void HookNativeWindowEvents ()
+    private void HookNativeWindowEvents()
     {
-        var mauiWindow = Window;
+        Window? mauiWindow = Window;
         if (mauiWindow?.Handler?.PlatformView is not Microsoft.UI.Xaml.Window nativeWindow)
         {
             return;
         }
 
-        var content = nativeWindow.Content as Microsoft.UI.Xaml.UIElement;
+        var content = nativeWindow.Content;
         if (content == null)
         {
             return;
@@ -358,36 +366,39 @@ public partial class MainPage : ContentPage
         content.PointerWheelChanged += OnNativePointerWheel;
     }
 
-    private void OnNativeKeyDown (object sender, Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
+    private void OnNativeKeyDown(object sender, Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
     {
         var window = sender as Microsoft.UI.Xaml.UIElement;
-        bool ctrl = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread (Windows.System.VirtualKey.Control)
-            .HasFlag (Windows.UI.Core.CoreVirtualKeyStates.Down);
-        bool shift = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread (Windows.System.VirtualKey.Shift)
-            .HasFlag (Windows.UI.Core.CoreVirtualKeyStates.Down);
+        bool ctrl = Microsoft.UI.Input.InputKeyboardSource
+            .GetKeyStateForCurrentThread(Windows.System.VirtualKey.Control)
+            .HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down);
+        bool shift = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(Windows.System.VirtualKey.Shift)
+            .HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down);
 
-        string key = e.Key.ToString ();
-        HandleKeyDown (key, ctrl, shift);
+        string key = e.Key.ToString();
+        HandleKeyDown(key, ctrl, shift);
     }
 
-    private void OnNativePointerWheel (object sender, Microsoft.UI.Xaml.Input.PointerRoutedEventArgs e)
+    private void OnNativePointerWheel(object sender, Microsoft.UI.Xaml.Input.PointerRoutedEventArgs e)
     {
-        var point = e.GetCurrentPoint (sender as Microsoft.UI.Xaml.UIElement);
+        PointerPoint? point = e.GetCurrentPoint(sender as Microsoft.UI.Xaml.UIElement);
         int delta = point.Properties.MouseWheelDelta;
-        bool ctrl = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread (Windows.System.VirtualKey.Control)
-            .HasFlag (Windows.UI.Core.CoreVirtualKeyStates.Down);
+        bool ctrl = Microsoft.UI.Input.InputKeyboardSource
+            .GetKeyStateForCurrentThread(Windows.System.VirtualKey.Control)
+            .HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down);
 
         if (ctrl)
         {
             // Ctrl+Wheel = zoom
             if (delta > 0)
             {
-                _viewModel.ZoomInCommand.Execute (null);
+                _viewModel.ZoomInCommand.Execute(null);
             }
             else if (delta < 0)
             {
-                _viewModel.ZoomOutCommand.Execute (null);
+                _viewModel.ZoomOutCommand.Execute(null);
             }
+
             e.Handled = true;
         }
         else
@@ -395,12 +406,13 @@ public partial class MainPage : ContentPage
             // Plain wheel = page navigation
             if (delta > 0)
             {
-                _viewModel.PreviousPageCommand.Execute (null);
+                _viewModel.PreviousPageCommand.Execute(null);
             }
             else if (delta < 0)
             {
-                _viewModel.NextPageCommand.Execute (null);
+                _viewModel.NextPageCommand.Execute(null);
             }
+
             e.Handled = true;
         }
     }
@@ -409,14 +421,14 @@ public partial class MainPage : ContentPage
     ///     Track window position/size changes while in normal (non-maximized) state.
     ///     This gives us the "RestoreBounds" equivalent for persisting.
     /// </summary>
-    private void HookWindowStateTracking ()
+    private void HookWindowStateTracking()
     {
         if (Window?.Handler?.PlatformView is not Microsoft.UI.Xaml.Window nativeWindow)
         {
             return;
         }
 
-        var appWindow = nativeWindow.AppWindow;
+        AppWindow? appWindow = nativeWindow.AppWindow;
         appWindow.Changed += (s, args) =>
         {
             if (!args.DidPositionChange && !args.DidSizeChange)
@@ -428,7 +440,7 @@ public partial class MainPage : ContentPage
             if (appWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter presenter &&
                 presenter.State != Microsoft.UI.Windowing.OverlappedPresenterState.Maximized)
             {
-                _viewModel.SaveNormalBounds (Window.X, Window.Y, Window.Width, Window.Height);
+                _viewModel.SaveNormalBounds(Window.X, Window.Y, Window.Width, Window.Height);
             }
         };
     }

--- a/src/WinPrint.Maui/MauiProgram.cs
+++ b/src/WinPrint.Maui/MauiProgram.cs
@@ -10,70 +10,71 @@ namespace WinPrint.Maui;
 
 public static class MauiProgram
 {
-    public static MauiApp CreateMauiApp ()
+    public static MauiApp CreateMauiApp()
     {
 #if WINDOWS
         // Capture the *invocation* CWD before we change it below, so relative file
         // arguments passed on the command line can be resolved against the directory
         // the user launched the app from rather than the install directory.
-        string launchCwd = Directory.GetCurrentDirectory ();
+        string launchCwd = Directory.GetCurrentDirectory();
 #endif
 
         // MAUI/WinUI3 packaged apps start with CWD set to System32.
         // Set it to the exe directory so relative paths and settings file resolution work correctly.
-        string? exeDir = Path.GetDirectoryName (Environment.ProcessPath);
-        if (!string.IsNullOrEmpty (exeDir))
+        string? exeDir = Path.GetDirectoryName(Environment.ProcessPath);
+        if (!string.IsNullOrEmpty(exeDir))
         {
-            Directory.SetCurrentDirectory (exeDir);
+            Directory.SetCurrentDirectory(exeDir);
         }
 
 #if WINDOWS
         // Initialize services (same as WinForms Program.cs)
-        ServiceLocator.Current.TelemetryService.Start (AppDomain.CurrentDomain.FriendlyName);
+        ServiceLocator.Current.TelemetryService.Start(AppDomain.CurrentDomain.FriendlyName);
 
         // Parse command-line arguments using same Options model as WinForms/CLI
-        string[] args = Environment.GetCommandLineArgs ().Skip (1).ToArray ();
+        string[] args = [.. Environment.GetCommandLineArgs().Skip(1)];
         if (args.Length > 0)
         {
-            var parser = new Parser (with => with.EnableDashDash = true);
-            parser.ParseArguments<Options> (args)
-                .WithParsed (o =>
+            var parser = new Parser(with => with.EnableDashDash = true);
+            parser.ParseArguments<Options>(args)
+                .WithParsed(o =>
                 {
                     // Resolve relative file paths against the launch CWD, not the
                     // exe directory we just switched to above.
                     if (o.Files != null)
                     {
                         o.Files = o.Files
-                            .Select (f => Path.IsPathRooted (f) ? f : Path.GetFullPath (f, launchCwd))
-                            .ToList ();
+                            .Select(f => Path.IsPathRooted(f) ? f : Path.GetFullPath(f, launchCwd))
+                            .ToList();
                     }
-                    ModelLocator.Current.Options.CopyPropertiesFrom (o);
-                    Log.Information ("MAUI Command Line: {cmd}", Parser.Default.FormatCommandLine (o));
+
+                    ModelLocator.Current.Options.CopyPropertiesFrom(o);
+                    Log.Information("MAUI Command Line: {cmd}", Parser.Default.FormatCommandLine(o));
                 });
-            parser.Dispose ();
+            parser.Dispose();
         }
 #endif
 
-        MauiAppBuilder builder = MauiApp.CreateBuilder ();
+        MauiAppBuilder builder = MauiApp.CreateBuilder();
         builder
-            .UseMauiApp<App> ()
-            .ConfigureFonts (fonts =>
+            .UseMauiApp<App>()
+            .ConfigureFonts(fonts =>
             {
-                fonts.AddFont ("OpenSans-Regular.ttf", "OpenSansRegular");
-                fonts.AddFont ("OpenSans-Semibold.ttf", "OpenSansSemibold");
+                fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
+                fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
             });
 
-        builder.Services.AddSingleton<AppShell> ();
-        builder.Services.AddSingleton<MainPage> ();
+        builder.Services.AddSingleton<AppShell>();
+        builder.Services.AddSingleton<MainPage>();
 #if WINDOWS
-        builder.Services.AddSingleton (_ => ServiceLocator.Current);
-        builder.Services.AddSingleton (_ => ModelLocator.Current!);
+        builder.Services.AddSingleton(_ => ServiceLocator.Current);
+        builder.Services.AddSingleton(_ => ModelLocator.Current!);
 #endif
 
 #if DEBUG
-        builder.Logging.AddDebug ();
+        builder.Logging.AddDebug();
 #endif
 
-        return builder.Build ();
+        return builder.Build();
     }
 }

--- a/src/WinPrint.Maui/Platforms/MacCatalyst/AppDelegate.cs
+++ b/src/WinPrint.Maui/Platforms/MacCatalyst/AppDelegate.cs
@@ -2,11 +2,11 @@ using Foundation;
 
 namespace WinPrint.Maui;
 
-[Register ("AppDelegate")]
+[Register("AppDelegate")]
 public class AppDelegate : MauiUIApplicationDelegate
 {
-    protected override MauiApp CreateMauiApp ()
+    protected override MauiApp CreateMauiApp()
     {
-        return MauiProgram.CreateMauiApp ();
+        return MauiProgram.CreateMauiApp();
     }
 }

--- a/src/WinPrint.Maui/Platforms/MacCatalyst/CoreGraphicsBrush.cs
+++ b/src/WinPrint.Maui/Platforms/MacCatalyst/CoreGraphicsBrush.cs
@@ -9,10 +9,15 @@ internal sealed class CoreGraphicsBrush : IGraphicsBrush
     public float B { get; }
     public float A { get; }
 
-    public CoreGraphicsBrush (float r, float g, float b, float a)
+    public CoreGraphicsBrush(float r, float g, float b, float a)
     {
-        R = r; G = g; B = b; A = a;
+        R = r;
+        G = g;
+        B = b;
+        A = a;
     }
 
-    public void Dispose () { }
+    public void Dispose()
+    {
+    }
 }

--- a/src/WinPrint.Maui/Platforms/MacCatalyst/CoreGraphicsFont.cs
+++ b/src/WinPrint.Maui/Platforms/MacCatalyst/CoreGraphicsFont.cs
@@ -13,5 +13,12 @@ internal sealed class CoreGraphicsFont : IGraphicsFont
         Family = family; Size = size; Style = style;
     }
 
+    public float GetHeight (float dpi)
+    {
+        // Core Graphics text is measured in point space; approximate line height from the point size
+        // using a typical 1.2x line-spacing factor.
+        return Size * 1.2f;
+    }
+
     public void Dispose () { }
 }

--- a/src/WinPrint.Maui/Platforms/MacCatalyst/CoreGraphicsFont.cs
+++ b/src/WinPrint.Maui/Platforms/MacCatalyst/CoreGraphicsFont.cs
@@ -8,17 +8,21 @@ internal sealed class CoreGraphicsFont : IGraphicsFont
     public float Size { get; }
     public GraphicsFontStyle Style { get; }
 
-    public CoreGraphicsFont (string family, float size, GraphicsFontStyle style)
+    public CoreGraphicsFont(string family, float size, GraphicsFontStyle style)
     {
-        Family = family; Size = size; Style = style;
+        Family = family;
+        Size = size;
+        Style = style;
     }
 
-    public float GetHeight (float dpi)
+    public float GetHeight(float dpi)
     {
         // Core Graphics text is measured in point space; approximate line height from the point size
         // using a typical 1.2x line-spacing factor.
         return Size * 1.2f;
     }
 
-    public void Dispose () { }
+    public void Dispose()
+    {
+    }
 }

--- a/src/WinPrint.Maui/Platforms/MacCatalyst/CoreGraphicsPen.cs
+++ b/src/WinPrint.Maui/Platforms/MacCatalyst/CoreGraphicsPen.cs
@@ -10,10 +10,16 @@ internal sealed class CoreGraphicsPen : IGraphicsPen
     public float A { get; }
     public float Width { get; }
 
-    public CoreGraphicsPen (float r, float g, float b, float a, float width)
+    public CoreGraphicsPen(float r, float g, float b, float a, float width)
     {
-        R = r; G = g; B = b; A = a; Width = width;
+        R = r;
+        G = g;
+        B = b;
+        A = a;
+        Width = width;
     }
 
-    public void Dispose () { }
+    public void Dispose()
+    {
+    }
 }

--- a/src/WinPrint.Maui/Platforms/MacCatalyst/CoreGraphicsPrintContext.cs
+++ b/src/WinPrint.Maui/Platforms/MacCatalyst/CoreGraphicsPrintContext.cs
@@ -15,9 +15,9 @@ public sealed class CoreGraphicsPrintContext : IGraphicsContext
     private readonly CGContext _cgContext;
     private readonly PrintPageSetup _pageSetup;
     private readonly CGRect _pageRect;
-    private readonly Stack<CoreGraphicsState> _stateStack = new ();
+    private readonly Stack<CoreGraphicsState> _stateStack = new();
 
-    public CoreGraphicsPrintContext (CGContext context, PrintPageSetup pageSetup, CGRect pageRect)
+    public CoreGraphicsPrintContext(CGContext context, PrintPageSetup pageSetup, CGRect pageRect)
     {
         _cgContext = context;
         _pageSetup = pageSetup;
@@ -28,121 +28,122 @@ public sealed class CoreGraphicsPrintContext : IGraphicsContext
         DpiY = pageSetup.DpiY > 0 ? pageSetup.DpiY : 72f;
 
         // Flip coordinate system (Core Graphics is bottom-up)
-        _cgContext.TranslateCTM (0, pageRect.Height);
-        _cgContext.ScaleCTM (1, -1);
+        _cgContext.TranslateCTM(0, pageRect.Height);
+        _cgContext.ScaleCTM(1, -1);
     }
 
     public float DpiX { get; }
     public float DpiY { get; }
     public bool IsDisplayUnit => false;
 
-    public IGraphicsBrush BlackBrush { get; } = new CoreGraphicsBrush (0, 0, 0, 1);
-    public IGraphicsBrush GrayBrush { get; } = new CoreGraphicsBrush (0.5f, 0.5f, 0.5f, 1);
-    public IGraphicsBrush DarkGrayBrush { get; } = new CoreGraphicsBrush (0.25f, 0.25f, 0.25f, 1);
+    public IGraphicsBrush BlackBrush { get; } = new CoreGraphicsBrush(0, 0, 0, 1);
+    public IGraphicsBrush GrayBrush { get; } = new CoreGraphicsBrush(0.5f, 0.5f, 0.5f, 1);
+    public IGraphicsBrush DarkGrayBrush { get; } = new CoreGraphicsBrush(0.25f, 0.25f, 0.25f, 1);
 
-    public IGraphicsPen BlackPen { get; } = new CoreGraphicsPen (0, 0, 0, 1, 1f);
-    public IGraphicsPen GrayPen { get; } = new CoreGraphicsPen (0.5f, 0.5f, 0.5f, 1, 1f);
-    public IGraphicsPen RedPen { get; } = new CoreGraphicsPen (1, 0, 0, 1, 1f);
+    public IGraphicsPen BlackPen { get; } = new CoreGraphicsPen(0, 0, 0, 1, 1f);
+    public IGraphicsPen GrayPen { get; } = new CoreGraphicsPen(0.5f, 0.5f, 0.5f, 1, 1f);
+    public IGraphicsPen RedPen { get; } = new CoreGraphicsPen(1, 0, 0, 1, 1f);
 
-    public IGraphicsState Save ()
+    public IGraphicsState Save()
     {
-        _cgContext.SaveState ();
-        var state = new CoreGraphicsState ();
-        _stateStack.Push (state);
+        _cgContext.SaveState();
+        var state = new CoreGraphicsState();
+        _stateStack.Push(state);
         return state;
     }
 
-    public void Restore (IGraphicsState state)
+    public void Restore(IGraphicsState state)
     {
-        _cgContext.RestoreState ();
+        _cgContext.RestoreState();
         if (_stateStack.Count > 0)
         {
-            _stateStack.Pop ();
+            _stateStack.Pop();
         }
     }
 
-    public void TranslateTransform (float dx, float dy)
+    public void TranslateTransform(float dx, float dy)
     {
-        _cgContext.TranslateCTM (dx, dy);
+        _cgContext.TranslateCTM(dx, dy);
     }
 
-    public void ScaleTransform (float sx, float sy)
+    public void ScaleTransform(float sx, float sy)
     {
-        _cgContext.ScaleCTM (sx, sy);
+        _cgContext.ScaleCTM(sx, sy);
     }
 
-    public void SetClip (GraphicsRectF rect)
+    public void SetClip(GraphicsRectF rect)
     {
-        _cgContext.ClipToRect (new CGRect (rect.X, rect.Y, rect.Width, rect.Height));
+        _cgContext.ClipToRect(new CGRect(rect.X, rect.Y, rect.Width, rect.Height));
     }
 
-    public void ExcludeClip (GraphicsRectF rect)
+    public void ExcludeClip(GraphicsRectF rect)
     {
         // Core Graphics doesn't support exclude clip easily; no-op
     }
 
-    public void ResetClip ()
+    public void ResetClip()
     {
         // Managed via Save/Restore pattern
     }
 
-    public void SetTextRenderingMode (GraphicsTextRenderingMode mode)
+    public void SetTextRenderingMode(GraphicsTextRenderingMode mode)
     {
-        _cgContext.SetTextDrawingMode (CGTextDrawingMode.Fill);
-        _cgContext.SetShouldAntialias (mode == GraphicsTextRenderingMode.ClearTypeGridFit);
+        _cgContext.SetTextDrawingMode(CGTextDrawingMode.Fill);
+        _cgContext.SetShouldAntialias(mode == GraphicsTextRenderingMode.ClearTypeGridFit);
     }
 
-    public IGraphicsFont CreateFont (string family, float size, GraphicsFontStyle style, GraphicsFontUnit unit)
+    public IGraphicsFont CreateFont(string family, float size, GraphicsFontStyle style, GraphicsFontUnit unit)
     {
         float sizeInPoints = unit == GraphicsFontUnit.Pixel ? size * 72f / DpiY : size;
-        return new CoreGraphicsFont (family, sizeInPoints, style);
+        return new CoreGraphicsFont(family, sizeInPoints, style);
     }
 
-    public IGraphicsBrush CreateSolidBrush (GraphicsColor color)
+    public IGraphicsBrush CreateSolidBrush(GraphicsColor color)
     {
-        return new CoreGraphicsBrush (color.R / 255f, color.G / 255f, color.B / 255f, color.A / 255f);
+        return new CoreGraphicsBrush(color.R / 255f, color.G / 255f, color.B / 255f, color.A / 255f);
     }
 
-    public IGraphicsPen CreatePen (GraphicsColor color, float width = 1f)
+    public IGraphicsPen CreatePen(GraphicsColor color, float width = 1f)
     {
-        return new CoreGraphicsPen (color.R / 255f, color.G / 255f, color.B / 255f, color.A / 255f, width);
+        return new CoreGraphicsPen(color.R / 255f, color.G / 255f, color.B / 255f, color.A / 255f, width);
     }
 
-    public GraphicsSizeF MeasureString (string text, IGraphicsFont font)
+    public GraphicsSizeF MeasureString(string text, IGraphicsFont font)
     {
         var cgFont = (CoreGraphicsFont)font;
-        using var attrString = CreateAttributedString (text, cgFont);
-        using var ctLine = new CTLine (attrString);
-        var bounds = ctLine.GetBounds (CTLineBoundsOptions.UseOpticalBounds);
-        return new GraphicsSizeF ((float)bounds.Width, (float)bounds.Height);
+        using NSAttributedString attrString = CreateAttributedString(text, cgFont);
+        using var ctLine = new CTLine(attrString);
+        CGRect bounds = ctLine.GetBounds(CTLineBoundsOptions.UseOpticalBounds);
+        return new GraphicsSizeF((float)bounds.Width, (float)bounds.Height);
     }
 
-    public GraphicsSizeF MeasureString (string text, IGraphicsFont font, int width, GraphicsStringFormat format)
+    public GraphicsSizeF MeasureString(string text, IGraphicsFont font, int width, GraphicsStringFormat format)
     {
-        var measured = MeasureString (text, font);
-        return new GraphicsSizeF (Math.Min (measured.Width, width), measured.Height);
+        GraphicsSizeF measured = MeasureString(text, font);
+        return new GraphicsSizeF(Math.Min(measured.Width, width), measured.Height);
     }
 
-    public GraphicsSizeF MeasureString (string text, IGraphicsFont font, GraphicsSizeF proposedSize,
+    public GraphicsSizeF MeasureString(string text, IGraphicsFont font, GraphicsSizeF proposedSize,
         GraphicsStringFormat format, out int charsFitted, out int linesFilled)
     {
         var cgFont = (CoreGraphicsFont)font;
-        using var attrString = CreateAttributedString (text, cgFont);
-        using var framesetter = new CTFramesetter (attrString);
+        using NSAttributedString attrString = CreateAttributedString(text, cgFont);
+        using var framesetter = new CTFramesetter(attrString);
 
-        var fitRange = new NSRange (0, 0);
-        var constraints = new CGSize (proposedSize.Width, proposedSize.Height);
-        var suggestedSize = framesetter.SuggestFrameSize (new NSRange (0, text.Length), null, constraints, out fitRange);
+        var fitRange = new NSRange(0, 0);
+        var constraints = new CGSize(proposedSize.Width, proposedSize.Height);
+        CGSize suggestedSize =
+            framesetter.SuggestFrameSize(new NSRange(0, text.Length), null, constraints, out fitRange);
 
         charsFitted = (int)fitRange.Length;
         float lineHeight = cgFont.Size * 1.2f;
         linesFilled = lineHeight > 0 ? (int)(suggestedSize.Height / lineHeight) : 1;
-        linesFilled = Math.Max (1, linesFilled);
+        linesFilled = Math.Max(1, linesFilled);
 
-        return new GraphicsSizeF ((float)suggestedSize.Width, (float)suggestedSize.Height);
+        return new GraphicsSizeF((float)suggestedSize.Width, (float)suggestedSize.Height);
     }
 
-    public void DrawString (string text, IGraphicsFont font, IGraphicsBrush brush, float x, float y,
+    public void DrawString(string text, IGraphicsFont font, IGraphicsBrush brush, float x, float y,
         GraphicsStringFormat? format = null)
     {
         var cgFont = (CoreGraphicsFont)font;
@@ -150,81 +151,81 @@ public sealed class CoreGraphicsPrintContext : IGraphicsContext
 
         // Core Graphics text is drawn bottom-up; we flipped the context, so we draw normally
         // but need to flip text drawing locally
-        _cgContext.SaveState ();
-        _cgContext.TranslateCTM (x, y + cgFont.Size);
-        _cgContext.ScaleCTM (1, -1);
+        _cgContext.SaveState();
+        _cgContext.TranslateCTM(x, y + cgFont.Size);
+        _cgContext.ScaleCTM(1, -1);
 
-        using var attrString = CreateAttributedString (text, cgFont, cgBrush);
-        using var ctLine = new CTLine (attrString);
-        _cgContext.TextPosition = new CGPoint (0, 0);
-        ctLine.Draw (_cgContext);
+        using NSAttributedString attrString = CreateAttributedString(text, cgFont, cgBrush);
+        using var ctLine = new CTLine(attrString);
+        _cgContext.TextPosition = new CGPoint(0, 0);
+        ctLine.Draw(_cgContext);
 
-        _cgContext.RestoreState ();
+        _cgContext.RestoreState();
     }
 
-    public void DrawString (string text, IGraphicsFont font, IGraphicsBrush brush, GraphicsRectF rect,
+    public void DrawString(string text, IGraphicsFont font, IGraphicsBrush brush, GraphicsRectF rect,
         GraphicsStringFormat? format = null)
     {
         // Simple: draw at top-left of rect (ignoring alignment for now)
-        DrawString (text, font, brush, rect.X, rect.Y, format);
+        DrawString(text, font, brush, rect.X, rect.Y, format);
     }
 
-    public void DrawLine (IGraphicsPen pen, float x1, float y1, float x2, float y2)
+    public void DrawLine(IGraphicsPen pen, float x1, float y1, float x2, float y2)
     {
         var cgPen = (CoreGraphicsPen)pen;
-        _cgContext.SetStrokeColor (cgPen.R, cgPen.G, cgPen.B, cgPen.A);
-        _cgContext.SetLineWidth (cgPen.Width);
-        _cgContext.MoveTo (x1, y1);
-        _cgContext.AddLineToPoint (x2, y2);
-        _cgContext.StrokePath ();
+        _cgContext.SetStrokeColor(cgPen.R, cgPen.G, cgPen.B, cgPen.A);
+        _cgContext.SetLineWidth(cgPen.Width);
+        _cgContext.MoveTo(x1, y1);
+        _cgContext.AddLineToPoint(x2, y2);
+        _cgContext.StrokePath();
     }
 
-    public void DrawLine (IGraphicsPen pen, GraphicsPointF start, GraphicsPointF end)
+    public void DrawLine(IGraphicsPen pen, GraphicsPointF start, GraphicsPointF end)
     {
-        DrawLine (pen, start.X, start.Y, end.X, end.Y);
+        DrawLine(pen, start.X, start.Y, end.X, end.Y);
     }
 
-    public void DrawRectangle (IGraphicsPen pen, float x, float y, float width, float height)
+    public void DrawRectangle(IGraphicsPen pen, float x, float y, float width, float height)
     {
         var cgPen = (CoreGraphicsPen)pen;
-        _cgContext.SetStrokeColor (cgPen.R, cgPen.G, cgPen.B, cgPen.A);
-        _cgContext.SetLineWidth (cgPen.Width);
-        _cgContext.StrokeRect (new CGRect (x, y, width, height));
+        _cgContext.SetStrokeColor(cgPen.R, cgPen.G, cgPen.B, cgPen.A);
+        _cgContext.SetLineWidth(cgPen.Width);
+        _cgContext.StrokeRect(new CGRect(x, y, width, height));
     }
 
-    public void FillRectangle (IGraphicsBrush brush, GraphicsRectF rect)
+    public void FillRectangle(IGraphicsBrush brush, GraphicsRectF rect)
     {
-        FillRectangle (brush, rect.X, rect.Y, rect.Width, rect.Height);
+        FillRectangle(brush, rect.X, rect.Y, rect.Width, rect.Height);
     }
 
-    public void FillRectangle (IGraphicsBrush brush, float x, float y, float width, float height)
+    public void FillRectangle(IGraphicsBrush brush, float x, float y, float width, float height)
     {
         var cgBrush = (CoreGraphicsBrush)brush;
-        _cgContext.SetFillColor (cgBrush.R, cgBrush.G, cgBrush.B, cgBrush.A);
-        _cgContext.FillRect (new CGRect (x, y, width, height));
+        _cgContext.SetFillColor(cgBrush.R, cgBrush.G, cgBrush.B, cgBrush.A);
+        _cgContext.FillRect(new CGRect(x, y, width, height));
     }
 
-    private static NSAttributedString CreateAttributedString (string text, CoreGraphicsFont font,
+    private static NSAttributedString CreateAttributedString(string text, CoreGraphicsFont font,
         CoreGraphicsBrush? brush = null)
     {
-        var traits = CTFontSymbolicTraits.None;
-        if (font.Style.HasFlag (GraphicsFontStyle.Bold))
+        CTFontSymbolicTraits traits = CTFontSymbolicTraits.None;
+        if (font.Style.HasFlag(GraphicsFontStyle.Bold))
         {
             traits |= CTFontSymbolicTraits.Bold;
         }
 
-        if (font.Style.HasFlag (GraphicsFontStyle.Italic))
+        if (font.Style.HasFlag(GraphicsFontStyle.Italic))
         {
             traits |= CTFontSymbolicTraits.Italic;
         }
 
-        var ctFont = new CTFont (font.Family, font.Size);
+        var ctFont = new CTFont(font.Family, font.Size);
         if (traits != CTFontSymbolicTraits.None)
         {
-            var withTraits = ctFont.WithSymbolicTraits (font.Size, traits, traits);
+            CTFont? withTraits = ctFont.WithSymbolicTraits(font.Size, traits, traits);
             if (withTraits != null)
             {
-                ctFont.Dispose ();
+                ctFont.Dispose();
                 ctFont = withTraits;
             }
         }
@@ -232,9 +233,9 @@ public sealed class CoreGraphicsPrintContext : IGraphicsContext
         var attributes = new CTStringAttributes { Font = ctFont };
         if (brush != null)
         {
-            attributes.ForegroundColor = new CoreGraphics.CGColor (brush.R, brush.G, brush.B, brush.A);
+            attributes.ForegroundColor = new CGColor(brush.R, brush.G, brush.B, brush.A);
         }
 
-        return new NSAttributedString (text, attributes);
+        return new NSAttributedString(text, attributes);
     }
 }

--- a/src/WinPrint.Maui/Platforms/MacCatalyst/MacPrintJob.cs
+++ b/src/WinPrint.Maui/Platforms/MacCatalyst/MacPrintJob.cs
@@ -13,51 +13,51 @@ public class MacPrintJob : IPrintJob, IDisposable
 {
     private readonly PrintPageSetup _pageSetup;
     private readonly string _documentName;
-    private readonly List<(int pageNumber, Action<IGraphicsContext, int> render)> _pages = new ();
+    private readonly List<(int pageNumber, Action<IGraphicsContext, int> render)> _pages = [];
     private bool _disposed;
 
-    public MacPrintJob (PrintPageSetup pageSetup, string documentName)
+    public MacPrintJob(PrintPageSetup pageSetup, string documentName)
     {
         _pageSetup = pageSetup;
         _documentName = documentName;
     }
 
-    public void Begin ()
+    public void Begin()
     {
-        _pages.Clear ();
+        _pages.Clear();
     }
 
-    public void PrintPage (int pageNumber, Action<IGraphicsContext, int> renderPage)
+    public void PrintPage(int pageNumber, Action<IGraphicsContext, int> renderPage)
     {
-        _pages.Add ((pageNumber, renderPage));
+        _pages.Add((pageNumber, renderPage));
     }
 
-    public void End ()
+    public void End()
     {
         // Present the print interaction controller with our rendered pages
-        MainThread.BeginInvokeOnMainThread (() => PresentPrintController ());
+        MainThread.BeginInvokeOnMainThread(() => PresentPrintController());
     }
 
-    public void Dispose ()
+    public void Dispose()
     {
         if (!_disposed)
         {
-            _pages.Clear ();
+            _pages.Clear();
             _disposed = true;
         }
 
-        GC.SuppressFinalize (this);
+        GC.SuppressFinalize(this);
     }
 
-    private void PresentPrintController ()
+    private void PresentPrintController()
     {
-        var controller = UIPrintInteractionController.SharedPrintController;
+        UIPrintInteractionController? controller = UIPrintInteractionController.SharedPrintController;
         if (controller == null)
         {
             return;
         }
 
-        var printInfo = UIPrintInfo.PrintInfo;
+        UIPrintInfo printInfo = UIPrintInfo.PrintInfo;
         printInfo.JobName = _documentName;
         printInfo.OutputType = UIPrintInfoOutputType.General;
         printInfo.Orientation = _pageSetup.Landscape
@@ -66,13 +66,13 @@ public class MacPrintJob : IPrintJob, IDisposable
         controller.PrintInfo = printInfo;
 
         // Use a page renderer to draw each page
-        controller.PrintPageRenderer = new WinPrintPageRenderer (_pages, _pageSetup);
+        controller.PrintPageRenderer = new WinPrintPageRenderer(_pages, _pageSetup);
 
-        controller.Present (true, (_, completed, error) =>
+        controller.Present(true, (_, completed, error) =>
         {
             if (error != null)
             {
-                System.Diagnostics.Debug.WriteLine ($"Print error: {error.LocalizedDescription}");
+                System.Diagnostics.Debug.WriteLine($"Print error: {error.LocalizedDescription}");
             }
         });
     }

--- a/src/WinPrint.Maui/Platforms/MacCatalyst/MacPrintService.cs
+++ b/src/WinPrint.Maui/Platforms/MacCatalyst/MacPrintService.cs
@@ -7,17 +7,17 @@ namespace WinPrint.Maui.Services;
 /// </summary>
 public class MacPrintService : IPrintService
 {
-    public IReadOnlyList<PrinterInfo> GetAvailablePrinters ()
+    public IReadOnlyList<PrinterInfo> GetAvailablePrinters()
     {
         // Mac Catalyst / UIKit does not provide a list of printers programmatically.
         // The system print dialog handles printer selection.
         return new List<PrinterInfo>
         {
-            new () { Name = "(System Default)", IsDefault = true }
+            new() { Name = "(System Default)", IsDefault = true }
         };
     }
 
-    public PrintPageSetup GetDefaultPageSetup (string? printerName = null)
+    public PrintPageSetup GetDefaultPageSetup(string? printerName = null)
     {
         // Return US Letter defaults — the print dialog allows the user to change these.
         return new PrintPageSetup
@@ -36,15 +36,15 @@ public class MacPrintService : IPrintService
         };
     }
 
-    public PrintPageSetup ShowPrintDialog (PrintDialogOptions options, PrintPageSetup currentSetup)
+    public PrintPageSetup ShowPrintDialog(PrintDialogOptions options, PrintPageSetup currentSetup)
     {
         // On Mac Catalyst, the print dialog is shown as part of the print job submission.
         // We return the current setup and the dialog is presented during CreateJob/Begin.
         return currentSetup;
     }
 
-    public IPrintJob CreateJob (PrintPageSetup pageSetup, string documentName)
+    public IPrintJob CreateJob(PrintPageSetup pageSetup, string documentName)
     {
-        return new MacPrintJob (pageSetup, documentName);
+        return new MacPrintJob(pageSetup, documentName);
     }
 }

--- a/src/WinPrint.Maui/Platforms/MacCatalyst/Program.cs
+++ b/src/WinPrint.Maui/Platforms/MacCatalyst/Program.cs
@@ -5,10 +5,10 @@ namespace WinPrint.Maui;
 public class Program
 {
     // This is the main entry point of the application.
-    private static void Main (string[] args)
+    private static void Main(string[] args)
     {
         // if you want to use a different Application Delegate class from "AppDelegate"
         // you can specify it here.
-        UIApplication.Main (args, null, typeof (AppDelegate));
+        UIApplication.Main(args, null, typeof(AppDelegate));
     }
 }

--- a/src/WinPrint.Maui/Platforms/MacCatalyst/WinPrintPageRenderer.cs
+++ b/src/WinPrint.Maui/Platforms/MacCatalyst/WinPrintPageRenderer.cs
@@ -13,7 +13,7 @@ internal class WinPrintPageRenderer : UIPrintPageRenderer
     private readonly List<(int pageNumber, Action<IGraphicsContext, int> render)> _pages;
     private readonly PrintPageSetup _pageSetup;
 
-    public WinPrintPageRenderer (
+    public WinPrintPageRenderer(
         List<(int pageNumber, Action<IGraphicsContext, int> render)> pages,
         PrintPageSetup pageSetup)
     {
@@ -23,24 +23,24 @@ internal class WinPrintPageRenderer : UIPrintPageRenderer
 
     public override nint NumberOfPages => _pages.Count;
 
-    public override void DrawPage (nint index, CGRect pageRect)
+    public override void DrawPage(nint index, CGRect pageRect)
     {
-        base.DrawPage (index, pageRect);
+        base.DrawPage(index, pageRect);
 
         if (index < 0 || index >= _pages.Count)
         {
             return;
         }
 
-        var (pageNumber, render) = _pages[(int)index];
+        (int pageNumber, Action<IGraphicsContext, int> render) = _pages[(int)index];
 
-        var context = UIGraphics.GetCurrentContext ();
+        CGContext? context = UIGraphics.GetCurrentContext();
         if (context == null)
         {
             return;
         }
 
-        var canvas = new CoreGraphicsPrintContext (context, _pageSetup, pageRect);
-        render (canvas, pageNumber);
+        var canvas = new CoreGraphicsPrintContext(context, _pageSetup, pageRect);
+        render(canvas, pageNumber);
     }
 }

--- a/src/WinPrint.Maui/Platforms/Windows/App.xaml.cs
+++ b/src/WinPrint.Maui/Platforms/Windows/App.xaml.cs
@@ -12,13 +12,13 @@ public partial class App : MauiWinUIApplication
     ///     Initializes the singleton application object.  This is the first line of authored code
     ///     executed, and as such is the logical equivalent of main() or WinMain().
     /// </summary>
-    public App ()
+    public App()
     {
-        InitializeComponent ();
+        InitializeComponent();
     }
 
-    protected override MauiApp CreateMauiApp ()
+    protected override MauiApp CreateMauiApp()
     {
-        return MauiProgram.CreateMauiApp ();
+        return MauiProgram.CreateMauiApp();
     }
 }

--- a/src/WinPrint.Maui/Platforms/Windows/WindowsPrintJob.cs
+++ b/src/WinPrint.Maui/Platforms/Windows/WindowsPrintJob.cs
@@ -11,17 +11,17 @@ public class WindowsPrintJob : IPrintJob, IDisposable
 {
     private readonly PrintDocument _printDocument;
     private readonly PrintPageSetup _pageSetup;
-    private readonly List<(int PageNum, Action<IGraphicsContext, int> Render)> _pages = new ();
+    private readonly List<(int PageNum, Action<IGraphicsContext, int> Render)> _pages = [];
     private int _pageIndex;
     private bool _disposed;
 
-    public WindowsPrintJob (PrintPageSetup pageSetup, string documentName)
+    public WindowsPrintJob(PrintPageSetup pageSetup, string documentName)
     {
         _pageSetup = pageSetup;
         _printDocument = new PrintDocument { DocumentName = documentName };
 
         // Configure printer
-        if (!string.IsNullOrEmpty (pageSetup.PrinterName))
+        if (!string.IsNullOrEmpty(pageSetup.PrinterName))
         {
             _printDocument.PrinterSettings.PrinterName = pageSetup.PrinterName;
         }
@@ -31,7 +31,7 @@ public class WindowsPrintJob : IPrintJob, IDisposable
         // Find matching paper size
         foreach (PaperSize ps in _printDocument.PrinterSettings.PaperSizes)
         {
-            if (string.Equals (ps.PaperName, pageSetup.PaperSizeName, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(ps.PaperName, pageSetup.PaperSizeName, StringComparison.OrdinalIgnoreCase))
             {
                 _printDocument.DefaultPageSettings.PaperSize = ps;
                 break;
@@ -41,44 +41,44 @@ public class WindowsPrintJob : IPrintJob, IDisposable
         _printDocument.PrintPage += OnPrintPage;
     }
 
-    public void Begin ()
+    public void Begin()
     {
-        _pages.Clear ();
+        _pages.Clear();
         _pageIndex = 0;
     }
 
-    public void PrintPage (int pageNumber, Action<IGraphicsContext, int> renderPage)
+    public void PrintPage(int pageNumber, Action<IGraphicsContext, int> renderPage)
     {
-        _pages.Add ((pageNumber, renderPage));
+        _pages.Add((pageNumber, renderPage));
     }
 
-    public void End ()
+    public void End()
     {
         if (_pages.Count > 0)
         {
-            _printDocument.Print ();
+            _printDocument.Print();
         }
     }
 
-    public void Dispose ()
+    public void Dispose()
     {
         if (!_disposed)
         {
             _printDocument.PrintPage -= OnPrintPage;
-            _printDocument.Dispose ();
+            _printDocument.Dispose();
             _disposed = true;
         }
 
-        GC.SuppressFinalize (this);
+        GC.SuppressFinalize(this);
     }
 
-    private void OnPrintPage (object sender, PrintPageEventArgs e)
+    private void OnPrintPage(object sender, PrintPageEventArgs e)
     {
         if (e.Graphics is not null && _pageIndex < _pages.Count)
         {
-            var (pageNum, render) = _pages[_pageIndex];
-            var context = new SystemDrawingGraphicsContext (e.Graphics);
-            render (context, pageNum);
+            (int pageNum, Action<IGraphicsContext, int> render) = _pages[_pageIndex];
+            var context = new SystemDrawingGraphicsContext(e.Graphics);
+            render(context, pageNum);
         }
 
         _pageIndex++;

--- a/src/WinPrint.Maui/Platforms/Windows/WindowsPrintService.cs
+++ b/src/WinPrint.Maui/Platforms/Windows/WindowsPrintService.cs
@@ -9,27 +9,27 @@ namespace WinPrint.Maui.Services;
 /// </summary>
 public class WindowsPrintService : IPrintService
 {
-    public IReadOnlyList<PrinterInfo> GetAvailablePrinters ()
+    public IReadOnlyList<PrinterInfo> GetAvailablePrinters()
     {
-        var printers = new List<PrinterInfo> ();
-        string defaultPrinter = new PrinterSettings ().PrinterName;
+        var printers = new List<PrinterInfo>();
+        string defaultPrinter = new PrinterSettings().PrinterName;
 
         foreach (string name in PrinterSettings.InstalledPrinters)
         {
-            printers.Add (new PrinterInfo
+            printers.Add(new PrinterInfo
             {
                 Name = name,
-                IsDefault = string.Equals (name, defaultPrinter, StringComparison.OrdinalIgnoreCase)
+                IsDefault = string.Equals(name, defaultPrinter, StringComparison.OrdinalIgnoreCase)
             });
         }
 
         return printers;
     }
 
-    public PrintPageSetup GetDefaultPageSetup (string? printerName = null)
+    public PrintPageSetup GetDefaultPageSetup(string? printerName = null)
     {
-        var settings = new PrinterSettings ();
-        if (!string.IsNullOrEmpty (printerName))
+        var settings = new PrinterSettings();
+        if (!string.IsNullOrEmpty(printerName))
         {
             settings.PrinterName = printerName;
         }
@@ -51,14 +51,14 @@ public class WindowsPrintService : IPrintService
         };
     }
 
-    public PrintPageSetup ShowPrintDialog (PrintDialogOptions options, PrintPageSetup currentSetup)
+    public PrintPageSetup ShowPrintDialog(PrintDialogOptions options, PrintPageSetup currentSetup)
     {
         var settings = new PrinterSettings { PrinterName = currentSetup.PrinterName };
-        var pageSettings = settings.DefaultPageSettings;
+        PageSettings pageSettings = settings.DefaultPageSettings;
 
         // Apply current setup to dialog so it reflects user's choices
         pageSettings.Landscape = currentSetup.Landscape;
-        pageSettings.Margins = new System.Drawing.Printing.Margins (
+        pageSettings.Margins = new Margins(
             currentSetup.MarginLeft, currentSetup.MarginRight,
             currentSetup.MarginTop, currentSetup.MarginBottom);
 
@@ -71,7 +71,7 @@ public class WindowsPrintService : IPrintService
             UseEXDialog = true
         };
 
-        if (dialog.ShowDialog () == System.Windows.Forms.DialogResult.OK)
+        if (dialog.ShowDialog() == DialogResult.OK)
         {
             pageSettings = dialog.PrinterSettings.DefaultPageSettings;
             return new PrintPageSetup
@@ -94,8 +94,8 @@ public class WindowsPrintService : IPrintService
         return currentSetup;
     }
 
-    public IPrintJob CreateJob (PrintPageSetup pageSetup, string documentName)
+    public IPrintJob CreateJob(PrintPageSetup pageSetup, string documentName)
     {
-        return new WindowsPrintJob (pageSetup, documentName);
+        return new WindowsPrintJob(pageSetup, documentName);
     }
 }

--- a/src/WinPrint.Maui/Services/PrintOrchestrator.cs
+++ b/src/WinPrint.Maui/Services/PrintOrchestrator.cs
@@ -15,7 +15,7 @@ public static class PrintOrchestrator
     /// <summary>
     ///     Executes the full print workflow for the MAUI app.
     /// </summary>
-    public static async Task PrintAsync (IPrintService printService, MainViewModel viewModel, bool showDialog = true)
+    public static async Task PrintAsync(IPrintService printService, MainViewModel viewModel, bool showDialog = true)
     {
         if (viewModel.SheetViewModel.NumSheets <= 0)
         {
@@ -24,65 +24,62 @@ public static class PrintOrchestrator
 
         // Build page setup from the ViewModel's current state (user already configured
         // printer, orientation, margins, and paper in the left panel).
-        var pageSetup = printService.GetDefaultPageSetup (viewModel.SelectedPrinter);
+        PrintPageSetup pageSetup = printService.GetDefaultPageSetup(viewModel.SelectedPrinter);
         pageSetup.Landscape = viewModel.Landscape;
 
         // Apply user's margins
-        if (decimal.TryParse (viewModel.MarginTop, out var mt))
+        if (decimal.TryParse(viewModel.MarginTop, out decimal mt))
         {
             pageSetup.MarginTop = (int)(mt * 100);
         }
 
-        if (decimal.TryParse (viewModel.MarginBottom, out var mb))
+        if (decimal.TryParse(viewModel.MarginBottom, out decimal mb))
         {
             pageSetup.MarginBottom = (int)(mb * 100);
         }
 
-        if (decimal.TryParse (viewModel.MarginLeft, out var ml))
+        if (decimal.TryParse(viewModel.MarginLeft, out decimal ml))
         {
             pageSetup.MarginLeft = (int)(ml * 100);
         }
 
-        if (decimal.TryParse (viewModel.MarginRight, out var mr))
+        if (decimal.TryParse(viewModel.MarginRight, out decimal mr))
         {
             pageSetup.MarginRight = (int)(mr * 100);
         }
 
         // Apply page setup to SheetViewModel for correct reflow
-        viewModel.SheetViewModel.SetPrinterPageSettings (pageSetup);
-        await viewModel.SheetViewModel.ReflowAsync ();
+        viewModel.SheetViewModel.SetPrinterPageSettings(pageSetup);
+        await viewModel.SheetViewModel.ReflowAsync();
 
         // Determine page range
         int fromPage = 1;
         int toPage = viewModel.SheetViewModel.NumSheets;
 
-        if (int.TryParse (viewModel.FromPage, out int from) && from >= 1)
+        if (int.TryParse(viewModel.FromPage, out int from) && from >= 1)
         {
             fromPage = from;
         }
 
-        if (int.TryParse (viewModel.ToPage, out int to) && to >= fromPage)
+        if (int.TryParse(viewModel.ToPage, out int to) && to >= fromPage)
         {
-            toPage = Math.Min (to, viewModel.SheetViewModel.NumSheets);
+            toPage = Math.Min(to, viewModel.SheetViewModel.NumSheets);
         }
 
         // Create and execute print job
-        string docName = !string.IsNullOrEmpty (viewModel.ActiveFile)
-            ? System.IO.Path.GetFileName (viewModel.ActiveFile)
+        string docName = !string.IsNullOrEmpty(viewModel.ActiveFile)
+            ? Path.GetFileName(viewModel.ActiveFile)
             : "WinPrint Document";
 
-        using var job = printService.CreateJob (pageSetup, docName);
-        job.Begin ();
+        using IPrintJob job = printService.CreateJob(pageSetup, docName);
+        job.Begin();
 
         for (int page = fromPage; page <= toPage; page++)
         {
             int pageNum = page;
-            job.PrintPage (pageNum, (context, num) =>
-            {
-                viewModel.SheetViewModel.PrintSheet (context, num, false);
-            });
+            job.PrintPage(pageNum, (context, num) => { viewModel.SheetViewModel.PrintSheet(context, num); });
         }
 
-        job.End ();
+        job.End();
     }
 }

--- a/src/WinPrint.Maui/ViewModels/MainViewModel.cs
+++ b/src/WinPrint.Maui/ViewModels/MainViewModel.cs
@@ -27,7 +27,7 @@ public sealed class MainViewModel : INotifyPropertyChanged
 {
     private readonly AppViewModel _app;
 
-    private readonly PrintPageSetup _currentPageSetup = new ()
+    private readonly PrintPageSetup _currentPageSetup = new()
     {
         PaperWidth = 850,
         PaperHeight = 1100,
@@ -45,28 +45,31 @@ public sealed class MainViewModel : INotifyPropertyChanged
     private string _fromPage = "";
     private string _toPage = "";
 
-    public MainViewModel ()
+    public MainViewModel()
     {
-        SheetViewModel = new SheetViewModel ();
-        _app = new AppViewModel (SheetViewModel, _currentPageSetup);
+        SheetViewModel = new SheetViewModel();
+        _app = new AppViewModel(SheetViewModel, _currentPageSetup);
 
-        OpenFileCommand = new RelayCommand (async () => await OpenFileAsync ());
-        PrintCommand = new RelayCommand (async () => await PrintAsync (), () => IsFileLoaded && !IsBusy);
-        NextPageCommand = new RelayCommand (
-            () => CurrentPage = Math.Min (CurrentPage + 1, TotalPages),
+        OpenFileCommand = new RelayCommand(async () => await OpenFileAsync());
+        PrintCommand = new RelayCommand(async () => await PrintAsync(), () => IsFileLoaded && !IsBusy);
+        NextPageCommand = new RelayCommand(
+            () => CurrentPage = Math.Min(CurrentPage + 1, TotalPages),
             () => CurrentPage < TotalPages);
-        PreviousPageCommand = new RelayCommand (
-            () => CurrentPage = Math.Max (CurrentPage - 1, 1),
+        PreviousPageCommand = new RelayCommand(
+            () => CurrentPage = Math.Max(CurrentPage - 1, 1),
             () => CurrentPage > 1);
-        FirstPageCommand = new RelayCommand (() => CurrentPage = 1, () => CurrentPage > 1);
-        LastPageCommand = new RelayCommand (() => CurrentPage = TotalPages, () => CurrentPage < TotalPages);
-        RefreshCommand = new RelayCommand (async () => await RefreshAsync (), () => IsFileLoaded && !IsBusy);
-        ZoomInCommand = new RelayCommand (() => ZoomFactor = Math.Min (ZoomFactor + 0.25f, 4.0f));
-        ZoomOutCommand = new RelayCommand (() => ZoomFactor = Math.Max (ZoomFactor - 0.25f, 0.25f));
-        ZoomFitCommand = new RelayCommand (() => ZoomFactor = 1.0f);
-        ChangeContentFontCommand = new RelayCommand (async () => await ChangeContentFontAsync ());
-        ChangeHeaderFooterFontCommand = new RelayCommand (async () => await ChangeHeaderFooterFontAsync ());
-        SettingsCommand = new RelayCommand (() => { /* TODO: Open settings dialog */ });
+        FirstPageCommand = new RelayCommand(() => CurrentPage = 1, () => CurrentPage > 1);
+        LastPageCommand = new RelayCommand(() => CurrentPage = TotalPages, () => CurrentPage < TotalPages);
+        RefreshCommand = new RelayCommand(async () => await RefreshAsync(), () => IsFileLoaded && !IsBusy);
+        ZoomInCommand = new RelayCommand(() => ZoomFactor = Math.Min(ZoomFactor + 0.25f, 4.0f));
+        ZoomOutCommand = new RelayCommand(() => ZoomFactor = Math.Max(ZoomFactor - 0.25f, 0.25f));
+        ZoomFitCommand = new RelayCommand(() => ZoomFactor = 1.0f);
+        ChangeContentFontCommand = new RelayCommand(async () => await ChangeContentFontAsync());
+        ChangeHeaderFooterFontCommand = new RelayCommand(async () => await ChangeHeaderFooterFontAsync());
+        SettingsCommand = new RelayCommand(() =>
+        {
+            /* TODO: Open settings dialog */
+        });
 
         // Forward AppViewModel state changes so XAML bindings update.
         _app.PropertyChanged += OnAppPropertyChanged;
@@ -74,27 +77,27 @@ public sealed class MainViewModel : INotifyPropertyChanged
         {
             if (MainThread.IsMainThread)
             {
-                InvalidatePreview?.Invoke ();
+                InvalidatePreview?.Invoke();
             }
             else
             {
-                MainThread.BeginInvokeOnMainThread (() => InvalidatePreview?.Invoke ());
+                MainThread.BeginInvokeOnMainThread(() => InvalidatePreview?.Invoke());
             }
         };
         _app.SheetApplied += (_, _) =>
         {
             if (MainThread.IsMainThread)
             {
-                OnSheetApplied ();
+                OnSheetApplied();
             }
             else
             {
-                MainThread.BeginInvokeOnMainThread (OnSheetApplied);
+                MainThread.BeginInvokeOnMainThread(OnSheetApplied);
             }
         };
 
-        _app.LoadSheets ();
-        SyncMarginsFromCurrentSheet ();
+        _app.LoadSheets();
+        SyncMarginsFromCurrentSheet();
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;
@@ -112,7 +115,7 @@ public sealed class MainViewModel : INotifyPropertyChanged
     public string Title
     {
         get => _title;
-        private set => SetField (ref _title, value);
+        private set => SetField(ref _title, value);
     }
 
     public string ActiveFile => _app.ActiveFile;
@@ -130,7 +133,7 @@ public sealed class MainViewModel : INotifyPropertyChanged
             if (_app.CurrentPage != value)
             {
                 _app.CurrentPage = value;
-                InvalidatePreview?.Invoke ();
+                InvalidatePreview?.Invoke();
             }
         }
     }
@@ -144,9 +147,9 @@ public sealed class MainViewModel : INotifyPropertyChanged
         get => _zoomFactor;
         set
         {
-            if (SetField (ref _zoomFactor, value))
+            if (SetField(ref _zoomFactor, value))
             {
-                InvalidatePreview?.Invoke ();
+                InvalidatePreview?.Invoke();
             }
         }
     }
@@ -162,8 +165,8 @@ public sealed class MainViewModel : INotifyPropertyChanged
         {
             if (_app.SelectedSheetIndex != value)
             {
-                _app.SelectSheetByIndex (value);
-                OnPropertyChanged ();
+                _app.SelectSheetByIndex(value);
+                OnPropertyChanged();
             }
         }
     }
@@ -177,8 +180,8 @@ public sealed class MainViewModel : INotifyPropertyChanged
         {
             if (Landscape != value)
             {
-                _app.SetLandscape (value);
-                OnPropertyChanged ();
+                _app.SetLandscape(value);
+                OnPropertyChanged();
             }
         }
     }
@@ -188,18 +191,18 @@ public sealed class MainViewModel : INotifyPropertyChanged
         get => _marginTop;
         set
         {
-            if (SetField (ref _marginTop, value))
+            if (SetField(ref _marginTop, value))
             {
-                OnPropertyChanged (nameof (MarginTopValue));
-                UpdateMargins ();
+                OnPropertyChanged(nameof(MarginTopValue));
+                UpdateMargins();
             }
         }
     }
 
     public double MarginTopValue
     {
-        get => double.TryParse (_marginTop, out var v) ? v : 0;
-        set => MarginTop = value.ToString ("F2");
+        get => double.TryParse(_marginTop, out double v) ? v : 0;
+        set => MarginTop = value.ToString("F2");
     }
 
     public string MarginBottom
@@ -207,18 +210,18 @@ public sealed class MainViewModel : INotifyPropertyChanged
         get => _marginBottom;
         set
         {
-            if (SetField (ref _marginBottom, value))
+            if (SetField(ref _marginBottom, value))
             {
-                OnPropertyChanged (nameof (MarginBottomValue));
-                UpdateMargins ();
+                OnPropertyChanged(nameof(MarginBottomValue));
+                UpdateMargins();
             }
         }
     }
 
     public double MarginBottomValue
     {
-        get => double.TryParse (_marginBottom, out var v) ? v : 0;
-        set => MarginBottom = value.ToString ("F2");
+        get => double.TryParse(_marginBottom, out double v) ? v : 0;
+        set => MarginBottom = value.ToString("F2");
     }
 
     public string MarginLeft
@@ -226,18 +229,18 @@ public sealed class MainViewModel : INotifyPropertyChanged
         get => _marginLeft;
         set
         {
-            if (SetField (ref _marginLeft, value))
+            if (SetField(ref _marginLeft, value))
             {
-                OnPropertyChanged (nameof (MarginLeftValue));
-                UpdateMargins ();
+                OnPropertyChanged(nameof(MarginLeftValue));
+                UpdateMargins();
             }
         }
     }
 
     public double MarginLeftValue
     {
-        get => double.TryParse (_marginLeft, out var v) ? v : 0;
-        set => MarginLeft = value.ToString ("F2");
+        get => double.TryParse(_marginLeft, out double v) ? v : 0;
+        set => MarginLeft = value.ToString("F2");
     }
 
     public string MarginRight
@@ -245,18 +248,18 @@ public sealed class MainViewModel : INotifyPropertyChanged
         get => _marginRight;
         set
         {
-            if (SetField (ref _marginRight, value))
+            if (SetField(ref _marginRight, value))
             {
-                OnPropertyChanged (nameof (MarginRightValue));
-                UpdateMargins ();
+                OnPropertyChanged(nameof(MarginRightValue));
+                UpdateMargins();
             }
         }
     }
 
     public double MarginRightValue
     {
-        get => double.TryParse (_marginRight, out var v) ? v : 0;
-        set => MarginRight = value.ToString ("F2");
+        get => double.TryParse(_marginRight, out double v) ? v : 0;
+        set => MarginRight = value.ToString("F2");
     }
 
     public int Rows
@@ -266,8 +269,8 @@ public sealed class MainViewModel : INotifyPropertyChanged
         {
             if (Rows != value)
             {
-                _app.SetRows (value);
-                OnPropertyChanged ();
+                _app.SetRows(value);
+                OnPropertyChanged();
             }
         }
     }
@@ -279,24 +282,24 @@ public sealed class MainViewModel : INotifyPropertyChanged
         {
             if (Columns != value)
             {
-                _app.SetColumns (value);
-                OnPropertyChanged ();
+                _app.SetColumns(value);
+                OnPropertyChanged();
             }
         }
     }
 
     public string PaddingValue
     {
-        get => ((_app.CurrentSheet?.Padding ?? 3) / 100.0).ToString ("F2");
+        get => ((_app.CurrentSheet?.Padding ?? 3) / 100.0).ToString("F2");
         set
         {
-            if (decimal.TryParse (value, out var d))
+            if (decimal.TryParse(value, out decimal d))
             {
                 int padding = (int)(d * 100m);
                 if ((_app.CurrentSheet?.Padding ?? -1) != padding)
                 {
-                    _app.SetPadding (padding);
-                    OnPropertyChanged ();
+                    _app.SetPadding(padding);
+                    OnPropertyChanged();
                 }
             }
         }
@@ -309,8 +312,8 @@ public sealed class MainViewModel : INotifyPropertyChanged
         {
             if (PageSeparator != value)
             {
-                _app.SetPageSeparator (value);
-                OnPropertyChanged ();
+                _app.SetPageSeparator(value);
+                OnPropertyChanged();
             }
         }
     }
@@ -322,8 +325,8 @@ public sealed class MainViewModel : INotifyPropertyChanged
         {
             if (LineNumbers != value)
             {
-                _app.SetLineNumbers (value);
-                OnPropertyChanged ();
+                _app.SetLineNumbers(value);
+                OnPropertyChanged();
             }
         }
     }
@@ -334,11 +337,12 @@ public sealed class MainViewModel : INotifyPropertyChanged
     {
         get
         {
-            var cs = SheetViewModel.ContentSettings;
+            ContentSettings? cs = SheetViewModel.ContentSettings;
             if (cs?.Font != null)
             {
                 return $"{cs.Font.Family}, {cs.Font.Style}, {cs.Font.Size}pt";
             }
+
             return "Default";
         }
     }
@@ -347,11 +351,12 @@ public sealed class MainViewModel : INotifyPropertyChanged
     {
         get
         {
-            var header = SheetViewModel.Header;
+            HeaderViewModel? header = SheetViewModel.Header;
             if (header?.Font != null)
             {
                 return $"{header.Font.Family}, {header.Font.Style}, {header.Font.Size}pt";
             }
+
             return "Default";
         }
     }
@@ -365,8 +370,8 @@ public sealed class MainViewModel : INotifyPropertyChanged
         {
             if (HeaderEnabled != value)
             {
-                _app.SetHeaderEnabled (value);
-                OnPropertyChanged ();
+                _app.SetHeaderEnabled(value);
+                OnPropertyChanged();
             }
         }
     }
@@ -378,8 +383,8 @@ public sealed class MainViewModel : INotifyPropertyChanged
         {
             if (HeaderText != value)
             {
-                _app.SetHeaderText (value);
-                OnPropertyChanged ();
+                _app.SetHeaderText(value);
+                OnPropertyChanged();
             }
         }
     }
@@ -391,8 +396,8 @@ public sealed class MainViewModel : INotifyPropertyChanged
         {
             if (FooterEnabled != value)
             {
-                _app.SetFooterEnabled (value);
-                OnPropertyChanged ();
+                _app.SetFooterEnabled(value);
+                OnPropertyChanged();
             }
         }
     }
@@ -404,16 +409,18 @@ public sealed class MainViewModel : INotifyPropertyChanged
         {
             if (FooterText != value)
             {
-                _app.SetFooterText (value);
-                OnPropertyChanged ();
+                _app.SetFooterText(value);
+                OnPropertyChanged();
             }
         }
     }
 
     // --- Printer ---
 
-    public ObservableCollection<string> PrinterNames { get; } = new () { "(Default Printer)" };
-    public ObservableCollection<string> PaperSizes { get; } = new () { "Letter (8.5 x 11)", "Legal (8.5 x 14)", "A4 (210 x 297mm)" };
+    public ObservableCollection<string> PrinterNames { get; } = ["(Default Printer)"];
+
+    public ObservableCollection<string> PaperSizes { get; } =
+        ["Letter (8.5 x 11)", "Legal (8.5 x 14)", "A4 (210 x 297mm)"];
 
     public string? SelectedPrinter
     {
@@ -423,7 +430,7 @@ public sealed class MainViewModel : INotifyPropertyChanged
             if (_app.SelectedPrinter != value)
             {
                 _app.SelectedPrinter = value;
-                OnPropertyChanged ();
+                OnPropertyChanged();
             }
         }
     }
@@ -438,10 +445,11 @@ public sealed class MainViewModel : INotifyPropertyChanged
                 _app.SelectedPaperSize = value;
                 if (value != null)
                 {
-                    UpdatePageSetupForPaper (value);
-                    _ = _app.ReflowAsync ();
+                    UpdatePageSetupForPaper(value);
+                    _ = _app.ReflowAsync();
                 }
-                OnPropertyChanged ();
+
+                OnPropertyChanged();
             }
         }
     }
@@ -449,13 +457,13 @@ public sealed class MainViewModel : INotifyPropertyChanged
     public string FromPage
     {
         get => _fromPage;
-        set => SetField (ref _fromPage, value);
+        set => SetField(ref _fromPage, value);
     }
 
     public string ToPage
     {
         get => _toPage;
-        set => SetField (ref _toPage, value);
+        set => SetField(ref _toPage, value);
     }
 
     // --- Version ---
@@ -466,7 +474,7 @@ public sealed class MainViewModel : INotifyPropertyChanged
         {
             try
             {
-                return $"v{FileVersionInfo.GetVersionInfo (typeof (LogService).Assembly.Location).FileVersion}";
+                return $"v{FileVersionInfo.GetVersionInfo(typeof(LogService).Assembly.Location).FileVersion}";
             }
             catch
             {
@@ -498,104 +506,118 @@ public sealed class MainViewModel : INotifyPropertyChanged
 
     // --- Actions ---
 
-    public async Task OpenFileAsync ()
+    public async Task OpenFileAsync()
     {
-        string? filePath = PickFileAsync != null ? await PickFileAsync () : null;
-        if (!string.IsNullOrEmpty (filePath))
+        string? filePath = PickFileAsync != null ? await PickFileAsync() : null;
+        if (!string.IsNullOrEmpty(filePath))
         {
-            await LoadFileAsync (filePath);
+            await LoadFileAsync(filePath);
         }
     }
 
-    public Task<bool> LoadFileAsync (string filePath) => _app.LoadFileAsync (filePath);
+    public Task<bool> LoadFileAsync(string filePath)
+    {
+        return _app.LoadFileAsync(filePath);
+    }
 
-    public async Task PrintAsync ()
+    public async Task PrintAsync()
     {
         if (PerformPrintAsync != null)
         {
-            await PerformPrintAsync ();
+            await PerformPrintAsync();
         }
     }
 
-    public Task RefreshAsync () => _app.RefreshAsync ();
-
-    private async Task ChangeContentFontAsync ()
+    public Task RefreshAsync()
     {
-        var cs = SheetViewModel.ContentSettings;
+        return _app.RefreshAsync();
+    }
+
+    private async Task ChangeContentFontAsync()
+    {
+        ContentSettings? cs = SheetViewModel.ContentSettings;
         if (cs?.Font == null || PickFontAsync == null)
         {
             return;
         }
 
-        var result = await PickFontAsync (cs.Font.Family, cs.Font.Size, cs.Font.Style.ToString ());
+        (string Family, float Size, string Style)? result =
+            await PickFontAsync(cs.Font.Family, cs.Font.Size, cs.Font.Style.ToString());
         if (result.HasValue)
         {
-            cs.Font = new WinPrint.Core.Models.Font
+            cs.Font = new Core.Models.Font
             {
                 Family = result.Value.Family,
                 Size = result.Value.Size,
-                Style = Enum.TryParse<WinPrint.Core.Models.FontStyle> (result.Value.Style, out var style)
+                Style = Enum.TryParse(result.Value.Style, out FontStyle style)
                     ? style
-                    : WinPrint.Core.Models.FontStyle.Regular
+                    : FontStyle.Regular
             };
-            OnPropertyChanged (nameof (ContentFontDescription));
-            await _app.ReflowAsync ();
+            OnPropertyChanged(nameof(ContentFontDescription));
+            await _app.ReflowAsync();
         }
     }
 
-    private async Task ChangeHeaderFooterFontAsync ()
+    private async Task ChangeHeaderFooterFontAsync()
     {
-        var header = SheetViewModel.Header;
+        HeaderViewModel? header = SheetViewModel.Header;
         if (header?.Font == null || PickFontAsync == null)
         {
             return;
         }
 
-        var result = await PickFontAsync (header.Font.Family, header.Font.Size, header.Font.Style.ToString ());
+        (string Family, float Size, string Style)? result =
+            await PickFontAsync(header.Font.Family, header.Font.Size, header.Font.Style.ToString());
         if (result.HasValue)
         {
-            var newFont = new WinPrint.Core.Models.Font
+            var newFont = new Core.Models.Font
             {
                 Family = result.Value.Family,
                 Size = result.Value.Size,
-                Style = Enum.TryParse<WinPrint.Core.Models.FontStyle> (result.Value.Style, out var style)
+                Style = Enum.TryParse(result.Value.Style, out FontStyle style)
                     ? style
-                    : WinPrint.Core.Models.FontStyle.Regular
+                    : FontStyle.Regular
             };
             header.Font = newFont;
             if (SheetViewModel.Footer != null)
             {
-                SheetViewModel.Footer.Font = (WinPrint.Core.Models.Font)newFont.Clone ();
+                SheetViewModel.Footer.Font = (Core.Models.Font)newFont.Clone();
             }
-            OnPropertyChanged (nameof (HeaderFooterFontDescription));
-            await _app.ReflowAsync ();
+
+            OnPropertyChanged(nameof(HeaderFooterFontDescription));
+            await _app.ReflowAsync();
         }
     }
 
-    public void PaintCurrentPage (IGraphicsContext context)
+    public void PaintCurrentPage(IGraphicsContext context)
     {
         if (!IsFileLoaded || TotalPages == 0)
         {
             return;
         }
-        SheetViewModel.PrintSheet (context, CurrentPage, true);
+
+        SheetViewModel.PrintSheet(context, CurrentPage, true);
     }
 
     /// <summary>
     ///     Persist window state and shared selections on close. Delegates to AppViewModel.
     /// </summary>
-    public void SaveWindowState (double x, double y, double width, double height, bool isMaximized)
-        => _app.SaveWindowState (x, y, width, height, isMaximized);
+    public void SaveWindowState(double x, double y, double width, double height, bool isMaximized)
+    {
+        _app.SaveWindowState(x, y, width, height, isMaximized);
+    }
 
     /// <summary>
     ///     Record the latest "normal" (non-maximized) window bounds. Delegates to AppViewModel.
     /// </summary>
-    public void SaveNormalBounds (double x, double y, double width, double height)
-        => _app.SaveNormalBounds (x, y, width, height);
+    public void SaveNormalBounds(double x, double y, double width, double height)
+    {
+        _app.SaveNormalBounds(x, y, width, height);
+    }
 
     // --- Internals ---
 
-    private void OnAppPropertyChanged (object? sender, PropertyChangedEventArgs e)
+    private void OnAppPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         // AppViewModel.LoadFileAsync / ReflowAsync use ConfigureAwait(false), so
         // continuations (including the IsBusy=false flip) run on the thread pool.
@@ -603,161 +625,163 @@ public sealed class MainViewModel : INotifyPropertyChanged
         // so marshal every forwarded notification.
         if (MainThread.IsMainThread)
         {
-            ForwardAppPropertyChanged (e.PropertyName);
+            ForwardAppPropertyChanged(e.PropertyName);
         }
         else
         {
-            MainThread.BeginInvokeOnMainThread (() => ForwardAppPropertyChanged (e.PropertyName));
+            MainThread.BeginInvokeOnMainThread(() => ForwardAppPropertyChanged(e.PropertyName));
         }
     }
 
-    private void ForwardAppPropertyChanged (string? propertyName)
+    private void ForwardAppPropertyChanged(string? propertyName)
     {
         // Forward state changes so XAML bindings update.
         switch (propertyName)
         {
-            case nameof (AppViewModel.ActiveFile):
-                OnPropertyChanged (nameof (ActiveFile));
-                Title = string.IsNullOrEmpty (_app.ActiveFile)
+            case nameof(AppViewModel.ActiveFile):
+                OnPropertyChanged(nameof(ActiveFile));
+                Title = string.IsNullOrEmpty(_app.ActiveFile)
                     ? "WinPrint"
-                    : $"WinPrint - {Path.GetFileName (_app.ActiveFile)}";
-                OnPropertyChanged (nameof (IsFileLoaded));
-                RaiseCommandsCanExecuteChanged ();
+                    : $"WinPrint - {Path.GetFileName(_app.ActiveFile)}";
+                OnPropertyChanged(nameof(IsFileLoaded));
+                RaiseCommandsCanExecuteChanged();
                 break;
-            case nameof (AppViewModel.IsBusy):
-                OnPropertyChanged (nameof (IsBusy));
-                RaiseCommandsCanExecuteChanged ();
+            case nameof(AppViewModel.IsBusy):
+                OnPropertyChanged(nameof(IsBusy));
+                RaiseCommandsCanExecuteChanged();
                 break;
-            case nameof (AppViewModel.StatusText):
-                OnPropertyChanged (nameof (StatusText));
+            case nameof(AppViewModel.StatusText):
+                OnPropertyChanged(nameof(StatusText));
                 break;
-            case nameof (AppViewModel.CurrentPage):
-                OnPropertyChanged (nameof (CurrentPage));
-                OnPropertyChanged (nameof (PageIndicator));
-                RaiseCommandsCanExecuteChanged ();
+            case nameof(AppViewModel.CurrentPage):
+                OnPropertyChanged(nameof(CurrentPage));
+                OnPropertyChanged(nameof(PageIndicator));
+                RaiseCommandsCanExecuteChanged();
                 break;
-            case nameof (AppViewModel.TotalPages):
-                OnPropertyChanged (nameof (TotalPages));
-                OnPropertyChanged (nameof (PageIndicator));
-                RaiseCommandsCanExecuteChanged ();
+            case nameof(AppViewModel.TotalPages):
+                OnPropertyChanged(nameof(TotalPages));
+                OnPropertyChanged(nameof(PageIndicator));
+                RaiseCommandsCanExecuteChanged();
                 break;
-            case nameof (AppViewModel.SelectedPrinter):
-                OnPropertyChanged (nameof (SelectedPrinter));
+            case nameof(AppViewModel.SelectedPrinter):
+                OnPropertyChanged(nameof(SelectedPrinter));
                 break;
-            case nameof (AppViewModel.SelectedPaperSize):
-                OnPropertyChanged (nameof (SelectedPaperSize));
+            case nameof(AppViewModel.SelectedPaperSize):
+                OnPropertyChanged(nameof(SelectedPaperSize));
                 break;
-            case nameof (AppViewModel.SelectedSheetIndex):
-                OnPropertyChanged (nameof (SelectedSheetIndex));
+            case nameof(AppViewModel.SelectedSheetIndex):
+                OnPropertyChanged(nameof(SelectedSheetIndex));
                 break;
         }
     }
 
-    private void OnSheetApplied ()
+    private void OnSheetApplied()
     {
         // Sync the inch-string display values for the margin controls.
-        SyncMarginsFromCurrentSheet ();
+        SyncMarginsFromCurrentSheet();
 
         // Notify XAML that every sheet-derived property may have changed.
-        OnPropertyChanged (nameof (Landscape));
-        OnPropertyChanged (nameof (Rows));
-        OnPropertyChanged (nameof (Columns));
-        OnPropertyChanged (nameof (PaddingValue));
-        OnPropertyChanged (nameof (PageSeparator));
-        OnPropertyChanged (nameof (LineNumbers));
-        OnPropertyChanged (nameof (HeaderEnabled));
-        OnPropertyChanged (nameof (HeaderText));
-        OnPropertyChanged (nameof (FooterEnabled));
-        OnPropertyChanged (nameof (FooterText));
-        OnPropertyChanged (nameof (ContentFontDescription));
-        OnPropertyChanged (nameof (HeaderFooterFontDescription));
+        OnPropertyChanged(nameof(Landscape));
+        OnPropertyChanged(nameof(Rows));
+        OnPropertyChanged(nameof(Columns));
+        OnPropertyChanged(nameof(PaddingValue));
+        OnPropertyChanged(nameof(PageSeparator));
+        OnPropertyChanged(nameof(LineNumbers));
+        OnPropertyChanged(nameof(HeaderEnabled));
+        OnPropertyChanged(nameof(HeaderText));
+        OnPropertyChanged(nameof(FooterEnabled));
+        OnPropertyChanged(nameof(FooterText));
+        OnPropertyChanged(nameof(ContentFontDescription));
+        OnPropertyChanged(nameof(HeaderFooterFontDescription));
 
         // After a sheet swap, reload the active file with the new sheet so the preview reflects it.
-        if (_app.IsFileLoaded && !string.IsNullOrEmpty (_app.ActiveFile))
+        if (_app.IsFileLoaded && !string.IsNullOrEmpty(_app.ActiveFile))
         {
-            _ = _app.LoadFileAsync (_app.ActiveFile);
+            _ = _app.LoadFileAsync(_app.ActiveFile);
         }
     }
 
-    private void SyncMarginsFromCurrentSheet ()
+    private void SyncMarginsFromCurrentSheet()
     {
-        var sheet = _app.CurrentSheet;
+        SheetSettings? sheet = _app.CurrentSheet;
         if (sheet == null)
         {
             return;
         }
-        _marginTop = (sheet.Margins.Top / 100.0).ToString ("F2");
-        _marginBottom = (sheet.Margins.Bottom / 100.0).ToString ("F2");
-        _marginLeft = (sheet.Margins.Left / 100.0).ToString ("F2");
-        _marginRight = (sheet.Margins.Right / 100.0).ToString ("F2");
-        OnPropertyChanged (nameof (MarginTop));
-        OnPropertyChanged (nameof (MarginBottom));
-        OnPropertyChanged (nameof (MarginLeft));
-        OnPropertyChanged (nameof (MarginRight));
-        OnPropertyChanged (nameof (MarginTopValue));
-        OnPropertyChanged (nameof (MarginBottomValue));
-        OnPropertyChanged (nameof (MarginLeftValue));
-        OnPropertyChanged (nameof (MarginRightValue));
+
+        _marginTop = (sheet.Margins.Top / 100.0).ToString("F2");
+        _marginBottom = (sheet.Margins.Bottom / 100.0).ToString("F2");
+        _marginLeft = (sheet.Margins.Left / 100.0).ToString("F2");
+        _marginRight = (sheet.Margins.Right / 100.0).ToString("F2");
+        OnPropertyChanged(nameof(MarginTop));
+        OnPropertyChanged(nameof(MarginBottom));
+        OnPropertyChanged(nameof(MarginLeft));
+        OnPropertyChanged(nameof(MarginRight));
+        OnPropertyChanged(nameof(MarginTopValue));
+        OnPropertyChanged(nameof(MarginBottomValue));
+        OnPropertyChanged(nameof(MarginLeftValue));
+        OnPropertyChanged(nameof(MarginRightValue));
     }
 
-    private void UpdateMargins ()
+    private void UpdateMargins()
     {
-        if (decimal.TryParse (_marginTop, out var top) &&
-            decimal.TryParse (_marginBottom, out var bottom) &&
-            decimal.TryParse (_marginLeft, out var left) &&
-            decimal.TryParse (_marginRight, out var right))
+        if (decimal.TryParse(_marginTop, out decimal top) &&
+            decimal.TryParse(_marginBottom, out decimal bottom) &&
+            decimal.TryParse(_marginLeft, out decimal left) &&
+            decimal.TryParse(_marginRight, out decimal right))
         {
-            var margins = new PrintMargins (
+            var margins = new PrintMargins(
                 (int)(left * 100),
                 (int)(right * 100),
                 (int)(top * 100),
                 (int)(bottom * 100));
-            _app.SetMargins (margins);
+            _app.SetMargins(margins);
         }
     }
 
-    private void UpdatePageSetupForPaper (string paperName)
+    private void UpdatePageSetupForPaper(string paperName)
     {
-        if (paperName.StartsWith ("Letter"))
+        if (paperName.StartsWith("Letter"))
         {
             _currentPageSetup.PaperWidth = 850;
             _currentPageSetup.PaperHeight = 1100;
         }
-        else if (paperName.StartsWith ("Legal"))
+        else if (paperName.StartsWith("Legal"))
         {
             _currentPageSetup.PaperWidth = 850;
             _currentPageSetup.PaperHeight = 1400;
         }
-        else if (paperName.StartsWith ("A4"))
+        else if (paperName.StartsWith("A4"))
         {
             _currentPageSetup.PaperWidth = 827;
             _currentPageSetup.PaperHeight = 1169;
         }
     }
 
-    private bool SetField<T> (ref T field, T value, [CallerMemberName] string? propertyName = null)
+    private bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
     {
-        if (EqualityComparer<T>.Default.Equals (field, value))
+        if (EqualityComparer<T>.Default.Equals(field, value))
         {
             return false;
         }
+
         field = value;
-        OnPropertyChanged (propertyName);
+        OnPropertyChanged(propertyName);
         return true;
     }
 
-    private void OnPropertyChanged ([CallerMemberName] string? propertyName = null)
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
     {
-        PropertyChanged?.Invoke (this, new PropertyChangedEventArgs (propertyName));
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
 
-    private void RaiseCommandsCanExecuteChanged ()
+    private void RaiseCommandsCanExecuteChanged()
     {
-        (PrintCommand as RelayCommand)?.RaiseCanExecuteChanged ();
-        (RefreshCommand as RelayCommand)?.RaiseCanExecuteChanged ();
-        (NextPageCommand as RelayCommand)?.RaiseCanExecuteChanged ();
-        (PreviousPageCommand as RelayCommand)?.RaiseCanExecuteChanged ();
-        (FirstPageCommand as RelayCommand)?.RaiseCanExecuteChanged ();
-        (LastPageCommand as RelayCommand)?.RaiseCanExecuteChanged ();
+        (PrintCommand as RelayCommand)?.RaiseCanExecuteChanged();
+        (RefreshCommand as RelayCommand)?.RaiseCanExecuteChanged();
+        (NextPageCommand as RelayCommand)?.RaiseCanExecuteChanged();
+        (PreviousPageCommand as RelayCommand)?.RaiseCanExecuteChanged();
+        (FirstPageCommand as RelayCommand)?.RaiseCanExecuteChanged();
+        (LastPageCommand as RelayCommand)?.RaiseCanExecuteChanged();
     }
 }

--- a/src/WinPrint.Maui/ViewModels/RelayCommand.cs
+++ b/src/WinPrint.Maui/ViewModels/RelayCommand.cs
@@ -11,13 +11,13 @@ internal sealed class RelayCommand : ICommand
     private readonly Func<Task>? _asyncExecute;
     private readonly Action? _execute;
 
-    public RelayCommand (Action execute, Func<bool>? canExecute = null)
+    public RelayCommand(Action execute, Func<bool>? canExecute = null)
     {
         _execute = execute;
         _canExecute = canExecute;
     }
 
-    public RelayCommand (Func<Task> asyncExecute, Func<bool>? canExecute = null)
+    public RelayCommand(Func<Task> asyncExecute, Func<bool>? canExecute = null)
     {
         _asyncExecute = asyncExecute;
         _canExecute = canExecute;
@@ -25,25 +25,25 @@ internal sealed class RelayCommand : ICommand
 
     public event EventHandler? CanExecuteChanged;
 
-    public bool CanExecute (object? parameter)
+    public bool CanExecute(object? parameter)
     {
-        return _canExecute?.Invoke () ?? true;
+        return _canExecute?.Invoke() ?? true;
     }
 
-    public async void Execute (object? parameter)
+    public async void Execute(object? parameter)
     {
         if (_asyncExecute != null)
         {
-            await _asyncExecute ();
+            await _asyncExecute();
         }
         else
         {
-            _execute?.Invoke ();
+            _execute?.Invoke();
         }
     }
 
-    public void RaiseCanExecuteChanged ()
+    public void RaiseCanExecuteChanged()
     {
-        CanExecuteChanged?.Invoke (this, EventArgs.Empty);
+        CanExecuteChanged?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/src/WinPrint.Maui/Views/PrintPreviewDrawable.cs
+++ b/src/WinPrint.Maui/Views/PrintPreviewDrawable.cs
@@ -1,6 +1,8 @@
+using System.Drawing;
 using Microsoft.Maui.Graphics;
 using WinPrint.Maui.Graphics;
 using WinPrint.Maui.ViewModels;
+using Color = Microsoft.Maui.Graphics.Color;
 
 namespace WinPrint.Maui.Views;
 
@@ -11,19 +13,19 @@ public sealed class PrintPreviewDrawable : IDrawable
 {
     private readonly MainViewModel _viewModel;
 
-    public PrintPreviewDrawable (MainViewModel viewModel)
+    public PrintPreviewDrawable(MainViewModel viewModel)
     {
         _viewModel = viewModel;
     }
 
-    public void Draw (ICanvas canvas, RectF dirtyRect)
+    public void Draw(ICanvas canvas, RectF dirtyRect)
     {
         // Clear background
         canvas.FillColor = Colors.LightGray;
-        canvas.FillRectangle (dirtyRect);
+        canvas.FillRectangle(dirtyRect);
 
-        bool hasError = !string.IsNullOrEmpty (_viewModel.StatusText) &&
-            _viewModel.StatusText.StartsWith ("Error", StringComparison.OrdinalIgnoreCase);
+        bool hasError = !string.IsNullOrEmpty(_viewModel.StatusText) &&
+                        _viewModel.StatusText.StartsWith("Error", StringComparison.OrdinalIgnoreCase);
 
         if (!_viewModel.IsFileLoaded || _viewModel.TotalPages == 0)
         {
@@ -31,17 +33,18 @@ public sealed class PrintPreviewDrawable : IDrawable
             // sees what went wrong with the CLI argument / file open.
             if (hasError)
             {
-                DrawErrorOverlay (canvas, dirtyRect);
+                DrawErrorOverlay(canvas, dirtyRect);
             }
             else
             {
-                DrawPlaceholder (canvas, dirtyRect);
+                DrawPlaceholder(canvas, dirtyRect);
             }
+
             return;
         }
 
         // Use actual sheet bounds for aspect ratio (supports landscape/portrait)
-        var bounds = _viewModel.SheetViewModel.Bounds;
+        Rectangle bounds = _viewModel.SheetViewModel.Bounds;
         float boundsW = bounds.Width > 0 ? bounds.Width : 850;
         float boundsH = bounds.Height > 0 ? bounds.Height : 1100;
         float pageAspect = boundsW / boundsH;
@@ -70,72 +73,72 @@ public sealed class PrintPreviewDrawable : IDrawable
 
         // Draw page shadow
         canvas.FillColor = Colors.DarkGray;
-        canvas.FillRectangle (x + 3, y + 3, pageWidth, pageHeight);
+        canvas.FillRectangle(x + 3, y + 3, pageWidth, pageHeight);
 
         // Draw white page
         canvas.FillColor = Colors.White;
-        canvas.FillRectangle (x, y, pageWidth, pageHeight);
+        canvas.FillRectangle(x, y, pageWidth, pageHeight);
 
         // Draw page border
         canvas.StrokeColor = Colors.Gray;
         canvas.StrokeSize = 0.5f;
-        canvas.DrawRectangle (x, y, pageWidth, pageHeight);
+        canvas.DrawRectangle(x, y, pageWidth, pageHeight);
 
         // Render content via SheetViewModel
-        canvas.SaveState ();
-        canvas.Translate (x, y);
+        canvas.SaveState();
+        canvas.Translate(x, y);
 
         // Scale to fit the page area (SheetViewModel works in hundredths of an inch)
         float scaleX = pageWidth / boundsW;
         float scaleY = pageHeight / boundsH;
-        canvas.Scale (scaleX, scaleY);
+        canvas.Scale(scaleX, scaleY);
 
-        var context = new MauiGraphicsContext (canvas, 96f, 96f, true);
-        _viewModel.PaintCurrentPage (context);
+        var context = new MauiGraphicsContext(canvas, 96f, 96f, true);
+        _viewModel.PaintCurrentPage(context);
 
-        canvas.RestoreState ();
+        canvas.RestoreState();
 
         // Zoom overlay text when zoomed (per spec)
-        if (Math.Abs (zoom - 1.0f) > 0.01f)
+        if (Math.Abs(zoom - 1.0f) > 0.01f)
         {
             canvas.FontColor = Colors.Gray;
             canvas.FontSize = 12;
-            canvas.DrawString ($"{zoom * 100:F0}%",
+            canvas.DrawString($"{zoom * 100:F0}%",
                 dirtyRect.Width - 60, dirtyRect.Height - 24, 56, 20,
                 HorizontalAlignment.Right, VerticalAlignment.Center);
         }
 
         // Status/error overlay (only shows errors)
-        if (!string.IsNullOrEmpty (_viewModel.StatusText) &&
-            _viewModel.StatusText.StartsWith ("Error", StringComparison.OrdinalIgnoreCase))
+        if (!string.IsNullOrEmpty(_viewModel.StatusText) &&
+            _viewModel.StatusText.StartsWith("Error", StringComparison.OrdinalIgnoreCase))
         {
-            DrawErrorOverlay (canvas, dirtyRect);
+            DrawErrorOverlay(canvas, dirtyRect);
         }
     }
 
-    private void DrawErrorOverlay (ICanvas canvas, RectF dirtyRect)
+    private void DrawErrorOverlay(ICanvas canvas, RectF dirtyRect)
     {
         // Filled banner so the message is unmistakable, top-center of the preview area.
         const float bannerH = 56f;
-        var bannerRect = new RectF (dirtyRect.X + 16, dirtyRect.Y + 16, dirtyRect.Width - 32, bannerH);
-        canvas.FillColor = new Color (1.0f, 0.93f, 0.86f); // light orange
-        canvas.FillRoundedRectangle (bannerRect, 6);
+        var bannerRect = new RectF(dirtyRect.X + 16, dirtyRect.Y + 16, dirtyRect.Width - 32, bannerH);
+        canvas.FillColor = new Color(1.0f, 0.93f, 0.86f); // light orange
+        canvas.FillRoundedRectangle(bannerRect, 6);
         canvas.StrokeColor = Colors.OrangeRed;
         canvas.StrokeSize = 1f;
-        canvas.DrawRoundedRectangle (bannerRect, 6);
+        canvas.DrawRoundedRectangle(bannerRect, 6);
 
         canvas.FontColor = Colors.OrangeRed;
         canvas.FontSize = 14;
-        canvas.DrawString (_viewModel.StatusText,
+        canvas.DrawString(_viewModel.StatusText,
             bannerRect.X + 12, bannerRect.Y, bannerRect.Width - 24, bannerRect.Height,
             HorizontalAlignment.Left, VerticalAlignment.Center);
     }
 
-    private static void DrawPlaceholder (ICanvas canvas, RectF dirtyRect)
+    private static void DrawPlaceholder(ICanvas canvas, RectF dirtyRect)
     {
         canvas.FontColor = Colors.Gray;
         canvas.FontSize = 16;
-        canvas.DrawString ("Open a file to preview",
+        canvas.DrawString("Open a file to preview",
             dirtyRect.X, dirtyRect.Y, dirtyRect.Width, dirtyRect.Height,
             HorizontalAlignment.Center, VerticalAlignment.Center);
     }

--- a/src/WinPrint.Maui/WinPrint.Maui.csproj
+++ b/src/WinPrint.Maui/WinPrint.Maui.csproj
@@ -32,7 +32,7 @@
 		<ApplicationId>com.companyname.winprint.maui</ApplicationId>
 
 		<!-- Versions -->
-		<ApplicationDisplayVersion>2.5.0.0</ApplicationDisplayVersion>
+		<ApplicationDisplayVersion>2.5.0</ApplicationDisplayVersion>
 		<ApplicationVersion>2500</ApplicationVersion>
 		<Version>2.5.0.0</Version>
 

--- a/src/WinPrint.WinForms/AssocF.cs
+++ b/src/WinPrint.WinForms/AssocF.cs
@@ -4,8 +4,8 @@ using System.Diagnostics.CodeAnalysis;
 namespace WinPrint.WinForms;
 
 [Flags]
-[SuppressMessage ("Naming", "CA1714:Flags enums should have plural names", Justification = "<Pending>")]
-[SuppressMessage ("Naming", "CA1707:Identifiers should not contain underscores", Justification = "<Pending>")]
+[SuppressMessage("Naming", "CA1714:Flags enums should have plural names", Justification = "<Pending>")]
+[SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "<Pending>")]
 public enum AssocF
 {
     Init_NoRemapCLSID = 0x1,

--- a/src/WinPrint.WinForms/GlobalSuppressions.cs
+++ b/src/WinPrint.WinForms/GlobalSuppressions.cs
@@ -6,40 +6,40 @@
 using System.Diagnostics.CodeAnalysis;
 
 [assembly:
-    SuppressMessage ("Globalization", "CA1303:Do not pass literals as localized parameters",
+    SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters",
         Justification = "<Pending>", Scope = "member", Target = "~M:WinPrint.Preview.PageSettingsChanged")]
 [assembly:
-    SuppressMessage ("Globalization", "CA1305:Specify IFormatProvider", Justification = "<Pending>", Scope = "member",
+    SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "<Pending>", Scope = "member",
         Target = "~M:WinPrint.Preview.Preview_Layout(System.Object,System.Windows.Forms.LayoutEventArgs)")]
 [assembly:
-    SuppressMessage ("Globalization", "CA1303:Do not pass literals as localized parameters",
+    SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters",
         Justification = "<Pending>", Scope = "member",
         Target = "~M:WinPrint.Preview.pd_PrintPage(System.Object,System.Drawing.Printing.PrintPageEventArgs)")]
 [assembly:
-    SuppressMessage ("Globalization", "CA1303:Do not pass literals as localized parameters",
+    SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters",
         Justification = "<Pending>", Scope = "member",
         Target = "~M:WinPrint.HeaderFooter.Paint(System.Drawing.Graphics)")]
 [assembly:
-    SuppressMessage ("Globalization", "CA1303:Do not pass literals as localized parameters",
+    SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters",
         Justification = "<Pending>", Scope = "member", Target = "~M:WinPrint.HeaderFooter.#ctor(WinPrint.Document)")]
 [assembly:
-    SuppressMessage ("Globalization", "CA1305:Specify IFormatProvider", Justification = "<Pending>", Scope = "member",
+    SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "<Pending>", Scope = "member",
         Target = "~M:WinPrint.MainWindow.MainWindow_Layout(System.Object,System.Windows.Forms.LayoutEventArgs)")]
 [assembly:
-    SuppressMessage ("Globalization", "CA1303:Do not pass literals as localized parameters",
+    SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters",
         Justification = "<Pending>", Scope = "member", Target = "~M:WinPrint.MainWindow.ShowFilesDialog")]
 [assembly:
-    SuppressMessage ("Globalization", "CA1305:Specify IFormatProvider", Justification = "<Pending>", Scope = "member",
+    SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "<Pending>", Scope = "member",
         Target = "~M:WinPrint.Winforms.MainWindow.landscapeCheckbox_CheckedChanged(System.Object,System.EventArgs)")]
 [assembly:
-    SuppressMessage ("Globalization", "CA1305:Specify IFormatProvider", Justification = "<Pending>", Scope = "member",
+    SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "<Pending>", Scope = "member",
         Target = "~M:WinPrint.Winforms.PrintPreview.PageDown")]
 [assembly:
-    SuppressMessage ("Globalization", "CA1305:Specify IFormatProvider", Justification = "<Pending>", Scope = "member",
+    SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "<Pending>", Scope = "member",
         Target = "~M:WinPrint.Winforms.PrintPreview.PageUp")]
 [assembly:
-    SuppressMessage ("Globalization", "CA1305:Specify IFormatProvider", Justification = "<Pending>", Scope = "member",
+    SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "<Pending>", Scope = "member",
         Target = "~M:WinPrint.Winforms.PrintPreview.ZoomIn")]
 [assembly:
-    SuppressMessage ("Globalization", "CA1305:Specify IFormatProvider", Justification = "<Pending>", Scope = "member",
+    SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "<Pending>", Scope = "member",
         Target = "~M:WinPrint.Winforms.PrintPreview.ZoomOut")]

--- a/src/WinPrint.WinForms/GuiLogSink.cs
+++ b/src/WinPrint.WinForms/GuiLogSink.cs
@@ -13,34 +13,34 @@ namespace WinPrint.WinForms;
 
 public class GuiLogSink : ILogEventSink
 {
-    private static readonly Lazy<GuiLogSink> _instance = new (() => new GuiLogSink ());
+    private static readonly Lazy<GuiLogSink> _instance = new(() => new GuiLogSink());
 
     // Set by Program before log events are emitted.
     public Control OutputWindow = null!;
 
-    public GuiLogSink ()
+    public GuiLogSink()
     {
-        TextFormatter = new MessageTemplateTextFormatter ("{Message:lj}");
+        TextFormatter = new MessageTemplateTextFormatter("{Message:lj}");
     }
 
     public static GuiLogSink Instance => _instance.Value;
 
     public ITextFormatter TextFormatter { get; set; }
 
-    public void Emit (LogEvent logEvent)
+    public void Emit(LogEvent logEvent)
     {
         if (logEvent == null)
         {
-            throw new ArgumentNullException (nameof (logEvent));
+            throw new ArgumentNullException(nameof(logEvent));
         }
 
         if (OutputWindow == null)
         {
-            throw new ArgumentNullException ("GuiLogSink: Output not set");
+            throw new ArgumentNullException("GuiLogSink: Output not set");
         }
 
-        using var strWriter = new StringWriter ();
-        TextFormatter.Format (logEvent, strWriter);
+        using var strWriter = new StringWriter();
+        TextFormatter.Format(logEvent, strWriter);
         try
         {
             string msg = $"{strWriter}";
@@ -67,7 +67,7 @@ public class GuiLogSink : ILogEventSink
                     Exception? ex = logEvent.Exception;
                     if (logEvent.Exception == null)
                     {
-                        ex = new Exception ();
+                        ex = new Exception();
                     }
 
                     OutputWindow.Text = msg;
@@ -83,7 +83,7 @@ public class GuiLogSink : ILogEventSink
         }
         catch (Exception e)
         {
-            Debug.WriteLine (e.Message);
+            Debug.WriteLine(e.Message);
         }
     }
 }

--- a/src/WinPrint.WinForms/MainWindow.cs
+++ b/src/WinPrint.WinForms/MainWindow.cs
@@ -27,11 +27,11 @@ namespace WinPrint.Winforms;
 
 public partial class MainWindow : Form
 {
-    private readonly CancellationTokenSource _cancellationToken = new ();
-    private readonly OpenFileDialog openFileDialog = new ();
+    private readonly CancellationTokenSource _cancellationToken = new();
+    private readonly OpenFileDialog openFileDialog = new();
 
     // The Windows printer document
-    private readonly PrintDocument printDoc = new ();
+    private readonly PrintDocument printDoc = new();
 
     public PrintPreview PrintPreview;
 
@@ -41,9 +41,9 @@ public partial class MainWindow : Form
     // Flag: Has Dispose already been called?
     private bool disposed;
 
-    public MainWindow ()
+    public MainWindow()
     {
-        InitializeComponent ();
+        InitializeComponent();
 
         Icon = Resources.printer_and_fax_w;
 
@@ -57,21 +57,21 @@ public partial class MainWindow : Form
             Padding = dummyButton.Padding,
             Name = "printPreview",
             Size = dummyButton.Size,
-            MinimumSize = new Size (0, 0),
+            MinimumSize = new Size(0, 0),
             TabIndex = 1,
             TabStop = true
         };
         PrintPreview.Click += printPreview_Click;
 
-        Color ();
+        Color();
 
         // This gets the version # from winprint.core.dll
-        versionLabel.Text = $"v{FileVersionInfo.GetVersionInfo (typeof (LogService).Assembly.Location).FileVersion}";
+        versionLabel.Text = $"v{FileVersionInfo.GetVersionInfo(typeof(LogService).Assembly.Location).FileVersion}";
 
         if (LicenseManager.UsageMode != LicenseUsageMode.Designtime)
         {
-            panelRight.Controls.Remove (dummyButton);
-            panelRight.Controls.Add (PrintPreview);
+            panelRight.Controls.Remove(dummyButton);
+            panelRight.Controls.Add(PrintPreview);
             printersCB.Enabled = false;
             paperSizesCB.Enabled = false;
         }
@@ -93,12 +93,12 @@ public partial class MainWindow : Form
     }
 
     private SheetSettings CurrentSheetSettings =>
-        ModelLocator.Current.Settings.Sheets.GetValueOrDefault (ModelLocator.Current.Settings.DefaultSheet.ToString ())
-        ?? throw new InvalidOperationException ("Default sheet settings not found.");
+        ModelLocator.Current.Settings.Sheets.GetValueOrDefault(ModelLocator.Current.Settings.DefaultSheet.ToString())
+        ?? throw new InvalidOperationException("Default sheet settings not found.");
 
-    private void Color ()
+    private void Color()
     {
-        var back = System.Drawing.Color.FromName ("white");
+        var back = System.Drawing.Color.FromName("white");
         Color text = SystemColors.ControlText;
         //printPreview.BackColor = back;
         printersCB.BackColor = back;
@@ -188,7 +188,7 @@ public partial class MainWindow : Form
     ///     Clean up any resources being used.
     /// </summary>
     /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-    protected override void Dispose (bool disposing)
+    protected override void Dispose(bool disposing)
     {
         if (disposed)
         {
@@ -197,21 +197,21 @@ public partial class MainWindow : Form
 
         if (disposing && components != null)
         {
-            components.Dispose ();
+            components.Dispose();
             //if (streamToPrint != null) streamToPrint.Dispose();
             if (printDoc != null)
             {
-                printDoc.Dispose ();
+                printDoc.Dispose();
             }
 
             if (PrintPreview != null)
             {
-                PrintPreview.Dispose ();
+                PrintPreview.Dispose();
             }
         }
 
         disposed = true;
-        base.Dispose (disposing);
+        base.Dispose(disposing);
     }
 
     /// <summary>
@@ -219,16 +219,16 @@ public partial class MainWindow : Form
     ///     This should only be called once
     /// </summary>
     // TODO: Refactor PropertyChanged lambdas to be functions so they can be -=
-    private void SetupSheetViewModelNotifications ()
+    private void SetupSheetViewModelNotifications()
     {
         //LogService.TraceMessage();
         if (PrintPreview.SheetViewModel != null)
         {
-            LogService.TraceMessage ("SetupSheetViewModelNotifications was already called");
+            LogService.TraceMessage("SetupSheetViewModelNotifications was already called");
             return;
         }
 
-        PrintPreview.SheetViewModel = new SheetViewModel ();
+        PrintPreview.SheetViewModel = new SheetViewModel();
         PrintPreview.SheetViewModel.PropertyChanged += PropertyChangedEventHandler;
         PrintPreview.SheetViewModel.SettingsChanged += SettingsChangedEventHandler;
         PrintPreview.SheetViewModel.PageSettingsSet += PageSettingsSetEventHandler;
@@ -236,42 +236,42 @@ public partial class MainWindow : Form
         PrintPreview.SheetViewModel.ReadyChanged += ReadyChangedEventHandler;
     }
 
-    private void FileLoadedEventHandler (object? sender, bool loading)
+    private void FileLoadedEventHandler(object? sender, bool loading)
     {
         if (InvokeRequired)
         {
-            BeginInvoke ((Action)(() => FileLoadedEventHandler (sender, loading)));
+            BeginInvoke((Action)(() => FileLoadedEventHandler(sender, loading)));
         }
         else
         {
-            LogService.TraceMessage ($"{loading}");
+            LogService.TraceMessage($"{loading}");
             if (loading)
             {
             }
         }
     }
 
-    private void PageSettingsSetEventHandler (object? sender, EventArgs e)
+    private void PageSettingsSetEventHandler(object? sender, EventArgs e)
     {
         if (InvokeRequired)
         {
-            BeginInvoke ((Action)(() => PageSettingsSetEventHandler (sender, e)));
+            BeginInvoke((Action)(() => PageSettingsSetEventHandler(sender, e)));
         }
         else
         {
-            LogService.TraceMessage ();
+            LogService.TraceMessage();
         }
     }
 
-    private void ReadyChangedEventHandler (object? sender, bool ready)
+    private void ReadyChangedEventHandler(object? sender, bool ready)
     {
         if (InvokeRequired)
         {
-            BeginInvoke ((Action)(() => ReadyChangedEventHandler (sender, ready)));
+            BeginInvoke((Action)(() => ReadyChangedEventHandler(sender, ready)));
         }
         else
         {
-            LogService.TraceMessage ($"{ready}");
+            LogService.TraceMessage($"{ready}");
             printButton.Enabled = ready;
 
             if (!ready)
@@ -279,26 +279,26 @@ public partial class MainWindow : Form
                 return;
             }
 
-            if (string.IsNullOrEmpty (activeFile))
+            if (string.IsNullOrEmpty(activeFile))
             {
-                PrintPreview.Invalidate ();
+                PrintPreview.Invalidate();
                 PrintPreview.Text = Resources.HelloMsg;
             }
             else
             {
                 // Document is loaded and flowed. We're ready to preview and/or pring.
                 PrintPreview.CurrentSheet = 1;
-                PrintPreview.Invalidate ();
+                PrintPreview.Invalidate();
                 PrintPreview.Text = "";
             }
         }
     }
 
-    private void PropertyChangedEventHandler (object? sender, PropertyChangedEventArgs e)
+    private void PropertyChangedEventHandler(object? sender, PropertyChangedEventArgs e)
     {
         if (InvokeRequired)
         {
-            BeginInvoke ((Action)(() => PropertyChangedEventHandler (sender, e)));
+            BeginInvoke((Action)(() => PropertyChangedEventHandler(sender, e)));
         }
         else
         {
@@ -306,15 +306,15 @@ public partial class MainWindow : Form
             switch (e.PropertyName)
             {
                 case "Landscape":
-                    LogService.TraceMessage ($"  Checking checkbox: {CurrentSheetSettings.Landscape}");
+                    LogService.TraceMessage($"  Checking checkbox: {CurrentSheetSettings.Landscape}");
                     landscapeCheckbox.Checked = PrintPreview.SheetViewModel.Landscape;
                     break;
 
                 case "Header":
                     headerTextBox.Text = PrintPreview.SheetViewModel.Header.Text;
                     enableHeader.Checked = PrintPreview.SheetViewModel.Header.Enabled;
-                    headerFooterFontLink.Text = PrintPreview.SheetViewModel.Header.Font?.ToString () ??
-                                                throw new InvalidOperationException ("Header font settings not found.");
+                    headerFooterFontLink.Text = PrintPreview.SheetViewModel.Header.Font?.ToString() ??
+                                                throw new InvalidOperationException("Header font settings not found.");
                     break;
 
                 case "Footer":
@@ -329,9 +329,9 @@ public partial class MainWindow : Form
                     bottomMargin.Value = PrintPreview.SheetViewModel.Margins.Bottom / 100M;
 
                     // Keep PrintDocument updated for WinForms.PrintPreview
-                    var m = PrintPreview.SheetViewModel.Margins;
+                    PrintMargins m = PrintPreview.SheetViewModel.Margins;
                     printDoc.PrinterSettings.DefaultPageSettings.Margins =
-                        new Margins (m.Left, m.Right, m.Top, m.Bottom);
+                        new Margins(m.Left, m.Right, m.Top, m.Bottom);
                     break;
 
                 case "PageSeparator":
@@ -371,8 +371,8 @@ public partial class MainWindow : Form
                     break;
 
                 case "ContentSettings":
-                    contentFontLink.Text = PrintPreview.SheetViewModel.ContentSettings.Font?.ToString () ??
-                                           throw new InvalidOperationException ("Content font settings not found.");
+                    contentFontLink.Text = PrintPreview.SheetViewModel.ContentSettings.Font?.ToString() ??
+                                           throw new InvalidOperationException("Content font settings not found.");
                     lineNumbers.Checked = PrintPreview.SheetViewModel.ContentSettings.LineNumbers;
                     //lineNumberSeparator.Checked = printPreview.SheetViewModel.ContentSettings.lineNumberSeparator;
                     break;
@@ -391,23 +391,23 @@ public partial class MainWindow : Form
 
 
                 default:
-                    throw new InvalidOperationException ($"Property Change Not Handled: {e.PropertyName}");
+                    throw new InvalidOperationException($"Property Change Not Handled: {e.PropertyName}");
             }
         }
     }
 
-    private void SettingsChangedEventHandler (object? o, SheetViewModelSettingsChangedEvent e)
+    private void SettingsChangedEventHandler(object? o, SheetViewModelSettingsChangedEvent e)
     {
         if (InvokeRequired)
         {
-            BeginInvoke ((Action)(() => SettingsChangedEventHandler (o, e)));
+            BeginInvoke((Action)(() => SettingsChangedEventHandler(o, e)));
         }
         else
         {
-            LogService.TraceMessage ($"{e.Reflow}");
+            LogService.TraceMessage($"{e.Reflow}");
             if (e.Reflow)
             {
-                LoadFile ();
+                LoadFile();
             }
             else
             {
@@ -420,41 +420,41 @@ public partial class MainWindow : Form
                 //else {
                 //    printPreview.Invalidate();
                 //}
-                PrintPreview.Invalidate ();
+                PrintPreview.Invalidate();
             }
         }
     }
 
-    private void MainWindow_Load (object? sender, EventArgs e)
+    private void MainWindow_Load(object? sender, EventArgs e)
     {
         // Check for updates
-        LogService.TraceMessage ("First reference to UpdateService");
+        LogService.TraceMessage("First reference to UpdateService");
         if (ServiceLocator.Current.UpdateService == null)
         {
-            _ = MessageBox.Show (Resources.UpdateServiceFailure);
+            _ = MessageBox.Show(Resources.UpdateServiceFailure);
             return;
         }
 
         ServiceLocator.Current.UpdateService.GotLatestVersion += UpdateService_GotLatestVersion;
         ServiceLocator.Current.UpdateService.DownloadComplete += UpdateService_DownloadComplete;
-        ServiceLocator.Current.UpdateService.GetLatestVersionAsync (_cancellationToken.Token).ConfigureAwait (false);
+        ServiceLocator.Current.UpdateService.GetLatestVersionAsync(_cancellationToken.Token).ConfigureAwait(false);
 
         // Load settings by referencing ModelLocator.Current
-        LogService.TraceMessage ("First reference to ModelLocator.Current.Settings");
+        LogService.TraceMessage("First reference to ModelLocator.Current.Settings");
         if (ModelLocator.Current.Settings == null)
         {
-            MessageBox.Show (Resources.SettingsLoadMsg);
+            MessageBox.Show(Resources.SettingsLoadMsg);
             return;
         }
 
         if (ModelLocator.Current.Settings.Size != null)
         {
-            Size = new Size (ModelLocator.Current.Settings.Size.Width, ModelLocator.Current.Settings.Size.Height);
+            Size = new Size(ModelLocator.Current.Settings.Size.Width, ModelLocator.Current.Settings.Size.Height);
         }
 
         if (ModelLocator.Current.Settings.Location != null)
         {
-            Location = new Point (ModelLocator.Current.Settings.Location.X, ModelLocator.Current.Settings.Location.Y);
+            Location = new Point(ModelLocator.Current.Settings.Location.X, ModelLocator.Current.Settings.Location.Y);
         }
 
         WindowState = (FormWindowState)ModelLocator.Current.Settings.WindowState;
@@ -464,12 +464,12 @@ public partial class MainWindow : Form
             if (e.KeyCode == Keys.F5)
             {
                 //printPreview.Invalidate(true);
-                Log.Debug ("-------- F5 ---------");
+                Log.Debug("-------- F5 ---------");
 
-                ServiceLocator.Current.TelemetryService.TrackEvent ("Refresh");
+                ServiceLocator.Current.TelemetryService.TrackEvent("Refresh");
 
                 // TODO: Refactor threading
-                Task.Run (() => Start ());
+                Task.Run(() => Start());
             }
         };
 
@@ -477,16 +477,16 @@ public partial class MainWindow : Form
         Dictionary<string, SheetSettings> sheets = ModelLocator.Current.Settings.Sheets;
 
         // Load Language/ContentType mapping
-        LogService.TraceMessage (
+        LogService.TraceMessage(
             $"{ModelLocator.Current.FileTypeMapping.ContentTypes.Count} languages, {ModelLocator.Current.FileTypeMapping.FilesAssociations.Count} file assocations");
 
-        ModelLocator.Current.Settings.PropertyChanged += (s, e) => BeginInvoke ((Action)(() =>
+        ModelLocator.Current.Settings.PropertyChanged += (s, e) => BeginInvoke((Action)(() =>
         {
-            LogService.TraceMessage ($"Settings.PropertyChanged: {e.PropertyName}");
+            LogService.TraceMessage($"Settings.PropertyChanged: {e.PropertyName}");
             switch (e.PropertyName)
             {
                 case "DefaultSheet":
-                    SheetChanged ();
+                    SheetChanged();
                     break;
             }
         }));
@@ -495,13 +495,13 @@ public partial class MainWindow : Form
         comboBoxSheet.ValueMember = "Key";
         foreach (KeyValuePair<string, SheetSettings> s in sheets)
         {
-            comboBoxSheet.Items.Add (new KeyValuePair<string, string> (s.Key, s.Value.Name));
+            comboBoxSheet.Items.Add(new KeyValuePair<string, string>(s.Key, s.Value.Name));
         }
 
         // Select default printer and paper size
         foreach (string printer in PrinterSettings.InstalledPrinters)
         {
-            printersCB.Items.Add (printer);
+            printersCB.Items.Add(printer);
             if (printDoc.PrinterSettings.IsDefaultPrinter && printer == printDoc.PrinterSettings.PrinterName)
             {
                 printersCB.Text = printDoc.PrinterSettings.PrinterName;
@@ -509,18 +509,18 @@ public partial class MainWindow : Form
         }
 
         // --p
-        if (!string.IsNullOrEmpty (ModelLocator.Current.Options.Printer))
+        if (!string.IsNullOrEmpty(ModelLocator.Current.Options.Printer))
         {
             printDoc.PrinterSettings.PrinterName = printersCB.Text = ModelLocator.Current.Options.Printer;
         }
 
         foreach (PaperSize ps in printDoc.PrinterSettings.PaperSizes)
         {
-            paperSizesCB.Items.Add (ps.PaperName);
+            paperSizesCB.Items.Add(ps.PaperName);
         }
 
         // --z
-        if (!string.IsNullOrEmpty (ModelLocator.Current.Options.PaperSize))
+        if (!string.IsNullOrEmpty(ModelLocator.Current.Options.PaperSize))
         {
             paperSizesCB.Text = ModelLocator.Current.Options.PaperSize;
         }
@@ -534,7 +534,7 @@ public partial class MainWindow : Form
         paperSizesCB.Enabled = true;
 
         // Create sheet view model & wire up notifications
-        SetupSheetViewModelNotifications ();
+        SetupSheetViewModelNotifications();
 
         if (ModelLocator.Current.Options.FromPage != 0)
         {
@@ -551,14 +551,14 @@ public partial class MainWindow : Form
         // --s
         // Select default Sheet 
         SheetSettings newSheet = CurrentSheetSettings;
-        if (!string.IsNullOrEmpty (ModelLocator.Current.Options.Sheet))
+        if (!string.IsNullOrEmpty(ModelLocator.Current.Options.Sheet))
         {
-            newSheet = PrintPreview.SheetViewModel.FindSheet (ModelLocator.Current.Options.Sheet, out string sheetID);
+            newSheet = PrintPreview.SheetViewModel.FindSheet(ModelLocator.Current.Options.Sheet, out string sheetID);
         }
 
         comboBoxSheet.Text = newSheet.Name;
         // This will cause a flurry of property change notifications, setting all UI elements
-        PrintPreview.SheetViewModel.SetSheet (newSheet);
+        PrintPreview.SheetViewModel.SetSheet(newSheet);
 
         // Must set landscape after printer/paper selection
         // --l and --o
@@ -574,38 +574,38 @@ public partial class MainWindow : Form
 
         // Override content-type
         // --t
-        if (!string.IsNullOrEmpty (ModelLocator.Current.Options.ContentType))
+        if (!string.IsNullOrEmpty(ModelLocator.Current.Options.ContentType))
         {
             // TODO: (nothing?)
         }
 
-        PrintPreview.Select ();
-        PrintPreview.Focus ();
+        PrintPreview.Select();
+        PrintPreview.Focus();
         //this.Cursor = Cursors.Default;
 
-        if (ModelLocator.Current.Options.Files != null && ModelLocator.Current.Options.Files.ToList ().Count > 0)
+        if (ModelLocator.Current.Options.Files != null && ModelLocator.Current.Options.Files.ToList().Count > 0)
         {
-            activeFile = ModelLocator.Current.Options.Files.ToList ()[0];
+            activeFile = ModelLocator.Current.Options.Files.ToList()[0];
         }
 
-        if (ModelLocator.Current.Settings.DefaultSyntaxHighlighterCteNameClassName.Equals (nameof (AnsiCte),
+        if (ModelLocator.Current.Settings.DefaultSyntaxHighlighterCteNameClassName.Equals(nameof(AnsiCte),
                 StringComparison.OrdinalIgnoreCase))
         {
             // Verify Pygments is installed when the legacy Pygments-backed CTE is configured.
-            (bool installed, string message) = ServiceLocator.Current.PygmentsConverterService.CheckInstall ();
+            (bool installed, string message) = ServiceLocator.Current.PygmentsConverterService.CheckInstall();
             if (!installed)
             {
-                MessageBox.Show (message, "Warning");
+                MessageBox.Show(message, "Warning");
             }
         }
 
         // By running this on a different thread, we enable the main window to show
         // as quickly as possible; making startup seem faster.
         //Task.Run(() => Start());
-        Start ();
+        Start();
     }
 
-    private void UpdateService_DownloadComplete (object? sender, string path)
+    private void UpdateService_DownloadComplete(object? sender, string path)
     {
         //Process.Start(ServiceLocator.Current.UpdateService.ReleasePageUri.AbsoluteUri);
 #if DEBUG
@@ -625,160 +625,160 @@ public partial class MainWindow : Form
 
         try
         {
-            p.Start ();
+            p.Start();
         }
         catch (Win32Exception we)
         {
-            Log.Information (
-                $"{GetType ().Name}: '{p.StartInfo.FileName} {p.StartInfo.Arguments}' failed to run with error: {we.Message}");
+            Log.Information(
+                $"{GetType().Name}: '{p.StartInfo.FileName} {p.StartInfo.Arguments}' failed to run with error: {we.Message}");
         }
 
-        BeginInvoke ((Action)(() => Close ()));
+        BeginInvoke((Action)(() => Close()));
     }
 
-    private void UpdateService_GotLatestVersion (object? sender, Version version)
+    private void UpdateService_GotLatestVersion(object? sender, Version version)
     {
         if (InvokeRequired)
         {
-            BeginInvoke ((Action)(() => UpdateService_GotLatestVersion (sender, version)));
+            BeginInvoke((Action)(() => UpdateService_GotLatestVersion(sender, version)));
         }
         else
         {
-            if (version == null && !string.IsNullOrWhiteSpace (ServiceLocator.Current.UpdateService.ErrorMessage))
+            if (version == null && !string.IsNullOrWhiteSpace(ServiceLocator.Current.UpdateService.ErrorMessage))
             {
-                Log.Information (
+                Log.Information(
                     $"Could not access tig.github.io/winprint to see if a newer version is available. {ServiceLocator.Current.UpdateService.ErrorMessage}");
             }
-            else if (ServiceLocator.Current.UpdateService.CompareVersions () < 0)
+            else if (ServiceLocator.Current.UpdateService.CompareVersions() < 0)
             {
-                Log.Information ("------------------------------------------------");
-                Log.Information ($"A newer version of winprint ({version}) is available at");
-                Log.Information ($"   {ServiceLocator.Current.UpdateService.ReleasePageUri}");
-                Log.Information ("------------------------------------------------");
+                Log.Information("------------------------------------------------");
+                Log.Information($"A newer version of winprint ({version}) is available at");
+                Log.Information($"   {ServiceLocator.Current.UpdateService.ReleasePageUri}");
+                Log.Information("------------------------------------------------");
 
-                using var dlg = new UpdateDialog ();
-                dlg.ShowDialog (this);
+                using var dlg = new UpdateDialog();
+                dlg.ShowDialog(this);
             }
-            else if (ServiceLocator.Current.UpdateService.CompareVersions () > 0)
+            else if (ServiceLocator.Current.UpdateService.CompareVersions() > 0)
             {
-                Log.Information (
+                Log.Information(
                     $"You are are running a MORE recent version than can be found at tig.github.io/winprint ({version})");
             }
             else
             {
-                Log.Information ("You are running the most recent version of winprint");
+                Log.Information("You are running the most recent version of winprint");
             }
         }
     }
 
-    private void Start ()
+    private void Start()
     {
-        LogService.TraceMessage ();
+        LogService.TraceMessage();
 
-        if (string.IsNullOrEmpty (activeFile))
+        if (string.IsNullOrEmpty(activeFile))
         {
             // If a file's not been set, juice the print preview and show the file open dialog box
-            LoadFile ();
+            LoadFile();
             //ShowFilesDialog();
         }
         else
         {
-            LoadFile ();
+            LoadFile();
         }
     }
 
-    private void LoadFile ()
+    private void LoadFile()
     {
         if (InvokeRequired)
         {
-            BeginInvoke ((Action)(() => LoadFile ()));
+            BeginInvoke((Action)(() => LoadFile()));
         }
         else
         {
             // Reset View Model
-            PrintPreview.SheetViewModel.Reset ();
-            PrintPreview.Invalidate ();
+            PrintPreview.SheetViewModel.Reset();
+            PrintPreview.Invalidate();
             PrintPreview.Text = Resources.LoadingMsg;
 
             // On another thread 
             //    - load file
             //    - set printer page settings
             //    - reflow
-            Task.Run (async () =>
+            Task.Run(async () =>
             {
                 string stage = "Loading";
                 string fileToPrint = activeFile;
                 try
                 {
-                    BeginInvoke ((Action)(() => { PrintPreview.Text = $"{stage}..."; }));
+                    BeginInvoke((Action)(() => { PrintPreview.Text = $"{stage}..."; }));
                     // This is an IO bound operation. 
                     // TODO: This does not need to run on another thread if we are using async/await correctly
                     // Core requires a fully qualified path. If FileName was provided, ensure it's fully qualified.
                     // Note, Title stays as was provided via -FileName or -Title
-                    if (!string.IsNullOrEmpty (fileToPrint) && !Path.IsPathFullyQualified (fileToPrint))
+                    if (!string.IsNullOrEmpty(fileToPrint) && !Path.IsPathFullyQualified(fileToPrint))
                     {
-                        fileToPrint = Path.GetFullPath (fileToPrint, Directory.GetCurrentDirectory ());
+                        fileToPrint = Path.GetFullPath(fileToPrint, Directory.GetCurrentDirectory());
                     }
 
                     await PrintPreview.SheetViewModel
-                        .LoadFileAsync (fileToPrint, ModelLocator.Current.Options.ContentType).ConfigureAwait (false);
+                        .LoadFileAsync(fileToPrint, ModelLocator.Current.Options.ContentType).ConfigureAwait(false);
 
                     // Set landscape. This causes other DefaultPageSettings to change
                     // These are CPU bound operations. 
                     // TODO: Do not use async/await for CPU bound operations https://docs.microsoft.com/en-us/dotnet/standard/async-in-depth
                     stage = "Getting Printer Page Settings";
-                    BeginInvoke ((Action)(() => { PrintPreview.Text = $"{stage}..."; }));
+                    BeginInvoke((Action)(() => { PrintPreview.Text = $"{stage}..."; }));
                     printDoc.DefaultPageSettings.Landscape = PrintPreview.SheetViewModel.Landscape;
-                    PrintPreview.SheetViewModel.SetPrinterPageSettings (printDoc.DefaultPageSettings);
+                    PrintPreview.SheetViewModel.SetPrinterPageSettings(printDoc.DefaultPageSettings);
 
 
                     stage = "Rendering";
-                    BeginInvoke ((Action)(() => { PrintPreview.Text = $"{stage}..."; }));
-                    await PrintPreview.SheetViewModel.ReflowAsync ().ConfigureAwait (false);
+                    BeginInvoke((Action)(() => { PrintPreview.Text = $"{stage}..."; }));
+                    await PrintPreview.SheetViewModel.ReflowAsync().ConfigureAwait(false);
                 }
                 catch (DirectoryNotFoundException dnfe)
                 {
-                    Log.Error (dnfe, "File Not Found");
-                    ShowMessage ($"{stage}: {dnfe.Message}");
+                    Log.Error(dnfe, "File Not Found");
+                    ShowMessage($"{stage}: {dnfe.Message}");
                 }
                 catch (FileNotFoundException fnfe)
                 {
-                    Log.Error (fnfe, "File Not Found");
-                    ShowMessage ($"{stage}: {fnfe.Message}");
+                    Log.Error(fnfe, "File Not Found");
+                    ShowMessage($"{stage}: {fnfe.Message}");
                     //fileButton_Click(null, null);
                 }
                 catch (InvalidOperationException ioe)
                 {
-                    ServiceLocator.Current.TelemetryService.TrackException (ioe);
-                    Log.Error (ioe, "Error Operation {file}", fileToPrint);
-                    ShowMessage ($"{stage}: {ioe.Message}");
+                    ServiceLocator.Current.TelemetryService.TrackException(ioe);
+                    Log.Error(ioe, "Error Operation {file}", fileToPrint);
+                    ShowMessage($"{stage}: {ioe.Message}");
                     //                fileButton_Click(null, null);
                 }
 #pragma warning disable CA1031 // Do not catch general exception types
                 catch (Exception e)
                 {
 #pragma warning restore CA1031 // Do not catch general exception types
-                    ServiceLocator.Current.TelemetryService.TrackException (e);
-                    Log.Error (e, "Exception {file}", fileToPrint);
-                    ShowMessage ($"{stage}: Exception: {e.Message}{Environment.NewLine}({fileToPrint})");
+                    ServiceLocator.Current.TelemetryService.TrackException(e);
+                    Log.Error(e, "Exception {file}", fileToPrint);
+                    ShowMessage($"{stage}: Exception: {e.Message}{Environment.NewLine}({fileToPrint})");
                 }
                 finally
                 {
                     // Set Loading to false in case of an error
                     //printPreview.SheetViewModel.Loading = false;
                     //printPreview.SheetViewModel.Ready = false;
-                    PrintPreview.Select ();
-                    PrintPreview.Focus ();
+                    PrintPreview.Select();
+                    PrintPreview.Focus();
                 }
             });
         }
     }
 
-    private void ShowMessage (string message)
+    private void ShowMessage(string message)
     {
         if (InvokeRequired)
         {
-            BeginInvoke ((Action)(() => ShowMessage (message)));
+            BeginInvoke((Action)(() => ShowMessage(message)));
         }
         else
         {
@@ -786,35 +786,35 @@ public partial class MainWindow : Form
         }
     }
 
-    private void ShowFilesDialog ()
+    private void ShowFilesDialog()
     {
         if (InvokeRequired)
         {
-            BeginInvoke ((Action)(() => ShowFilesDialog ()));
+            BeginInvoke((Action)(() => ShowFilesDialog()));
         }
         else
         {
-            LogService.TraceMessage ();
-            ServiceLocator.Current.TelemetryService.TrackEvent ("Show Files Dialog");
+            LogService.TraceMessage();
+            ServiceLocator.Current.TelemetryService.TrackEvent("Show Files Dialog");
             openFileDialog.Filter = Resources.FileOpenTemplate;
             openFileDialog.FilterIndex = 3;
             //openFileDialog.RestoreDirectory = true;
-            if (openFileDialog.ShowDialog (this) == DialogResult.OK)
+            if (openFileDialog.ShowDialog(this) == DialogResult.OK)
             {
-                activeFile = openFileDialog.FileNames.ToList ()[0];
-                LoadFile ();
+                activeFile = openFileDialog.FileNames.ToList()[0];
+                LoadFile();
             }
         }
     }
 
-    private void SheetChanged ()
+    private void SheetChanged()
     {
-        LogService.TraceMessage ();
+        LogService.TraceMessage();
         SheetSettings newSheet = CurrentSheetSettings;
         comboBoxSheet.Text = newSheet.Name;
-        PrintPreview.SheetViewModel.SetSheet (newSheet);
+        PrintPreview.SheetViewModel.SetSheet(newSheet);
         //SheetSettingsChanged();
-        LoadFile ();
+        LoadFile();
     }
 
     /// <summary>
@@ -829,7 +829,7 @@ public partial class MainWindow : Form
 
     //    });
     //}
-    private void MainWindow_FormClosing (object? sender, FormClosingEventArgs e)
+    private void MainWindow_FormClosing(object? sender, FormClosingEventArgs e)
     {
         if (ModelLocator.Current.Settings is null)
         {
@@ -843,29 +843,29 @@ public partial class MainWindow : Form
         // Save Window state
         if (WindowState == FormWindowState.Normal)
         {
-            ModelLocator.Current.Settings.Size = new WindowSize (Size.Width, Size.Height);
-            ModelLocator.Current.Settings.Location = new WindowLocation (Location.X, Location.Y);
+            ModelLocator.Current.Settings.Size = new WindowSize(Size.Width, Size.Height);
+            ModelLocator.Current.Settings.Location = new WindowLocation(Location.X, Location.Y);
         }
         else
         {
-            ModelLocator.Current.Settings.Size = new WindowSize (RestoreBounds.Width, RestoreBounds.Height);
-            ModelLocator.Current.Settings.Location = new WindowLocation (RestoreBounds.X, RestoreBounds.Y);
+            ModelLocator.Current.Settings.Size = new WindowSize(RestoreBounds.Width, RestoreBounds.Height);
+            ModelLocator.Current.Settings.Location = new WindowLocation(RestoreBounds.X, RestoreBounds.Y);
         }
 
         ModelLocator.Current.Settings.WindowState = (Core.Models.FormWindowState)WindowState;
 
-        ServiceLocator.Current.TelemetryService.TrackEvent ("Form Closing",
+        ServiceLocator.Current.TelemetryService.TrackEvent("Form Closing",
             new Dictionary<string, string?>
             {
-                { "windowState", ModelLocator.Current.Settings.WindowState.ToString () },
+                { "windowState", ModelLocator.Current.Settings.WindowState.ToString() },
                 { "size", $"{ModelLocator.Current.Settings.Size.Width}x{ModelLocator.Current.Settings.Size.Height}" },
                 { "location", $"{ModelLocator.Current.Settings.Location.X}x{ModelLocator.Current.Settings.Location.Y}" }
             });
 
-        ServiceLocator.Current.SettingsService.SaveSettings (ModelLocator.Current.Settings);
+        ServiceLocator.Current.SettingsService.SaveSettings(ModelLocator.Current.Settings);
     }
 
-    private void MainWindow_Layout (object? sender, LayoutEventArgs e)
+    private void MainWindow_Layout(object? sender, LayoutEventArgs e)
     {
         // This event is raised once at startup with the AffectedControl
         // and AffectedProperty properties on the LayoutEventArgs as null. 
@@ -880,39 +880,39 @@ public partial class MainWindow : Form
         }
     }
 
-    private void landscapeCheckbox_CheckedChanged (object? sender, EventArgs e)
+    private void landscapeCheckbox_CheckedChanged(object? sender, EventArgs e)
     {
-        LogService.TraceMessage ($"{landscapeCheckbox.Checked}");
+        LogService.TraceMessage($"{landscapeCheckbox.Checked}");
         CurrentSheetSettings.Landscape =
             printDoc.DefaultPageSettings.Landscape =
                 landscapeCheckbox.Checked;
 
-        ServiceLocator.Current.TelemetryService.TrackEvent ("landscapeCheckbox_CheckedChanged",
+        ServiceLocator.Current.TelemetryService.TrackEvent("landscapeCheckbox_CheckedChanged",
             new Dictionary<string, string?>
             {
-                { "landscape", landscapeCheckbox.Checked.ToString () }
+                { "landscape", landscapeCheckbox.Checked.ToString() }
             });
     }
 
-    private void headerTextBox_TextChanged (object? sender, EventArgs e)
+    private void headerTextBox_TextChanged(object? sender, EventArgs e)
     {
         CurrentSheetSettings.Header.Text = headerTextBox.Text;
 
-        ServiceLocator.Current.TelemetryService.TrackEvent ("headerTextBox_TextChanged");
+        ServiceLocator.Current.TelemetryService.TrackEvent("headerTextBox_TextChanged");
     }
 
-    private void footerTextBox_TextChanged (object? sender, EventArgs e)
+    private void footerTextBox_TextChanged(object? sender, EventArgs e)
     {
         CurrentSheetSettings.Footer.Text = footerTextBox.Text;
 
-        ServiceLocator.Current.TelemetryService.TrackEvent ("footerTextBox_TextChanged");
+        ServiceLocator.Current.TelemetryService.TrackEvent("footerTextBox_TextChanged");
     }
 
-    private void printersCB_SelectedIndexChanged (object? sender, EventArgs e)
+    private void printersCB_SelectedIndexChanged(object? sender, EventArgs e)
     {
         if (printersCB.Enabled)
         {
-            LogService.TraceMessage ("printersCB_SelectedIndexChanged");
+            LogService.TraceMessage("printersCB_SelectedIndexChanged");
             if (printersCB.SelectedItem is not string selectedPrinter)
             {
                 return;
@@ -920,19 +920,19 @@ public partial class MainWindow : Form
 
             printDoc.PrinterSettings.PrinterName = selectedPrinter;
 
-            ServiceLocator.Current.TelemetryService.TrackEvent ("printersCB_SelectedIndexChanged",
+            ServiceLocator.Current.TelemetryService.TrackEvent("printersCB_SelectedIndexChanged",
                 new Dictionary<string, string?>
                 {
                     { "printerName", printDoc.PrinterSettings.PrinterName }
                 });
 
-            paperSizesCB.Items.Clear ();
+            paperSizesCB.Items.Clear();
             foreach (PaperSize ps in printDoc.PrinterSettings.PaperSizes)
             {
-                paperSizesCB.Items.Add (ps.PaperName);
+                paperSizesCB.Items.Add(ps.PaperName);
             }
 
-            ServiceLocator.Current.TelemetryService.TrackEvent ("printersCB_SelectedIndexChanged",
+            ServiceLocator.Current.TelemetryService.TrackEvent("printersCB_SelectedIndexChanged",
                 new Dictionary<string, string?>
                 {
                     { "printerName", printDoc.PrinterSettings.PrinterName }
@@ -942,77 +942,77 @@ public partial class MainWindow : Form
         }
     }
 
-    private void paperSizesCB_SelectedIndexChanged (object? sender, EventArgs e)
+    private void paperSizesCB_SelectedIndexChanged(object? sender, EventArgs e)
     {
         if (printersCB.Enabled)
         {
-            LogService.TraceMessage ("paperSizesCB_SelectedIndexChanged");
+            LogService.TraceMessage("paperSizesCB_SelectedIndexChanged");
             // Set the paper size based upon the selection in the combo box.
             if (paperSizesCB.SelectedIndex != -1)
             {
                 printDoc.DefaultPageSettings.PaperSize =
                     printDoc.PrinterSettings.PaperSizes[paperSizesCB.SelectedIndex];
-                ServiceLocator.Current.TelemetryService.TrackEvent ("paperSizesCB_SelectedIndexChanged",
+                ServiceLocator.Current.TelemetryService.TrackEvent("paperSizesCB_SelectedIndexChanged",
                     new Dictionary<string, string?>
                     {
                         { "paperName", printDoc.DefaultPageSettings.PaperSize.PaperName }
                     });
             }
 
-            LoadFile ();
+            LoadFile();
         }
     }
 
-    [SuppressMessage ("Design", "CA1031:Do not catch general exception types", Justification = "<Pending>")]
-    private async void printButton_Click (object? sender, EventArgs args)
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "<Pending>")]
+    private async void printButton_Click(object? sender, EventArgs args)
     {
-        using var print = new Print ();
+        using var print = new Print();
         // TODO: It's hokey that Landscape is the only printer setting that's treated specially
         // 
         print.PrintDocument.DefaultPageSettings.Landscape = landscapeCheckbox.Checked;
-        print.SheetViewModel.SetSheet (CurrentSheetSettings);
+        print.SheetViewModel.SetSheet(CurrentSheetSettings);
 
         try
         {
-            ShowMessage ("Preparing to print..");
+            ShowMessage("Preparing to print..");
             await print.SheetViewModel
-                .LoadFileAsync (PrintPreview.SheetViewModel.File, ModelLocator.Current.Options.ContentType)
-                .ConfigureAwait (false);
+                .LoadFileAsync(PrintPreview.SheetViewModel.File, ModelLocator.Current.Options.ContentType)
+                .ConfigureAwait(false);
 
-            print.SetPrinter (printDoc.PrinterSettings.PrinterName);
-            print.SetPaperSize (printDoc.DefaultPageSettings.PaperSize.PaperName);
+            print.SetPrinter(printDoc.PrinterSettings.PrinterName);
+            print.SetPaperSize(printDoc.DefaultPageSettings.PaperSize.PaperName);
         }
         catch (FileNotFoundException fnfe)
         {
-            Log.Error (fnfe, "File Not Found");
-            ShowMessage ($"{fnfe.Message}");
+            Log.Error(fnfe, "File Not Found");
+            ShowMessage($"{fnfe.Message}");
             return;
         }
         catch (InvalidOperationException ioe)
         {
-            ServiceLocator.Current.TelemetryService.TrackException (ioe);
-            Log.Error (ioe, "Error Operation {file}", activeFile);
-            ShowMessage ($"{ioe.Message}");
+            ServiceLocator.Current.TelemetryService.TrackException(ioe);
+            Log.Error(ioe, "Error Operation {file}", activeFile);
+            ShowMessage($"{ioe.Message}");
             return;
         }
 #pragma warning disable CA1031 // Do not catch general exception types
         catch (Exception e)
         {
 #pragma warning restore CA1031 // Do not catch general exception types
-            ServiceLocator.Current.TelemetryService.TrackException (e);
-            Log.Error (e, "Exception {file}", activeFile);
-            ShowMessage ($"Exception: {e.Message}{Environment.NewLine}({activeFile})");
+            ServiceLocator.Current.TelemetryService.TrackException(e);
+            Log.Error(e, "Exception {file}", activeFile);
+            ShowMessage($"Exception: {e.Message}{Environment.NewLine}({activeFile})");
             return;
         }
 
-        if (!int.TryParse (fromText.Text, out int from))
+        if (!int.TryParse(fromText.Text, out int from))
         {
             from = 0;
         }
 
         // Ideally we'd get NumSheets from print.SheetSVM but that would cause a
         // un-needed Reflow. So use the printPreview VM.
-        if (!int.TryParse (toText.Text, out int to))
+        if (!int.TryParse(toText.Text, out int to))
         {
             to = 0; // printPreview.SheetViewModel.NumSheets;
         }
@@ -1026,7 +1026,7 @@ public partial class MainWindow : Form
 
         if (ModelLocator.Current.Settings.ShowPrintDialog)
         {
-            BeginInvoke (async () =>
+            BeginInvoke(async () =>
             {
                 using var printDialog = new PrintDialog
                 {
@@ -1041,7 +1041,7 @@ public partial class MainWindow : Form
                 printDialog.PrinterSettings.ToPage = print.PrintDocument.PrinterSettings.ToPage;
 
                 //If the result is OK then print the document.
-                if (printDialog.ShowDialog () == DialogResult.OK)
+                if (printDialog.ShowDialog() == DialogResult.OK)
                 {
                     if (printDialog.PrinterSettings.PrintRange == PrintRange.SomePages)
                     {
@@ -1050,40 +1050,40 @@ public partial class MainWindow : Form
                         print.PrintDocument.PrinterSettings.ToPage = printDialog.PrinterSettings.ToPage;
                     }
 
-                    ShowMessage ($"Printing to {printDoc.PrinterSettings.PrinterName}");
+                    ShowMessage($"Printing to {printDoc.PrinterSettings.PrinterName}");
                     // BUGBUG: having the printpreview invalidate while we're printing causes an exception
                     // in litehtml. Do not un comment this until figured out
                     //print.PrintingSheet += Print_PrintingSheet;
-                    await print.DoPrint ().ConfigureAwait (false);
-                    ShowMessage ("");
+                    await print.DoPrint().ConfigureAwait(false);
+                    ShowMessage("");
                 }
             });
         }
         else
         {
-            ShowMessage ($"Printing to {printDoc.PrinterSettings.PrinterName}");
+            ShowMessage($"Printing to {printDoc.PrinterSettings.PrinterName}");
 
             // BUGBUG: having the printpreview invalidate while we're printing causes an exception
             // in litehtml. Do not un comment this until figured out
             //print.PrintingSheet += Print_PrintingSheet;
-            await print.DoPrint ().ConfigureAwait (false);
-            ShowMessage ("");
+            await print.DoPrint().ConfigureAwait(false);
+            ShowMessage("");
         }
     }
 
-    private void Print_PrintingSheet (object? sender, int sheetNum)
+    private void Print_PrintingSheet(object? sender, int sheetNum)
     {
-        ShowMessage ($"Printing sheet {sheetNum}");
+        ShowMessage($"Printing sheet {sheetNum}");
     }
 
-    private void panelRight_Resize (object? sender, EventArgs e)
+    private void panelRight_Resize(object? sender, EventArgs e)
     {
         //SizePreview();
     }
 
-    private void enableHeader_CheckedChanged (object? sender, EventArgs e)
+    private void enableHeader_CheckedChanged(object? sender, EventArgs e)
     {
-        LogService.TraceMessage ($"enableHeader_CheckedChanged: {enableHeader.Checked}");
+        LogService.TraceMessage($"enableHeader_CheckedChanged: {enableHeader.Checked}");
         if (printersCB.Enabled)
         {
             // TODO: This should find the Preview SheetViewModel instance and set the property on this, not
@@ -1093,9 +1093,9 @@ public partial class MainWindow : Form
         }
     }
 
-    private void enableFooter_CheckedChanged (object? sender, EventArgs e)
+    private void enableFooter_CheckedChanged(object? sender, EventArgs e)
     {
-        LogService.TraceMessage ($"enableFooter_CheckedChanged: {enableFooter.Checked}");
+        LogService.TraceMessage($"enableFooter_CheckedChanged: {enableFooter.Checked}");
         if (printersCB.Enabled)
         {
             // TODO: This should find the Preview SheetViewModel instance and set the property on this, not
@@ -1105,18 +1105,18 @@ public partial class MainWindow : Form
         }
     }
 
-    private void comboBoxSheet_SelectedIndexChanged (object? sender, EventArgs e)
+    private void comboBoxSheet_SelectedIndexChanged(object? sender, EventArgs e)
     {
         if (comboBoxSheet.SelectedItem is not KeyValuePair<string, string> si)
         {
             return;
         }
 
-        LogService.TraceMessage ($"comboBoxSheet_SelectedIndexChanged: {si.Key}, {si.Value}");
+        LogService.TraceMessage($"comboBoxSheet_SelectedIndexChanged: {si.Key}, {si.Value}");
         if (printersCB.Enabled)
         {
-            ModelLocator.Current.Settings.DefaultSheet = Guid.Parse (si.Key);
-            ServiceLocator.Current.TelemetryService.TrackEvent ("Change Selected Sheet Settings",
+            ModelLocator.Current.Settings.DefaultSheet = Guid.Parse(si.Key);
+            ServiceLocator.Current.TelemetryService.TrackEvent("Change Selected Sheet Settings",
                 new Dictionary<string, string?>
                 {
                     { "sheetSettingsName", si.Value },
@@ -1126,74 +1126,74 @@ public partial class MainWindow : Form
         }
     }
 
-    private void topMargin_ValueChanged (object? sender, EventArgs e)
+    private void topMargin_ValueChanged(object? sender, EventArgs e)
     {
-        var margins = (PrintMargins)CurrentSheetSettings.Margins.Clone ();
+        var margins = (PrintMargins)CurrentSheetSettings.Margins.Clone();
         margins.Top = (int)(topMargin.Value * 100M);
         CurrentSheetSettings.Margins = margins;
     }
 
-    private void leftMargin_ValueChanged (object? sender, EventArgs e)
+    private void leftMargin_ValueChanged(object? sender, EventArgs e)
     {
-        var margins = (PrintMargins)CurrentSheetSettings.Margins.Clone ();
+        var margins = (PrintMargins)CurrentSheetSettings.Margins.Clone();
         margins.Left = (int)(leftMargin.Value * 100M);
         CurrentSheetSettings.Margins = margins;
     }
 
-    private void rightMargin_ValueChanged (object? sender, EventArgs e)
+    private void rightMargin_ValueChanged(object? sender, EventArgs e)
     {
-        var margins = (PrintMargins)CurrentSheetSettings.Margins.Clone ();
+        var margins = (PrintMargins)CurrentSheetSettings.Margins.Clone();
         margins.Right = (int)(rightMargin.Value * 100M);
         CurrentSheetSettings.Margins = margins;
     }
 
-    private void bottomMargin_ValueChanged (object? sender, EventArgs e)
+    private void bottomMargin_ValueChanged(object? sender, EventArgs e)
     {
-        var margins = (PrintMargins)CurrentSheetSettings.Margins.Clone ();
+        var margins = (PrintMargins)CurrentSheetSettings.Margins.Clone();
         margins.Bottom = (int)(bottomMargin.Value * 100M);
         CurrentSheetSettings.Margins = margins;
     }
 
-    private void pageSeparator_CheckedChanged (object? sender, EventArgs e)
+    private void pageSeparator_CheckedChanged(object? sender, EventArgs e)
     {
         CurrentSheetSettings.PageSeparator = pageSeparator.Checked;
     }
 
-    private void rows_ValueChanged (object? sender, EventArgs e)
+    private void rows_ValueChanged(object? sender, EventArgs e)
     {
         CurrentSheetSettings.Rows = (int)rows.Value;
     }
 
-    private void columns_ValueChanged (object? sender, EventArgs e)
+    private void columns_ValueChanged(object? sender, EventArgs e)
     {
         CurrentSheetSettings.Columns = (int)columns.Value;
     }
 
-    private void padding_ValueChanged (object? sender, EventArgs e)
+    private void padding_ValueChanged(object? sender, EventArgs e)
     {
         CurrentSheetSettings.Padding = (int)(padding.Value * 100M);
     }
 
-    private void fileButton_Click (object? sender, EventArgs e)
+    private void fileButton_Click(object? sender, EventArgs e)
     {
-        ShowFilesDialog ();
+        ShowFilesDialog();
     }
 
-    private void lineNumbers_CheckedChanged (object? sender, EventArgs e)
+    private void lineNumbers_CheckedChanged(object? sender, EventArgs e)
     {
-        LogService.TraceMessage ($"lineNumbers_CheckedChanged: {lineNumbers.Checked}");
+        LogService.TraceMessage($"lineNumbers_CheckedChanged: {lineNumbers.Checked}");
         ContentSettings contentSettings = CurrentSheetSettings.ContentSettings ??
-                                          throw new InvalidOperationException ("Content settings not found.");
+                                          throw new InvalidOperationException("Content settings not found.");
         contentSettings.LineNumbers = lineNumbers.Checked;
     }
 
-    [SuppressMessage ("Design",
+    [SuppressMessage("Design",
         "CA1031:Do not catch general exception types", Justification = "<Pending>")]
-    private void settingsButton_Click (object? sender, EventArgs args)
+    private void settingsButton_Click(object? sender, EventArgs args)
     {
-        Log.Debug ($"Opening settings file: {ServiceLocator.Current.SettingsService.SettingsFileName}");
+        Log.Debug($"Opening settings file: {ServiceLocator.Current.SettingsService.SettingsFileName}");
 
-        ServiceLocator.Current.TelemetryService.TrackEvent ("Settings Button Click");
+        ServiceLocator.Current.TelemetryService.TrackEvent("Settings Button Click");
 
         Process? proc = null;
         try
@@ -1203,29 +1203,29 @@ public partial class MainWindow : Form
                 UseShellExecute = true, // This is important
                 FileName = ServiceLocator.Current.SettingsService.SettingsFileName
             };
-            proc = Process.Start (psi);
+            proc = Process.Start(psi);
         }
         catch (Exception e)
         {
             // TODO: Better error message (output of stderr?)
-            ServiceLocator.Current.TelemetryService.TrackException (e);
+            ServiceLocator.Current.TelemetryService.TrackException(e);
 
-            Log.Error (e, $"Couldn't open settings file {ServiceLocator.Current.SettingsService.SettingsFileName}.");
+            Log.Error(e, $"Couldn't open settings file {ServiceLocator.Current.SettingsService.SettingsFileName}.");
         }
         finally
         {
-            proc?.Dispose ();
+            proc?.Dispose();
         }
     }
 
-    [SuppressMessage ("Design",
+    [SuppressMessage("Design",
         "CA1031:Do not catch general exception types", Justification = "<Pending>")]
-    private void helpaboutLink_LinkClicked (object? sender, LinkLabelLinkClickedEventArgs args)
+    private void helpaboutLink_LinkClicked(object? sender, LinkLabelLinkClickedEventArgs args)
     {
         string url = "https://tig.github.io/winprint";
-        Log.Debug ($"Browsing to home page: {url}");
+        Log.Debug($"Browsing to home page: {url}");
 
-        ServiceLocator.Current.TelemetryService.TrackEvent ("Help/About Link Click");
+        ServiceLocator.Current.TelemetryService.TrackEvent("Help/About Link Click");
 
         Process? proc = null;
         try
@@ -1235,68 +1235,70 @@ public partial class MainWindow : Form
                 UseShellExecute = true, // This is important
                 FileName = url
             };
-            proc = Process.Start (psi);
+            proc = Process.Start(psi);
         }
         catch (Exception e)
         {
             // TODO: Better error message (output of stderr?)
-            ServiceLocator.Current.TelemetryService.TrackException (e);
+            ServiceLocator.Current.TelemetryService.TrackException(e);
 
-            Log.Error (e, $"Couldn't browse to {url}.");
+            Log.Error(e, $"Couldn't browse to {url}.");
         }
         finally
         {
-            proc?.Dispose ();
+            proc?.Dispose();
         }
     }
 
-    private void contentFontLink_LinkClicked (object? sender, LinkLabelLinkClickedEventArgs e)
+    private void contentFontLink_LinkClicked(object? sender, LinkLabelLinkClickedEventArgs e)
     {
         ContentSettings contentSettings = CurrentSheetSettings.ContentSettings ??
-                                          throw new InvalidOperationException ("Content settings not found.");
+                                          throw new InvalidOperationException("Content settings not found.");
 
         Font contentFont = contentSettings.Font ??
-                           throw new InvalidOperationException ("Content font settings not found.");
+                           throw new InvalidOperationException("Content font settings not found.");
         fontDialog.Font =
-            new System.Drawing.Font (new FontFamily (contentFont.Family), contentFont.Size, (System.Drawing.FontStyle)contentFont.Style, GraphicsUnit.Point);
-        if (DialogResult.OK == fontDialog.ShowDialog (this))
+            new System.Drawing.Font(new FontFamily(contentFont.Family), contentFont.Size,
+                (System.Drawing.FontStyle)contentFont.Style, GraphicsUnit.Point);
+        if (DialogResult.OK == fontDialog.ShowDialog(this))
         {
             contentSettings.Font = new Font
             {
                 Family = fontDialog.Font.FontFamily.Name,
-                Size = (float)Math.Round (fontDialog.Font.SizeInPoints),
-                Style = (WinPrint.Core.Models.FontStyle)fontDialog.Font.Style
+                Size = (float)Math.Round(fontDialog.Font.SizeInPoints),
+                Style = (Core.Models.FontStyle)fontDialog.Font.Style
             };
-            contentFontLink.Text = contentSettings.Font.ToString ();
+            contentFontLink.Text = contentSettings.Font.ToString();
         }
     }
 
-    private void headerFooterFontLink_LinkClicked (object? sender, LinkLabelLinkClickedEventArgs e)
+    private void headerFooterFontLink_LinkClicked(object? sender, LinkLabelLinkClickedEventArgs e)
     {
         Header header = CurrentSheetSettings.Header;
         Footer footer = CurrentSheetSettings.Footer;
 
-        Font headerFont = header.Font ?? throw new InvalidOperationException ("Header font settings not found.");
-        fontDialog.Font = new System.Drawing.Font (new FontFamily (headerFont.Family), headerFont.Size, GraphicsUnit.Point);
+        Font headerFont = header.Font ?? throw new InvalidOperationException("Header font settings not found.");
+        fontDialog.Font =
+            new System.Drawing.Font(new FontFamily(headerFont.Family), headerFont.Size, GraphicsUnit.Point);
 
-        if (DialogResult.OK == fontDialog.ShowDialog (this))
+        if (DialogResult.OK == fontDialog.ShowDialog(this))
         {
             // Note we set BOTH the header & footer to the same thing. But for GUI we use the Header as source of truth.
             header.Font = footer.Font = new Font
             {
                 Family = fontDialog.Font.FontFamily.Name,
-                Size = (float)Math.Round (fontDialog.Font.SizeInPoints),
-                Style = (WinPrint.Core.Models.FontStyle)fontDialog.Font.Style
+                Size = (float)Math.Round(fontDialog.Font.SizeInPoints),
+                Style = (Core.Models.FontStyle)fontDialog.Font.Style
             };
-            headerFooterFontLink.Text = header.Font.ToString ();
+            headerFooterFontLink.Text = header.Font.ToString();
         }
     }
 
-    private void printPreview_Click (object? sender, EventArgs e)
+    private void printPreview_Click(object? sender, EventArgs e)
     {
-        if (string.IsNullOrEmpty (activeFile))
+        if (string.IsNullOrEmpty(activeFile))
         {
-            ShowFilesDialog ();
+            ShowFilesDialog();
         }
     }
 }

--- a/src/WinPrint.WinForms/Native.cs
+++ b/src/WinPrint.WinForms/Native.cs
@@ -6,18 +6,18 @@ namespace WinPrint.WinForms;
 
 internal class NativeMethods
 {
-    [DllImport ("Shlwapi.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-    private static extern uint AssocQueryString (AssocF flags, AssocStr str, string pszAssoc, string? pszExtra,
+    [DllImport("Shlwapi.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern uint AssocQueryString(AssocF flags, AssocStr str, string pszAssoc, string? pszExtra,
         [Out] StringBuilder? pszOut, [In][Out] ref uint pcchOut);
 
-    [SuppressMessage ("Performance", "CA1806:Do not ignore method results", Justification = "<Pending>")]
-    public static string FileExtentionInfo (AssocStr assocStr, string doctype)
+    [SuppressMessage("Performance", "CA1806:Do not ignore method results", Justification = "<Pending>")]
+    public static string FileExtentionInfo(AssocStr assocStr, string doctype)
     {
         uint pcchOut = 0;
-        AssocQueryString (AssocF.Verify, assocStr, doctype, null, null, ref pcchOut);
+        AssocQueryString(AssocF.Verify, assocStr, doctype, null, null, ref pcchOut);
 
-        var pszOut = new StringBuilder ((int)pcchOut);
-        AssocQueryString (AssocF.Verify, assocStr, doctype, null, pszOut, ref pcchOut);
-        return pszOut.ToString ();
+        var pszOut = new StringBuilder((int)pcchOut);
+        AssocQueryString(AssocF.Verify, assocStr, doctype, null, pszOut, ref pcchOut);
+        return pszOut.ToString();
     }
 }

--- a/src/WinPrint.WinForms/PrintPreview.cs
+++ b/src/WinPrint.WinForms/PrintPreview.cs
@@ -17,7 +17,7 @@ public partial class PrintPreview : Control
 {
     private const int _messageHorizMargin = 20;
 
-    private readonly StringFormat _messageStringFormat = new ()
+    private readonly StringFormat _messageStringFormat = new()
     {
         LineAlignment = StringAlignment.Center,
         Alignment = StringAlignment.Center
@@ -28,45 +28,45 @@ public partial class PrintPreview : Control
 
     // Assigned by MainWindow after designer initialization.
 
-    public PrintPreview ()
+    public PrintPreview()
     {
         //DoubleBuffered = true;
-        InitializeComponent ();
+        InitializeComponent();
         CurrentSheet = 1;
         Zoom = 100;
         MouseWheel += _MouseWheel;
         BackColor = SystemColors.AppWorkspace;
     }
 
-    [Browsable (false)]
-    [DesignerSerializationVisibility (DesignerSerializationVisibility.Hidden)]
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public SheetViewModel SheetViewModel { get; set; } = null!;
 
-    [Category ("Data")]
-    [Description ("Specifies the page number of the current sheet.")]
-    [Bindable (true)]
-    [DesignerSerializationVisibility (DesignerSerializationVisibility.Hidden)]
+    [Category("Data")]
+    [Description("Specifies the page number of the current sheet.")]
+    [Bindable(true)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public int CurrentSheet { get; set; }
 
-    [Category ("Data")]
-    [Description ("Specifies zoom level.")]
-    [Bindable (true)]
-    [DefaultValue (100)]
+    [Category("Data")]
+    [Description("Specifies zoom level.")]
+    [Bindable(true)]
+    [DefaultValue(100)]
     public int Zoom { get; set; }
 
-    private void _MouseWheel (object? sender, MouseEventArgs e)
+    private void _MouseWheel(object? sender, MouseEventArgs e)
     {
-        ServiceLocator.Current.TelemetryService.TrackEvent ("Print Preview Mouse Wheel",
-            new Dictionary<string, string?> { ["ModifierKeys"] = ModifierKeys.ToString () });
-        if (ModifierKeys.HasFlag (Keys.Control))
+        ServiceLocator.Current.TelemetryService.TrackEvent("Print Preview Mouse Wheel",
+            new Dictionary<string, string?> { ["ModifierKeys"] = ModifierKeys.ToString() });
+        if (ModifierKeys.HasFlag(Keys.Control))
         {
             if (e.Delta < 0)
             {
-                ZoomOut ();
+                ZoomOut();
             }
             else
             {
-                ZoomIn ();
+                ZoomIn();
             }
         }
         else
@@ -74,16 +74,16 @@ public partial class PrintPreview : Control
             // LogService.TraceMessage($"_MouseWheel page {e.Delta}");
             if (e.Delta < 0)
             {
-                PageDown ();
+                PageDown();
             }
             else
             {
-                PageUp ();
+                PageUp();
             }
         }
     }
 
-    private void ZoomIn ()
+    private void ZoomIn()
     {
         int multiplier = 10;
         if (Zoom >= 200)
@@ -92,12 +92,12 @@ public partial class PrintPreview : Control
         }
 
         Zoom += multiplier;
-        Invalidate ();
-        ServiceLocator.Current.TelemetryService.TrackEvent ("Print Preview Zoom In",
-            new Dictionary<string, string?> { ["Zoom"] = Zoom.ToString () });
+        Invalidate();
+        ServiceLocator.Current.TelemetryService.TrackEvent("Print Preview Zoom In",
+            new Dictionary<string, string?> { ["Zoom"] = Zoom.ToString() });
     }
 
-    private void ZoomOut ()
+    private void ZoomOut()
     {
         int multiplier = 10;
         if (Zoom >= 200)
@@ -112,41 +112,41 @@ public partial class PrintPreview : Control
             Zoom = 10;
         }
 
-        Invalidate ();
-        ServiceLocator.Current.TelemetryService.TrackEvent ("Print Preview Zoom Out",
-            new Dictionary<string, string?> { ["Zoom"] = Zoom.ToString () });
+        Invalidate();
+        ServiceLocator.Current.TelemetryService.TrackEvent("Print Preview Zoom Out",
+            new Dictionary<string, string?> { ["Zoom"] = Zoom.ToString() });
     }
 
-    protected override void OnResize (EventArgs e)
+    protected override void OnResize(EventArgs e)
     {
-        Invalidate ();
+        Invalidate();
         //base.OnResize(e);
     }
 
-    protected override void OnClick (EventArgs e)
+    protected override void OnClick(EventArgs e)
     {
-        base.OnClick (e);
-        Select ();
+        base.OnClick(e);
+        Select();
         //Invalidate();
     }
 
-    protected override void OnLostFocus (EventArgs e)
+    protected override void OnLostFocus(EventArgs e)
     {
-        base.OnLostFocus (e);
+        base.OnLostFocus(e);
         //Invalidate();
     }
 
-    protected override void OnKeyUp (KeyEventArgs e)
+    protected override void OnKeyUp(KeyEventArgs e)
     {
         if (e is null)
         {
-            throw new ArgumentNullException (nameof (e));
+            throw new ArgumentNullException(nameof(e));
         }
 
-        ServiceLocator.Current.TelemetryService.TrackEvent ("Print Preview Key Up",
-            new Dictionary<string, string?> { ["KeyCode"] = e.KeyCode.ToString () });
+        ServiceLocator.Current.TelemetryService.TrackEvent("Print Preview Key Up",
+            new Dictionary<string, string?> { ["KeyCode"] = e.KeyCode.ToString() });
 
-        base.OnKeyUp (e);
+        base.OnKeyUp(e);
 
 #if TERMINAL
         var pygCte = SheetViewModel.ContentEngine as PygmentsCte;
@@ -154,19 +154,19 @@ public partial class PrintPreview : Control
         switch (e.KeyCode)
         {
             case Keys.PageDown:
-                PageDown ();
+                PageDown();
                 break;
 
             case Keys.PageUp:
-                PageUp ();
+                PageUp();
                 break;
 
             case Keys.Oemplus:
-                ZoomIn ();
+                ZoomIn();
                 break;
 
             case Keys.OemMinus:
-                ZoomOut ();
+                ZoomOut();
                 break;
 
             case Keys.Down:
@@ -174,7 +174,7 @@ public partial class PrintPreview : Control
                 pygCte.DecoderClient.MoveCursor(null, libvt100.Direction.Down, 1);
                 Invalidate();
 #else
-                PageDown ();
+                PageDown();
 #endif
                 break;
             case Keys.Up:
@@ -182,16 +182,16 @@ public partial class PrintPreview : Control
                 pygCte?.DecoderClient.MoveCursor(null, libvt100.Direction.Up, 1);
                 Invalidate();
 #else
-                PageUp ();
+                PageUp();
 #endif
                 break;
 
             case Keys.Home:
-                Home ();
+                Home();
                 break;
 
             case Keys.End:
-                End ();
+                End();
                 break;
 
 #if TERMINAL
@@ -211,82 +211,82 @@ public partial class PrintPreview : Control
         }
     }
 
-    private void PageUp ()
+    private void PageUp()
     {
         if (CurrentSheet > 1)
         {
             CurrentSheet--;
-            Invalidate ();
+            Invalidate();
         }
 
-        ServiceLocator.Current.TelemetryService.TrackEvent ("Print Preview Page Up",
-            new Dictionary<string, string?> { ["Page"] = CurrentSheet.ToString () });
+        ServiceLocator.Current.TelemetryService.TrackEvent("Print Preview Page Up",
+            new Dictionary<string, string?> { ["Page"] = CurrentSheet.ToString() });
     }
 
-    private void PageDown ()
+    private void PageDown()
     {
-        LogService.TraceMessage ("Preview:PageDown");
+        LogService.TraceMessage("Preview:PageDown");
         if (CurrentSheet < SheetViewModel.NumSheets)
         {
             CurrentSheet++;
-            Invalidate ();
+            Invalidate();
         }
 
-        ServiceLocator.Current.TelemetryService.TrackEvent ("Print Preview Page Down",
-            new Dictionary<string, string?> { ["Page"] = CurrentSheet.ToString () });
+        ServiceLocator.Current.TelemetryService.TrackEvent("Print Preview Page Down",
+            new Dictionary<string, string?> { ["Page"] = CurrentSheet.ToString() });
     }
 
-    private void Home ()
+    private void Home()
     {
         CurrentSheet = 1;
-        Invalidate ();
-        ServiceLocator.Current.TelemetryService.TrackEvent ("Print Preview Home",
-            new Dictionary<string, string?> { ["Page"] = CurrentSheet.ToString () });
+        Invalidate();
+        ServiceLocator.Current.TelemetryService.TrackEvent("Print Preview Home",
+            new Dictionary<string, string?> { ["Page"] = CurrentSheet.ToString() });
     }
 
-    private void End ()
+    private void End()
     {
         CurrentSheet = SheetViewModel.NumSheets;
-        Invalidate ();
-        ServiceLocator.Current.TelemetryService.TrackEvent ("Print Preview End",
-            new Dictionary<string, string?> { ["Page"] = CurrentSheet.ToString () });
+        Invalidate();
+        ServiceLocator.Current.TelemetryService.TrackEvent("Print Preview End",
+            new Dictionary<string, string?> { ["Page"] = CurrentSheet.ToString() });
     }
 
-    protected override void OnTextChanged (EventArgs e)
+    protected override void OnTextChanged(EventArgs e)
     {
         // Invalidate previous
-        Invalidate (_messageRect);
+        Invalidate(_messageRect);
 
         // Invalidate new
-        Invalidate (GetTextRect (Graphics.FromHwnd (Handle)));
+        Invalidate(GetTextRect(Graphics.FromHwnd(Handle)));
     }
 
-    protected override void OnPaint (PaintEventArgs e)
+    protected override void OnPaint(PaintEventArgs e)
     {
         if (e is null)
         {
-            throw new ArgumentNullException (nameof (e));
+            throw new ArgumentNullException(nameof(e));
         }
 
-        LogService.TraceMessage ($"PrintPreview.Text: {Text} - clip: {e.ClipRectangle}");
+        LogService.TraceMessage($"PrintPreview.Text: {Text} - clip: {e.ClipRectangle}");
 
         if (SheetViewModel != null && SheetViewModel.Ready)
         {
-            GraphicsState state = e.Graphics.Save ();
+            GraphicsState state = e.Graphics.Save();
 
             // Calculate scale and location
-            var paperSize = new Size (ClientSize.Width - Padding.Horizontal, ClientSize.Height - Padding.Vertical);
+            var paperSize = new Size(ClientSize.Width - Padding.Horizontal, ClientSize.Height - Padding.Vertical);
             double w = SheetViewModel.Bounds.Width;
             double h = SheetViewModel.Bounds.Height;
             double scalingX = paperSize.Width / w;
             double scalingY = paperSize.Height / h;
 
             // Now, we have two scaling ratios, which one produces the smaller image? The one that has the smallest scaling factor.
-            double scale = Math.Min (scalingY, scalingX) * (Zoom / 100F);
-            LogService.TraceMessage ($"Scale {scale}");
+            double scale = Math.Min(scalingY, scalingX) * (Zoom / 100F);
+            LogService.TraceMessage($"Scale {scale}");
 
-            var previewSize = new Size ((int)(w * scale), (int)(h * scale));
-            LogService.TraceMessage ($"previewSize {previewSize.Width}, {previewSize.Height}");
+            var previewSize = new Size((int)(w * scale), (int)(h * scale));
+            LogService.TraceMessage($"previewSize {previewSize.Width}, {previewSize.Height}");
 
             // Don't do anything if the windows been shrunk too far or GDI+ will crash
             if (previewSize.Width > 10 && previewSize.Height > 10)
@@ -295,58 +295,58 @@ public partial class PrintPreview : Control
                 if (Zoom <= 100)
                 {
                     // Center
-                    e.Graphics.TranslateTransform (ClientSize.Width / 2 - previewSize.Width / 2,
+                    e.Graphics.TranslateTransform(ClientSize.Width / 2 - previewSize.Width / 2,
                         ClientSize.Height / 2 - previewSize.Height / 2);
                 }
                 else
                 {
                     // Top centered
-                    e.Graphics.TranslateTransform (ClientSize.Width / 2 - previewSize.Width / 2, Padding.Top);
+                    e.Graphics.TranslateTransform(ClientSize.Width / 2 - previewSize.Width / 2, Padding.Top);
                 }
 
                 // Scale for client size & zoom
-                e.Graphics.ScaleTransform ((float)scale, (float)scale);
+                e.Graphics.ScaleTransform((float)scale, (float)scale);
 
                 // Paint the background white
-                e.Graphics.FillRectangle (Brushes.White, SheetViewModel.Bounds);
+                e.Graphics.FillRectangle(Brushes.White, SheetViewModel.Bounds);
 
-                SheetViewModel.PrintSheet (e.Graphics, CurrentSheet);
+                SheetViewModel.PrintSheet(e.Graphics, CurrentSheet);
             }
 
-            e.Graphics.Restore (state);
+            e.Graphics.Restore(state);
         }
 
         // If we're zoomed, paint zoom factor
         if (Zoom != 100)
         {
-            using var font = new Font (Font.FontFamily, 36F, FontStyle.Regular, GraphicsUnit.Point);
+            using var font = new Font(Font.FontFamily, 36F, FontStyle.Regular, GraphicsUnit.Point);
             string zText = $"{Zoom}%";
-            SizeF s = e.Graphics.MeasureString (zText, font);
-            e.Graphics.DrawString (zText, font, SystemBrushes.ControlLight, ClientSize.Width / 2 - s.Width / 2,
+            SizeF s = e.Graphics.MeasureString(zText, font);
+            e.Graphics.DrawString(zText, font, SystemBrushes.ControlLight, ClientSize.Width / 2 - s.Width / 2,
                 ClientSize.Height / 2 - s.Height / 2);
         }
 
-        PaintMessage (e);
+        PaintMessage(e);
     }
 
-    private void PaintMessage (PaintEventArgs e)
+    private void PaintMessage(PaintEventArgs e)
     {
         // While in error or loading & reflowing show Text 
-        Rectangle rect = GetTextRect (e.Graphics);
+        Rectangle rect = GetTextRect(e.Graphics);
         //e.Graphics.FillRectangle(SystemBrushes.Control, _messageRect);
-        e.Graphics.DrawString (Text, new Font (Font.FontFamily, 14F, FontStyle.Regular, GraphicsUnit.Point),
+        e.Graphics.DrawString(Text, new Font(Font.FontFamily, 14F, FontStyle.Regular, GraphicsUnit.Point),
             SystemBrushes.ControlText, rect, _messageStringFormat);
         //e.Graphics.DrawRectangle(Pens.Red, rect);
         _messageRect = rect;
     }
 
-    private Rectangle GetTextRect (Graphics g)
+    private Rectangle GetTextRect(Graphics g)
     {
         //var g = Graphics.FromHwnd(Handle);
-        SizeF size = g.MeasureString (Text, new Font (Font.FontFamily, 14F, FontStyle.Regular, GraphicsUnit.Point),
+        SizeF size = g.MeasureString(Text, new Font(Font.FontFamily, 14F, FontStyle.Regular, GraphicsUnit.Point),
             ClientRectangle.Width - _messageHorizMargin * 2, _messageStringFormat);
-        return new Rectangle ((int)Math.Ceiling (ClientRectangle.Width / 2 - size.Width / 2),
-            (int)Math.Ceiling (ClientRectangle.Height / 2 - size.Height / 2), (int)Math.Ceiling (size.Width),
-            (int)Math.Ceiling (size.Height));
+        return new Rectangle((int)Math.Ceiling(ClientRectangle.Width / 2 - size.Width / 2),
+            (int)Math.Ceiling(ClientRectangle.Height / 2 - size.Height / 2), (int)Math.Ceiling(size.Width),
+            (int)Math.Ceiling(size.Height));
     }
 }

--- a/src/WinPrint.WinForms/Program.cs
+++ b/src/WinPrint.WinForms/Program.cs
@@ -20,82 +20,82 @@ internal static class Program
     ///     The main entry point for the winprint GUI application.
     /// </summary>
     [STAThread]
-    private static void Main (string[] args)
+    private static void Main(string[] args)
     {
-        Application.SetHighDpiMode (HighDpiMode.SystemAware);
-        Application.EnableVisualStyles ();
-        Application.SetCompatibleTextRenderingDefault (false);
+        Application.SetHighDpiMode(HighDpiMode.SystemAware);
+        Application.EnableVisualStyles();
+        Application.SetCompatibleTextRenderingDefault(false);
 
-        ServiceLocator.Current.TelemetryService.Start (AppDomain.CurrentDomain.FriendlyName);
+        ServiceLocator.Current.TelemetryService.Start(AppDomain.CurrentDomain.FriendlyName);
 
         AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
         TaskScheduler.UnobservedTaskException += TaskScheduler_UnobservedTaskException;
 
-        var main = new MainWindow ();
+        var main = new MainWindow();
         GuiLogSink.Instance.OutputWindow = main;
 
         if (args.Length > 0)
         {
-            var parser = new Parser (with => with.EnableDashDash = true);
-            ParserResult<Options>? result = parser.ParseArguments<Options> (args);
+            var parser = new Parser(with => with.EnableDashDash = true);
+            ParserResult<Options>? result = parser.ParseArguments<Options>(args);
             result
-                .WithParsed (o =>
+                .WithParsed(o =>
                 {
                     if (o.Debug)
                     {
-                        ServiceLocator.Current.LogService.Start (AppDomain.CurrentDomain.FriendlyName,
+                        ServiceLocator.Current.LogService.Start(AppDomain.CurrentDomain.FriendlyName,
                             GuiLogSink.Instance, true, true);
                         ServiceLocator.Current.LogService.ConsoleLevelSwitch.MinimumLevel = LogEventLevel.Debug;
                         ServiceLocator.Current.LogService.MasterLevelSwitch.MinimumLevel = LogEventLevel.Debug;
                     }
                     else
                     {
-                        ServiceLocator.Current.LogService.Start (AppDomain.CurrentDomain.FriendlyName,
+                        ServiceLocator.Current.LogService.Start(AppDomain.CurrentDomain.FriendlyName,
                             GuiLogSink.Instance, false, true);
                         ServiceLocator.Current.LogService.ConsoleLevelSwitch.MinimumLevel = LogEventLevel.Information;
                     }
 
-                    ServiceLocator.Current.TelemetryService.TrackEvent ("Command Line Options",
-                        o.GetTelemetryDictionary ());
-                    Log.Information ("Command Line: {cmd}", Parser.Default.FormatCommandLine (o));
-                    ModelLocator.Current.Options.CopyPropertiesFrom (o);
+                    ServiceLocator.Current.TelemetryService.TrackEvent("Command Line Options",
+                        o.GetTelemetryDictionary());
+                    Log.Information("Command Line: {cmd}", Parser.Default.FormatCommandLine(o));
+                    ModelLocator.Current.Options.CopyPropertiesFrom(o);
                 })
-                .WithNotParsed (errs => DisplayHelp (result));
-            parser.Dispose ();
+                .WithNotParsed(errs => DisplayHelp(result));
+            parser.Dispose();
         }
 
-        Application.Run (main);
-        main.Dispose ();
+        Application.Run(main);
+        main.Dispose();
 
-        ServiceLocator.Current.TelemetryService.Stop ();
+        ServiceLocator.Current.TelemetryService.Stop();
     }
 
-    private static void DisplayHelp<T> (ParserResult<T> result)
+    private static void DisplayHelp<T>(ParserResult<T> result)
     {
-        var helpText = HelpText.AutoBuild (result, h =>
+        var helpText = HelpText.AutoBuild(result, h =>
         {
             h.AutoHelp = true;
             h.AutoVersion = true;
 
             //h.AddPostOptionsLine("Files\tOne or more filenames of files to be printed.");
-            return HelpText.DefaultParsingErrorsHandler (result, h);
+            return HelpText.DefaultParsingErrorsHandler(result, h);
         }, e => e);
-        MessageBox.Show (helpText);
-        ServiceLocator.Current.TelemetryService.TrackEvent ("Display Help");
-        Environment.Exit (0);
+        MessageBox.Show(helpText);
+        ServiceLocator.Current.TelemetryService.TrackEvent("Display Help");
+        Environment.Exit(0);
     }
 
-    private static void TaskScheduler_UnobservedTaskException (object? sender, UnobservedTaskExceptionEventArgs e)
+    private static void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
     {
-        ServiceLocator.Current.TelemetryService.TrackException (e.Exception);
+        ServiceLocator.Current.TelemetryService.TrackException(e.Exception);
     }
 
-    private static void CurrentDomain_UnhandledException (object? sender, UnhandledExceptionEventArgs e)
+    private static void CurrentDomain_UnhandledException(object? sender, UnhandledExceptionEventArgs e)
     {
         var ex = e.ExceptionObject as Exception;
         if (ex is not null)
         {
-            ServiceLocator.Current.TelemetryService.TrackException (ex);
+            ServiceLocator.Current.TelemetryService.TrackException(ex);
         }
     }
 }

--- a/src/WinPrint.WinForms/UpdateDialog.cs
+++ b/src/WinPrint.WinForms/UpdateDialog.cs
@@ -8,29 +8,29 @@ namespace WinPrint.WinForms;
 
 public partial class UpdateDialog : Form
 {
-    public UpdateDialog ()
+    public UpdateDialog()
     {
-        InitializeComponent ();
+        InitializeComponent();
         StartPosition = FormStartPosition.CenterParent;
         labelNewVersion.Text = $"A newer version ({ServiceLocator.Current.UpdateService.LatestVersion}) is available.";
         LinkLabel.Link releaseLink = linkReleasePage.Links[0] ??
-                                     throw new InvalidOperationException ("Release link was not initialized.");
+                                     throw new InvalidOperationException("Release link was not initialized.");
         releaseLink.LinkData = ServiceLocator.Current.UpdateService.ReleasePageUri?.AbsoluteUri ??
-                               throw new InvalidOperationException ("Release page URI was not initialized.");
+                               throw new InvalidOperationException("Release page URI was not initialized.");
     }
 
-    private void downloadButton_Click (object? sender, EventArgs args)
+    private void downloadButton_Click(object? sender, EventArgs args)
     {
-        ServiceLocator.Current.UpdateService.StartUpgradeAsync ().ConfigureAwait (false);
+        ServiceLocator.Current.UpdateService.StartUpgradeAsync().ConfigureAwait(false);
     }
 
-    private void linkReleasePage_LinkClicked (object? sender, LinkLabelLinkClickedEventArgs args)
+    private void linkReleasePage_LinkClicked(object? sender, LinkLabelLinkClickedEventArgs args)
     {
         string releasePage = linkReleasePage.Links[0]?.LinkData as string ??
-                             throw new InvalidOperationException ("Release link data was not initialized.");
-        Log.Debug ($"Browsing to release page: {releasePage}");
+                             throw new InvalidOperationException("Release link data was not initialized.");
+        Log.Debug($"Browsing to release page: {releasePage}");
 
-        ServiceLocator.Current.TelemetryService.TrackEvent ("Release Page Click");
+        ServiceLocator.Current.TelemetryService.TrackEvent("Release Page Click");
 
         Process? proc = null;
         try
@@ -40,18 +40,18 @@ public partial class UpdateDialog : Form
                 UseShellExecute = true, // This is important
                 FileName = releasePage
             };
-            proc = Process.Start (psi);
+            proc = Process.Start(psi);
         }
         catch (Exception e)
         {
             // TODO: Better error message (output of stderr?)
-            ServiceLocator.Current.TelemetryService.TrackException (e);
+            ServiceLocator.Current.TelemetryService.TrackException(e);
 
-            Log.Error (e, $"Couldn't browse to {releasePage}.");
+            Log.Error(e, $"Couldn't browse to {releasePage}.");
         }
         finally
         {
-            proc?.Dispose ();
+            proc?.Dispose();
         }
     }
 }

--- a/src/WinPrint.cli/PrintCommand.cs
+++ b/src/WinPrint.cli/PrintCommand.cs
@@ -28,241 +28,241 @@ public sealed class PrintCommand : ICliCommand
 
     public CommandKind Kind => CommandKind.Input;
 
-    public Type ResultType => typeof (PrintResult);
+    public Type ResultType => typeof(PrintResult);
 
     public bool AcceptsPositionalArgs => true;
 
     public IReadOnlyList<CommandOptionDescriptor> Options { get; } =
     [
-        new ("printer", "P", typeof (string), "Printer name. Defaults to the system default printer.", false, null),
-        new ("paper-size", null, typeof (string), "Paper size supported by the selected printer.", false, null),
-        new ("sheet", "s", typeof (string), "WinPrint sheet definition name or ID.", false, null),
-        new ("content-type", "c", typeof (string), "Content type engine, content type, or language override.", false,
+        new("printer", "P", typeof(string), "Printer name. Defaults to the system default printer.", false, null),
+        new("paper-size", null, typeof(string), "Paper size supported by the selected printer.", false, null),
+        new("sheet", "s", typeof(string), "WinPrint sheet definition name or ID.", false, null),
+        new("content-type", "c", typeof(string), "Content type engine, content type, or language override.", false,
             null),
-        new ("language", "l", typeof (string), "Language or content type override for syntax highlighting.", false,
+        new("language", "l", typeof(string), "Language or content type override for syntax highlighting.", false,
             null),
-        new ("orientation", null, typeof (string), "Page orientation: portrait or landscape.", false, null),
-        new ("line-numbers", null, typeof (string), "Line number setting: yes or no.", false, null),
-        new ("from-sheet", null, typeof (int), "First sheet to print.", false, null),
-        new ("to-sheet", null, typeof (int), "Last sheet to print.", false, null),
-        new ("what-if", "w", typeof (bool), "Count sheets without printing.", false, null),
-        new ("gui", "g", typeof (bool), "Open the WinPrint GUI for the file instead of printing from the CLI.", false,
+        new("orientation", null, typeof(string), "Page orientation: portrait or landscape.", false, null),
+        new("line-numbers", null, typeof(string), "Line number setting: yes or no.", false, null),
+        new("from-sheet", null, typeof(int), "First sheet to print.", false, null),
+        new("to-sheet", null, typeof(int), "Last sheet to print.", false, null),
+        new("what-if", "w", typeof(bool), "Count sheets without printing.", false, null),
+        new("gui", "g", typeof(bool), "Open the WinPrint GUI for the file instead of printing from the CLI.", false,
             null),
-        new ("config", null, typeof (bool), "Open WinPrint.config.json in the default editor.", false, null)
+        new("config", null, typeof(bool), "Open WinPrint.config.json in the default editor.", false, null)
     ];
 
-    public async Task<CommandResult> RunAsync (
+    public async Task<CommandResult> RunAsync(
         IApplication app,
         string? initial,
         CommandRunOptions options,
         CancellationToken cancellationToken)
     {
-        bool verbose = options.HasExtension ("verbose");
-        bool debug = options.HasExtension ("debug");
-        ServiceLocator.Current.TelemetryService.Start ("winprint");
-        ServiceLocator.Current.LogService.Start ("winprint", null, debug, verbose);
+        bool verbose = options.HasExtension("verbose");
+        bool debug = options.HasExtension("debug");
+        ServiceLocator.Current.TelemetryService.Start("winprint");
+        ServiceLocator.Current.LogService.Start("winprint", null, debug, verbose);
 
-        var version = FileVersionInfo.GetVersionInfo (Assembly.GetAssembly (typeof (UpdateService))!.Location);
-        WriteVerbose (options,
+        var version = FileVersionInfo.GetVersionInfo(Assembly.GetAssembly(typeof(UpdateService))!.Location);
+        WriteVerbose(options,
             $"winprint {version.ProductVersion} - {version.LegalCopyright} - https://tig.github.io/winprint");
 
         try
         {
-            if (GetFlag (options, "config"))
+            if (GetFlag(options, "config"))
             {
-                OpenSettingsFile ();
-                return Ok (PrintResult.NoPrint ("Opened WinPrint configuration."), options);
+                OpenSettingsFile();
+                return Ok(PrintResult.NoPrint("Opened WinPrint configuration."), options);
             }
 
             string? fileName = options.Arguments.Count > 0 ? options.Arguments[0] : null;
-            if (GetFlag (options, "gui"))
+            if (GetFlag(options, "gui"))
             {
-                OpenGui (fileName);
-                return Ok (PrintResult.NoPrint ("Opened WinPrint GUI."), options);
+                OpenGui(fileName);
+                return Ok(PrintResult.NoPrint("Opened WinPrint GUI."), options);
             }
 
-            using Print print = new ();
-            ConfigurePrinter (print, options);
-            SheetSettings sheet = ConfigureSheet (print, options);
+            using Print print = new();
+            ConfigurePrinter(print, options);
+            SheetSettings sheet = ConfigureSheet(print, options);
             string title = options.Title ?? fileName ?? "winprint";
-            string? contentType = GetOption (options, "language")
-                                  ?? GetOption (options, "content-type")
-                                  ?? ContentTypeEngineBase.GetContentType (fileName ?? "");
+            string? contentType = GetOption(options, "language")
+                                  ?? GetOption(options, "content-type")
+                                  ?? ContentTypeEngineBase.GetContentType(fileName ?? "");
 
             print.SheetViewModel.File = fileName ?? "";
             print.SheetViewModel.Title = title;
-            ConfigureSheetRange (print, options);
-            await LoadContentAsync (print, fileName, contentType, initial, cancellationToken).ConfigureAwait (false);
+            ConfigureSheetRange(print, options);
+            await LoadContentAsync(print, fileName, contentType, initial, cancellationToken).ConfigureAwait(false);
 
             if (verbose)
             {
-                WriteVerbose (options, $"FileName:            {fileName ?? ""}");
-                WriteVerbose (options, $"Title:               {title}");
-                WriteVerbose (options, $"Content Type:        {print.SheetViewModel.ContentType}");
-                WriteVerbose (options, $"Language:            {print.SheetViewModel.Language}");
-                WriteVerbose (options,
-                    $"Content Type Engine: {print.SheetViewModel.ContentEngine?.GetType ().Name ?? ""}");
-                WriteVerbose (options, $"Printer:             {print.PrintDocument.PrinterSettings.PrinterName}");
-                WriteVerbose (options,
+                WriteVerbose(options, $"FileName:            {fileName ?? ""}");
+                WriteVerbose(options, $"Title:               {title}");
+                WriteVerbose(options, $"Content Type:        {print.SheetViewModel.ContentType}");
+                WriteVerbose(options, $"Language:            {print.SheetViewModel.Language}");
+                WriteVerbose(options,
+                    $"Content Type Engine: {print.SheetViewModel.ContentEngine?.GetType().Name ?? ""}");
+                WriteVerbose(options, $"Printer:             {print.PrintDocument.PrinterSettings.PrinterName}");
+                WriteVerbose(options,
                     $"Paper Size:          {print.PrintDocument.DefaultPageSettings.PaperSize.PaperName}");
-                WriteVerbose (options,
+                WriteVerbose(options,
                     $"Orientation:         {(print.PrintDocument.DefaultPageSettings.Landscape ? "Landscape" : "Portrait")}");
-                WriteVerbose (options, $"Sheet Definition:    {sheet.Name}");
+                WriteVerbose(options, $"Sheet Definition:    {sheet.Name}");
             }
 
-            int sheets = GetFlag (options, "what-if")
-                ? await print.CountSheets (GetInt (options, "from-sheet"), GetInt (options, "to-sheet"))
-                    .ConfigureAwait (false)
-                : await print.DoPrint ().ConfigureAwait (false);
+            int sheets = GetFlag(options, "what-if")
+                ? await print.CountSheets(GetInt(options, "from-sheet"), GetInt(options, "to-sheet"))
+                    .ConfigureAwait(false)
+                : await print.DoPrint().ConfigureAwait(false);
 
-            PrintResult result = new (
-                GetFlag (options, "what-if") ? "counted" : "printed",
+            PrintResult result = new(
+                GetFlag(options, "what-if") ? "counted" : "printed",
                 sheets,
                 print.SheetViewModel.ContentType ?? "",
                 print.SheetViewModel.Language ?? "",
-                print.SheetViewModel.ContentEngine?.GetType ().Name ?? "",
+                print.SheetViewModel.ContentEngine?.GetType().Name ?? "",
                 print.PrintDocument.PrinterSettings.PrinterName,
                 print.PrintDocument.DefaultPageSettings.PaperSize.PaperName,
                 print.PrintDocument.DefaultPageSettings.Landscape ? "Landscape" : "Portrait",
                 sheet.Name);
 
-            return Ok (result, options);
+            return Ok(result, options);
         }
         catch (Exception ex) when (ex is InvalidPrinterException or InvalidOperationException or IOException
                                        or Win32Exception)
         {
-            Log.Error (ex, "winprint failed.");
-            return Error (ex);
+            Log.Error(ex, "winprint failed.");
+            return Error(ex);
         }
     }
 
-    private static async Task LoadContentAsync (
+    private static async Task LoadContentAsync(
         Print print,
         string? fileName,
         string? contentType,
         string? initial,
         CancellationToken cancellationToken)
     {
-        cancellationToken.ThrowIfCancellationRequested ();
+        cancellationToken.ThrowIfCancellationRequested();
 
-        if (!string.IsNullOrEmpty (fileName))
+        if (!string.IsNullOrEmpty(fileName))
         {
-            string path = Path.IsPathFullyQualified (fileName) ? fileName : Path.GetFullPath (fileName);
+            string path = Path.IsPathFullyQualified(fileName) ? fileName : Path.GetFullPath(fileName);
             print.SheetViewModel.File = path;
-            await print.SheetViewModel.LoadFileAsync (path, contentType).ConfigureAwait (false);
+            await print.SheetViewModel.LoadFileAsync(path, contentType).ConfigureAwait(false);
             return;
         }
 
         string document = initial ?? "";
-        if (string.IsNullOrEmpty (document) && Console.IsInputRedirected)
+        if (string.IsNullOrEmpty(document) && Console.IsInputRedirected)
         {
-            document = await Console.In.ReadToEndAsync (cancellationToken).ConfigureAwait (false);
+            document = await Console.In.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        if (string.IsNullOrEmpty (document))
+        if (string.IsNullOrEmpty(document))
         {
-            throw new InvalidOperationException ("Specify a file, pipe text to stdin, or pass --initial text.");
+            throw new InvalidOperationException("Specify a file, pipe text to stdin, or pass --initial text.");
         }
 
         print.SheetViewModel.Encoding = Encoding.UTF8;
-        await print.SheetViewModel.LoadStringAsync (document, contentType).ConfigureAwait (false);
+        await print.SheetViewModel.LoadStringAsync(document, contentType).ConfigureAwait(false);
     }
 
-    private static void ConfigurePrinter (Print print, CommandRunOptions options)
+    private static void ConfigurePrinter(Print print, CommandRunOptions options)
     {
-        if (GetOption (options, "printer") is { Length: > 0 } printer)
+        if (GetOption(options, "printer") is { Length: > 0 } printer)
         {
-            print.SetPrinter (printer);
+            print.SetPrinter(printer);
         }
 
-        if (GetOption (options, "paper-size") is { Length: > 0 } paperSize)
+        if (GetOption(options, "paper-size") is { Length: > 0 } paperSize)
         {
-            print.SetPaperSize (paperSize);
+            print.SetPaperSize(paperSize);
         }
     }
 
-    private static SheetSettings ConfigureSheet (Print print, CommandRunOptions options)
+    private static SheetSettings ConfigureSheet(Print print, CommandRunOptions options)
     {
-        string? sheetDefinition = GetOption (options, "sheet");
-        SheetSettings sheet = print.SheetViewModel.FindSheet (sheetDefinition ?? "", out _);
+        string? sheetDefinition = GetOption(options, "sheet");
+        SheetSettings sheet = print.SheetViewModel.FindSheet(sheetDefinition ?? "", out _);
 
-        if (GetOption (options, "orientation") is { Length: > 0 } orientation)
+        if (GetOption(options, "orientation") is { Length: > 0 } orientation)
         {
-            sheet.Landscape = orientation.Equals ("landscape", StringComparison.OrdinalIgnoreCase)
-                              || orientation.Equals ("yes", StringComparison.OrdinalIgnoreCase);
+            sheet.Landscape = orientation.Equals("landscape", StringComparison.OrdinalIgnoreCase)
+                              || orientation.Equals("yes", StringComparison.OrdinalIgnoreCase);
         }
 
-        if (GetOption (options, "line-numbers") is { Length: > 0 } lineNumbers)
+        if (GetOption(options, "line-numbers") is { Length: > 0 } lineNumbers)
         {
-            sheet.ContentSettings ??= new ContentSettings ();
-            sheet.ContentSettings.LineNumbers = lineNumbers.Equals ("yes", StringComparison.OrdinalIgnoreCase)
-                                                || lineNumbers.Equals ("true", StringComparison.OrdinalIgnoreCase);
+            sheet.ContentSettings ??= new ContentSettings();
+            sheet.ContentSettings.LineNumbers = lineNumbers.Equals("yes", StringComparison.OrdinalIgnoreCase)
+                                                || lineNumbers.Equals("true", StringComparison.OrdinalIgnoreCase);
         }
 
         print.PrintDocument.DefaultPageSettings.Landscape = sheet.Landscape;
-        print.SheetViewModel.SetSheet (sheet);
+        print.SheetViewModel.SetSheet(sheet);
         return sheet;
     }
 
-    private static void ConfigureSheetRange (Print print, CommandRunOptions options)
+    private static void ConfigureSheetRange(Print print, CommandRunOptions options)
     {
-        print.PrintDocument.PrinterSettings.FromPage = GetInt (options, "from-sheet");
-        print.PrintDocument.PrinterSettings.ToPage = GetInt (options, "to-sheet");
+        print.PrintDocument.PrinterSettings.FromPage = GetInt(options, "from-sheet");
+        print.PrintDocument.PrinterSettings.ToPage = GetInt(options, "to-sheet");
     }
 
-    private static void OpenSettingsFile ()
+    private static void OpenSettingsFile()
     {
-        using var proc = Process.Start (new ProcessStartInfo
+        using var proc = Process.Start(new ProcessStartInfo
         {
             UseShellExecute = true,
             FileName = ServiceLocator.Current.SettingsService.SettingsFileName
         });
     }
 
-    private static void OpenGui (string? fileName)
+    private static void OpenGui(string? fileName)
     {
-        string path = Path.GetDirectoryName (Assembly.GetAssembly (typeof (SettingsService))!.Location)!;
-        using var proc = Process.Start (new ProcessStartInfo
+        string path = Path.GetDirectoryName(Assembly.GetAssembly(typeof(SettingsService))!.Location)!;
+        using var proc = Process.Start(new ProcessStartInfo
         {
             UseShellExecute = true,
             Arguments = fileName ?? "",
-            FileName = Path.Combine (path, "winprintgui.exe")
+            FileName = Path.Combine(path, "winprintgui.exe")
         });
     }
 
-    private static string? GetOption (CommandRunOptions options, string name)
+    private static string? GetOption(CommandRunOptions options, string name)
     {
-        return options.CommandOptions.TryGetValue (name, out string? value) ? value : null;
+        return options.CommandOptions.TryGetValue(name, out string? value) ? value : null;
     }
 
-    private static bool GetFlag (CommandRunOptions options, string name)
+    private static bool GetFlag(CommandRunOptions options, string name)
     {
-        return options.CommandOptions.TryGetValue (name, out string? value)
-               && value.Equals ("true", StringComparison.OrdinalIgnoreCase);
+        return options.CommandOptions.TryGetValue(name, out string? value)
+               && value.Equals("true", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static int GetInt (CommandRunOptions options, string name)
+    private static int GetInt(CommandRunOptions options, string name)
     {
-        return options.CommandOptions.TryGetValue (name, out string? value) && int.TryParse (value, out int result)
+        return options.CommandOptions.TryGetValue(name, out string? value) && int.TryParse(value, out int result)
             ? result
             : 0;
     }
 
-    private static void WriteVerbose (CommandRunOptions options, string message)
+    private static void WriteVerbose(CommandRunOptions options, string message)
     {
-        if (options.HasExtension ("verbose"))
+        if (options.HasExtension("verbose"))
         {
-            Console.Error.WriteLine (message);
+            Console.Error.WriteLine(message);
         }
     }
 
-    private static CommandResult Ok (PrintResult result, CommandRunOptions options)
+    private static CommandResult Ok(PrintResult result, CommandRunOptions options)
     {
-        return new CommandResult (CommandStatus.Ok, result.ToString (), null, null);
+        return new CommandResult(CommandStatus.Ok, result.ToString(), null, null);
     }
 
-    private static CommandResult Error (Exception ex)
+    private static CommandResult Error(Exception ex)
     {
-        return new CommandResult (CommandStatus.Error, null, ex.GetType ().Name, ex.Message);
+        return new CommandResult(CommandStatus.Error, null, ex.GetType().Name, ex.Message);
     }
 }

--- a/src/WinPrint.cli/PrintResult.cs
+++ b/src/WinPrint.cli/PrintResult.cs
@@ -1,6 +1,6 @@
 namespace WinPrint.cli;
 
-public sealed record PrintResult (
+public sealed record PrintResult(
     string Action,
     int Sheets,
     string ContentType,
@@ -11,22 +11,22 @@ public sealed record PrintResult (
     string Orientation,
     string SheetDefinition)
 {
-    public override string ToString ()
+    public override string ToString()
     {
         return Action switch
         {
-            "printed" => $"Printed {Sheets} sheet{Plural (Sheets)}.",
-            "counted" => $"Would print {Sheets} sheet{Plural (Sheets)}.",
+            "printed" => $"Printed {Sheets} sheet{Plural(Sheets)}.",
+            "counted" => $"Would print {Sheets} sheet{Plural(Sheets)}.",
             _ => Action
         };
     }
 
-    public static PrintResult NoPrint (string action)
+    public static PrintResult NoPrint(string action)
     {
-        return new PrintResult (action, 0, "", "", "", "", "", "", "");
+        return new PrintResult(action, 0, "", "", "", "", "", "", "");
     }
 
-    private static string Plural (int count)
+    private static string Plural(int count)
     {
         return count == 1 ? "" : "s";
     }

--- a/src/WinPrint.cli/Program.cs
+++ b/src/WinPrint.cli/Program.cs
@@ -3,10 +3,10 @@ using System.Reflection;
 using Terminal.Gui.Cli;
 using WinPrint.cli;
 
-var assembly = Assembly.GetExecutingAssembly ();
-var versionInfo = FileVersionInfo.GetVersionInfo (assembly.Location);
+var assembly = Assembly.GetExecutingAssembly();
+var versionInfo = FileVersionInfo.GetVersionInfo(assembly.Location);
 
-CliHost host = new (options =>
+CliHost host = new(options =>
 {
     options.ApplicationName = "winprint";
     options.Version = versionInfo.ProductVersion ?? "0.0.0";
@@ -14,10 +14,10 @@ CliHost host = new (options =>
     options.AgentGuide = "WinPrint.cli.agent-guide.md";
     options.AgentGuideIsResource = true;
     options.ResourceAssembly = assembly;
-    options.GlobalOptions.Add (new GlobalOptionDescriptor ("verbose", "v", "Write progress details to stderr.", true));
-    options.GlobalOptions.Add (new GlobalOptionDescriptor ("debug", null, "Write diagnostic details to stderr.", true));
+    options.GlobalOptions.Add(new GlobalOptionDescriptor("verbose", "v", "Write progress details to stderr.", true));
+    options.GlobalOptions.Add(new GlobalOptionDescriptor("debug", null, "Write diagnostic details to stderr.", true));
 });
 
-host.Registry.Register (new PrintCommand ());
+host.Registry.Register(new PrintCommand());
 
-return await host.RunAsync (args).ConfigureAwait (false);
+return await host.RunAsync(args).ConfigureAwait(false);

--- a/src/WinPrint.slnx.DotSettings
+++ b/src/WinPrint.slnx.DotSettings
@@ -4,4 +4,6 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Kindel/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=linesperpage/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=winprint/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=winprintgui/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=winprintgui/@EntryIndexedValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeCleanup/Profiles/=WinPrintCleanup/@EntryIndexedValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;Profile name="WinPrintCleanup"&gt;&lt;CSReformatCode&gt;True&lt;/CSReformatCode&gt;&lt;CSCodeStyleAttributes ArrangeTypeAccessModifier="True" ArrangeTypeMemberModifiers="True" ArrangeThisQualifier="True" ArrangeQualifier="True" RemoveRedundantParentheses="True" AddMissingParentheses="True" ArrangeBraces="True" ArrangeAttributes="True" ArrangeArgumentsStyle="True" ArrangeCodeBodyStyle="True" ArrangeVarStyle="True" SortModifiers="True" /&gt;&lt;CSReorderTypeMembers&gt;False&lt;/CSReorderTypeMembers&gt;&lt;CSOptimizeUsings&gt;&lt;OptimizeUsings&gt;False&lt;/OptimizeUsings&gt;&lt;/CSOptimizeUsings&gt;&lt;CSShortenReferences&gt;False&lt;/CSShortenReferences&gt;&lt;RemoveCodeRedundancies&gt;True&lt;/RemoveCodeRedundancies&gt;&lt;/Profile&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeCleanup/SilentCleanupProfile/@EntryValue">WinPrintCleanup</s:String></wpf:ResourceDictionary>

--- a/tests/WinPrint.Core.UnitTests/Cte/AnsiCteTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Cte/AnsiCteTests.cs
@@ -15,218 +15,218 @@ namespace WinPrint.Core.UnitTests.Cte;
 
 public class AnsiCteTests
 {
-    private static readonly string CteClassName = typeof (AnsiCte).Name;
+    private static readonly string CteClassName = typeof(AnsiCte).Name;
 
-    public AnsiCteTests (ITestOutputHelper output)
+    public AnsiCteTests(ITestOutputHelper output)
     {
-        ServiceLocator.Current.LogService.Start (GetType ().Name,
-            new TestOutputSink (output, new MessageTemplateTextFormatter ("{Message:lj}")), true, true);
+        ServiceLocator.Current.LogService.Start(GetType().Name,
+            new TestOutputSink(output, new MessageTemplateTextFormatter("{Message:lj}")), true, true);
     }
 
     [Fact]
-    public void SupportedContentTypesTest ()
+    public void SupportedContentTypesTest()
     {
-        var cte = new AnsiCte ();
-        Assert.Equal (2, cte.SupportedContentTypes.Length);
-        Assert.Equal ("text/plain", cte.SupportedContentTypes[0]);
-        Assert.Equal ("text/ansi", cte.SupportedContentTypes[1]);
+        var cte = new AnsiCte();
+        Assert.Equal(2, cte.SupportedContentTypes.Length);
+        Assert.Equal("text/plain", cte.SupportedContentTypes[0]);
+        Assert.Equal("text/ansi", cte.SupportedContentTypes[1]);
     }
 
     [Fact]
-    public void NewContentTypeEngineTest ()
+    public void NewContentTypeEngineTest()
     {
-        var svm = new SheetViewModel ();
+        var svm = new SheetViewModel();
         (svm.ContentEngine, svm.ContentType, svm.Language) =
-            ContentTypeEngineBase.CreateContentTypeEngine (CteClassName);
-        Assert.NotNull (svm.ContentEngine);
+            ContentTypeEngineBase.CreateContentTypeEngine(CteClassName);
+        Assert.NotNull(svm.ContentEngine);
 
-        Assert.Equal (CteClassName, svm.ContentEngine!.GetType ().Name);
-        Assert.Equal ("text/plain", svm.ContentType);
+        Assert.Equal(CteClassName, svm.ContentEngine!.GetType().Name);
+        Assert.Equal("text/plain", svm.ContentType);
     }
 
     [Fact]
-    public void GetContentTypeTest ()
+    public void GetContentTypeTest()
     {
         //
         // Setup FileAssocaitons service
-        var settings = Settings.CreateDefaultSettings ();
-        ModelLocator.Current.Settings.CopyPropertiesFrom (settings);
+        var settings = Settings.CreateDefaultSettings();
+        ModelLocator.Current.Settings.CopyPropertiesFrom(settings);
 
         // obviouslly text
         string path = "foo.txt";
-        string type = ContentTypeEngineBase.GetContentType (path);
-        Assert.Equal ("text/plain", type);
+        string type = ContentTypeEngineBase.GetContentType(path);
+        Assert.Equal("text/plain", type);
 
         // html
         path = "foo.html";
-        type = ContentTypeEngineBase.GetContentType (path);
-        Assert.Equal ("text/html", type);
+        type = ContentTypeEngineBase.GetContentType(path);
+        Assert.Equal("text/html", type);
 
         path = "foo.htm";
-        type = ContentTypeEngineBase.GetContentType (path);
-        Assert.Equal ("text/html", type);
+        type = ContentTypeEngineBase.GetContentType(path);
+        Assert.Equal("text/html", type);
 
         // Something handled by An
         path = "foo.cs";
-        type = ContentTypeEngineBase.GetContentType (path);
-        Assert.Equal ("text/x-csharp", type);
+        type = ContentTypeEngineBase.GetContentType(path);
+        Assert.Equal("text/x-csharp", type);
 
         // Default
         path = "foo.xxxx";
-        type = ContentTypeEngineBase.GetContentType (path);
-        Assert.Equal ("text/plain", type);
+        type = ContentTypeEngineBase.GetContentType(path);
+        Assert.Equal("text/plain", type);
     }
 
-    [Fact (Skip = "AnsiCte is a stub - libvt100 submodule removed")]
-    public async Task RenderAsyncTest_FixedPitch ()
+    [Fact(Skip = "AnsiCte is a stub - libvt100 submodule removed")]
+    public async Task RenderAsyncTest_FixedPitch()
     {
         string shortLine = "This is a line 0123456789";
         string longLine = "This is a line 01234567890";
 
-        var settings = Settings.CreateDefaultSettings ();
-        ModelLocator.Current.Settings.CopyPropertiesFrom (settings);
+        var settings = Settings.CreateDefaultSettings();
+        ModelLocator.Current.Settings.CopyPropertiesFrom(settings);
 
-        var svm = new SheetViewModel ();
+        var svm = new SheetViewModel();
         (svm.ContentEngine, svm.ContentType, svm.Language) =
-            ContentTypeEngineBase.CreateContentTypeEngine (CteClassName);
+            ContentTypeEngineBase.CreateContentTypeEngine(CteClassName);
 
-        svm.ContentEngine!.ContentSettings = new ContentSettings ();
+        svm.ContentEngine!.ContentSettings = new ContentSettings();
 
         // Setup page so only 1 line will fit
-        svm.Margins = new PrintMargins (0, 0, 0, 0);
+        svm.Margins = new PrintMargins(0, 0, 0, 0);
 
         // Setup page so 10 chars can fit across
-        using var bitmap = new Bitmap (1, 1);
-        bitmap.SetResolution (96, 96);
-        var g = Graphics.FromImage (bitmap);
+        using var bitmap = new Bitmap(1, 1);
+        bitmap.SetResolution(96, 96);
+        var g = Graphics.FromImage(bitmap);
         g.PageUnit = GraphicsUnit.Display; // Display is 1/100th"
         g.TextRenderingHint = ContentTypeEngineBase.TextRenderingHint;
 
         // Set a font that's 1" high
         svm.ContentEngine!.ContentSettings.Font =
             new Font { Family = "Courier New", Size = 72 }; // 72 points is 1" high
-        var font = new System.Drawing.Font (svm.ContentEngine!.ContentSettings.Font.Family,
+        var font = new System.Drawing.Font(svm.ContentEngine!.ContentSettings.Font.Family,
             svm.ContentEngine!.ContentSettings.Font.Size / 72F * 96,
             (System.Drawing.FontStyle)svm.ContentEngine!.ContentSettings.Font.Style, GraphicsUnit.Pixel);
 
         // determine width     
         // Use page settings including lineNumberWidth
-        var proposedSize = new SizeF (10000, font.GetHeight () + font.GetHeight () / 2);
-        SizeF size = g.MeasureString (shortLine, font, proposedSize, ContentTypeEngineBase.StringFormat,
+        var proposedSize = new SizeF(10000, font.GetHeight() + font.GetHeight() / 2);
+        SizeF size = g.MeasureString(shortLine, font, proposedSize, ContentTypeEngineBase.StringFormat,
             out int charsFitted, out int linesFilled);
 
-        Assert.IsType<AnsiCte> (svm.ContentEngine).ContentSettings!.LineNumbers = false;
-        svm.ContentEngine!.PageSize = new SizeF (size.Width, font.GetHeight ()); // a line will be about 108 high
+        Assert.IsType<AnsiCte>(svm.ContentEngine).ContentSettings!.LineNumbers = false;
+        svm.ContentEngine!.PageSize = new SizeF(size.Width, font.GetHeight()); // a line will be about 108 high
 
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync (""));
-        Assert.Equal (1, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync(""));
+        Assert.Equal(1, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
 
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync (" "));
-        Assert.Equal (1, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync(" "));
+        Assert.Equal(1, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
 
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync ("\n"));
-        Assert.Equal (2, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync("\n"));
+        Assert.Equal(2, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
 
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync ("\n\n"));
-        Assert.Equal (3, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync("\n\n"));
+        Assert.Equal(3, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
 
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync ("\n\n\n"));
-        Assert.Equal (4, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync("\n\n\n"));
+        Assert.Equal(4, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
 
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync (" \n"));
-        Assert.Equal (2, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync(" \n"));
+        Assert.Equal(2, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
 
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync (" \n \n"));
-        Assert.Equal (3, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync(" \n \n"));
+        Assert.Equal(3, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
 
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync (shortLine));
-        Assert.Equal (1, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync(shortLine));
+        Assert.Equal(1, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
 
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync (shortLine + '_'));
-        Assert.Equal (2, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync(shortLine + '_'));
+        Assert.Equal(2, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
 
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync (shortLine + '\n'));
-        Assert.Equal (2, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync(shortLine + '\n'));
+        Assert.Equal(2, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
 
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync (shortLine.Replace ('9', ' ')));
-        Assert.Equal (1, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync(shortLine.Replace('9', ' ')));
+        Assert.Equal(1, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
 
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync ($"{shortLine}\n{shortLine}"));
-        Assert.Equal (2, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync($"{shortLine}\n{shortLine}"));
+        Assert.Equal(2, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
 
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync ($"{shortLine}\n{shortLine}\n{shortLine}"));
-        Assert.Equal (3, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync($"{shortLine}\n{shortLine}\n{shortLine}"));
+        Assert.Equal(3, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
 
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync ($"{shortLine}\n{shortLine}\n{shortLine}\n"));
-        Assert.Equal (4, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync($"{shortLine}\n{shortLine}\n{shortLine}\n"));
+        Assert.Equal(4, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
 
         // Test line wrapping
         // 0123456789
         // 0
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync ($"{longLine}"));
-        Assert.Equal (2, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync($"{longLine}"));
+        Assert.Equal(2, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
 
         // 0123456789
         // 0A
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync ($"{longLine}A"));
-        Assert.Equal (2, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync($"{longLine}A"));
+        Assert.Equal(2, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
 
         // 0123456789
         // 0A01234567
         // 89
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync ($"{longLine}A{longLine}"));
-        Assert.Equal (3, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync($"{longLine}A{longLine}"));
+        Assert.Equal(3, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
     }
 
-    [Fact (Skip = "AnsiCte is a stub - libvt100 submodule removed")]
-    public async Task RenderAsyncTest_LineWrap ()
+    [Fact(Skip = "AnsiCte is a stub - libvt100 submodule removed")]
+    public async Task RenderAsyncTest_LineWrap()
     {
         string text = "1";
         string ansiText = "[38;2;0;0;207;01m1[39;00m";
 
-        var settings = Settings.CreateDefaultSettings ();
-        ModelLocator.Current.Settings.CopyPropertiesFrom (settings);
+        var settings = Settings.CreateDefaultSettings();
+        ModelLocator.Current.Settings.CopyPropertiesFrom(settings);
 
-        var svm = new SheetViewModel ();
+        var svm = new SheetViewModel();
         (svm.ContentEngine, svm.ContentType, svm.Language) =
-            ContentTypeEngineBase.CreateContentTypeEngine (CteClassName);
+            ContentTypeEngineBase.CreateContentTypeEngine(CteClassName);
 
-        svm.ContentEngine!.ContentSettings = new ContentSettings ();
+        svm.ContentEngine!.ContentSettings = new ContentSettings();
 
         // Setup page so only 1 line will fit
-        svm.Margins = new PrintMargins (0, 0, 0, 0);
+        svm.Margins = new PrintMargins(0, 0, 0, 0);
 
         // Setup page so 10 chars can fit across
-        using var bitmap = new Bitmap (1, 1);
-        bitmap.SetResolution (96, 96);
-        var g = Graphics.FromImage (bitmap);
+        using var bitmap = new Bitmap(1, 1);
+        bitmap.SetResolution(96, 96);
+        var g = Graphics.FromImage(bitmap);
         g.PageUnit = GraphicsUnit.Display; // Display is 1/100th"
         g.TextRenderingHint = ContentTypeEngineBase.TextRenderingHint;
 
         // Set a font that's 1" high
         svm.ContentEngine!.ContentSettings.Font =
             new Font { Family = "Courier New", Size = 72 }; // 72 points is 1" high
-        var font = new System.Drawing.Font (svm.ContentEngine!.ContentSettings.Font.Family,
+        var font = new System.Drawing.Font(svm.ContentEngine!.ContentSettings.Font.Family,
             svm.ContentEngine!.ContentSettings.Font.Size / 72F * 96,
             (System.Drawing.FontStyle)svm.ContentEngine!.ContentSettings.Font.Style, GraphicsUnit.Pixel);
 
         // determine width     
         // Use page settings including lineNumberWidth
-        var proposedSize = new SizeF (10000, font.GetHeight () + font.GetHeight () / 2);
-        SizeF size = g.MeasureString (text, font, proposedSize, ContentTypeEngineBase.StringFormat, out int charsFitted,
+        var proposedSize = new SizeF(10000, font.GetHeight() + font.GetHeight() / 2);
+        SizeF size = g.MeasureString(text, font, proposedSize, ContentTypeEngineBase.StringFormat, out int charsFitted,
             out int linesFilled);
 
-        Assert.IsType<AnsiCte> (svm.ContentEngine).ContentSettings!.LineNumbers = false;
-        svm.ContentEngine!.PageSize = new SizeF (size.Width, font.GetHeight ()); // a line will be about 108 high
+        Assert.IsType<AnsiCte>(svm.ContentEngine).ContentSettings!.LineNumbers = false;
+        svm.ContentEngine!.PageSize = new SizeF(size.Width, font.GetHeight()); // a line will be about 108 high
 
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync (""));
-        Assert.Equal (1, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync(""));
+        Assert.Equal(1, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
 
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync (text));
-        Assert.Equal (1, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync(text));
+        Assert.Equal(1, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
 
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync (ansiText));
-        Assert.Equal (1, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync(ansiText));
+        Assert.Equal(1, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
     }
 
     //[Fact]

--- a/tests/WinPrint.Core.UnitTests/Cte/BaseCteTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Cte/BaseCteTests.cs
@@ -12,137 +12,137 @@ namespace WinPrint.Core.UnitTests.Cte;
 
 public class BaseCteTests
 {
-    public BaseCteTests (ITestOutputHelper output)
+    public BaseCteTests(ITestOutputHelper output)
     {
-        ServiceLocator.Current.LogService.Start (GetType ().Name,
-            new TestOutputSink (output, new MessageTemplateTextFormatter ("{Message:lj}")), true, true);
+        ServiceLocator.Current.LogService.Start(GetType().Name,
+            new TestOutputSink(output, new MessageTemplateTextFormatter("{Message:lj}")), true, true);
     }
 
     [Fact]
-    public void CreateContentTypeEngine_CteClassName ()
+    public void CreateContentTypeEngine_CteClassName()
     {
-        foreach (ContentTypeEngineBase cte in ContentTypeEngineBase.GetDerivedClassesCollection ())
+        foreach (ContentTypeEngineBase cte in ContentTypeEngineBase.GetDerivedClassesCollection())
         {
-            string CteClassName = cte.GetType ().Name;
-            var svm = new SheetViewModel ();
+            string CteClassName = cte.GetType().Name;
+            var svm = new SheetViewModel();
             (svm.ContentEngine, svm.ContentType, svm.Language) =
-                ContentTypeEngineBase.CreateContentTypeEngine (CteClassName);
-            Assert.NotNull (svm.ContentEngine);
+                ContentTypeEngineBase.CreateContentTypeEngine(CteClassName);
+            Assert.NotNull(svm.ContentEngine);
 
-            Assert.Equal (CteClassName, svm.ContentEngine!.GetType ().Name);
-            Assert.Equal (cte.SupportedContentTypes[0], svm.ContentType);
+            Assert.Equal(CteClassName, svm.ContentEngine!.GetType().Name);
+            Assert.Equal(cte.SupportedContentTypes[0], svm.ContentType);
         }
     }
 
     [Fact]
-    public void GetContentTypeOrLanguageTest ()
+    public void GetContentTypeOrLanguageTest()
     {
-        ServiceLocator.Current.SettingsService.SettingsFileName = $"WinPrint.{GetType ().Name}.json";
-        File.Delete (ServiceLocator.Current.SettingsService.SettingsFileName);
-        Settings? settings = ServiceLocator.Current.SettingsService.ReadSettings ();
-        ModelLocator.Current.Settings.CopyPropertiesFrom (settings);
-        FileTypeMapping ftm = ServiceLocator.Current.FileTypeMappingService.Load ();
-        Assert.NotNull (ftm);
+        ServiceLocator.Current.SettingsService.SettingsFileName = $"WinPrint.{GetType().Name}.json";
+        File.Delete(ServiceLocator.Current.SettingsService.SettingsFileName);
+        Settings? settings = ServiceLocator.Current.SettingsService.ReadSettings();
+        ModelLocator.Current.Settings.CopyPropertiesFrom(settings);
+        FileTypeMapping ftm = ServiceLocator.Current.FileTypeMappingService.Load();
+        Assert.NotNull(ftm);
         IList<ContentType> langs = ftm.ContentTypes;
-        Assert.NotNull (langs);
+        Assert.NotNull(langs);
         // For every cte, ensure every supported content type is valid
-        foreach (ContentTypeEngineBase c in ContentTypeEngineBase.GetDerivedClassesCollection ())
+        foreach (ContentTypeEngineBase c in ContentTypeEngineBase.GetDerivedClassesCollection())
         {
             foreach (string t in c.SupportedContentTypes)
             {
-                Assert.Contains (langs, l => l.Id == t || l.Aliases.Contains (t));
+                Assert.Contains(langs, l => l.Id == t || l.Aliases.Contains(t));
             }
         }
 
         // obviouslly text
         string path = "foo.txt";
-        string type = ContentTypeEngineBase.GetContentType (path);
-        Assert.Equal ("text/plain", type);
+        string type = ContentTypeEngineBase.GetContentType(path);
+        Assert.Equal("text/plain", type);
 
         path = "*.txt";
-        type = ContentTypeEngineBase.GetContentType (path);
-        Assert.Equal ("text/plain", type);
+        type = ContentTypeEngineBase.GetContentType(path);
+        Assert.Equal("text/plain", type);
 
         path = "text";
-        type = ContentTypeEngineBase.GetContentType (path);
-        Assert.Equal ("text/plain", type);
+        type = ContentTypeEngineBase.GetContentType(path);
+        Assert.Equal("text/plain", type);
 
         path = "text/plain";
-        type = ContentTypeEngineBase.GetContentType (path);
-        Assert.Equal ("text/plain", type);
+        type = ContentTypeEngineBase.GetContentType(path);
+        Assert.Equal("text/plain", type);
 
         // html
         path = "foo.html";
-        type = ContentTypeEngineBase.GetContentType (path);
-        Assert.Equal ("text/html", type);
+        type = ContentTypeEngineBase.GetContentType(path);
+        Assert.Equal("text/html", type);
 
         path = "foo.htm";
-        type = ContentTypeEngineBase.GetContentType (path);
-        Assert.Equal ("text/html", type);
+        type = ContentTypeEngineBase.GetContentType(path);
+        Assert.Equal("text/html", type);
 
         // Something handled by prismcte
         path = "foo.cs";
-        type = ContentTypeEngineBase.GetContentType (path);
-        Assert.Equal ("text/x-csharp", type);
+        type = ContentTypeEngineBase.GetContentType(path);
+        Assert.Equal("text/x-csharp", type);
 
         path = "*.cs";
-        type = ContentTypeEngineBase.GetContentType (path);
-        Assert.Equal ("text/x-csharp", type);
+        type = ContentTypeEngineBase.GetContentType(path);
+        Assert.Equal("text/x-csharp", type);
 
         // Defeault
         path = "foo.json";
-        type = ContentTypeEngineBase.GetContentType (path);
-        Assert.Equal ("application/json", type);
+        type = ContentTypeEngineBase.GetContentType(path);
+        Assert.Equal("application/json", type);
 
         // Default
         path = "foo.xxxx";
-        type = ContentTypeEngineBase.GetContentType (path);
-        Assert.Equal ("text/plain", type);
+        type = ContentTypeEngineBase.GetContentType(path);
+        Assert.Equal("text/plain", type);
 
         path = ".travis.yml";
-        type = ContentTypeEngineBase.GetContentType (path);
-        Assert.Equal ("text/x-yaml", type);
+        type = ContentTypeEngineBase.GetContentType(path);
+        Assert.Equal("text/x-yaml", type);
 
         path = ".bashrc";
-        type = ContentTypeEngineBase.GetContentType (path);
-        Assert.Equal ("application/x-sh", type);
+        type = ContentTypeEngineBase.GetContentType(path);
+        Assert.Equal("application/x-sh", type);
 
         path = "Kconfig";
-        type = ContentTypeEngineBase.GetContentType (path);
-        Assert.Equal ("text/x-kconfig", type);
+        type = ContentTypeEngineBase.GetContentType(path);
+        Assert.Equal("text/x-kconfig", type);
 
         path = "kconfig";
-        type = ContentTypeEngineBase.GetContentType (path);
-        Assert.Equal ("text/x-kconfig", type);
+        type = ContentTypeEngineBase.GetContentType(path);
+        Assert.Equal("text/x-kconfig", type);
     }
 
     [Fact]
-    public void CreateContentTypeEngineTests ()
+    public void CreateContentTypeEngineTests()
     {
         // TODO: Mock this out
-        ServiceLocator.Current.SettingsService.SettingsFileName = $"WinPrint.{GetType ().Name}.json";
-        File.Delete (ServiceLocator.Current.SettingsService.SettingsFileName);
+        ServiceLocator.Current.SettingsService.SettingsFileName = $"WinPrint.{GetType().Name}.json";
+        File.Delete(ServiceLocator.Current.SettingsService.SettingsFileName);
 
-        Settings? settings = ServiceLocator.Current.SettingsService.ReadSettings ();
-        ModelLocator.Current.Settings.CopyPropertiesFrom (settings);
+        Settings? settings = ServiceLocator.Current.SettingsService.ReadSettings();
+        ModelLocator.Current.Settings.CopyPropertiesFrom(settings);
 
         // (ContentTypeEngineBase cte, string language) CreateContentTypeEngine(string contentType)
         ContentTypeEngineBase? cte;
         string? contentType, language;
 
         string input = "json";
-        (cte, contentType, language) = ContentTypeEngineBase.CreateContentTypeEngine (input);
-        Assert.NotNull (cte);
-        Assert.Equal (ContentTypeEngineBase.DefaultSyntaxHighlighterCteNameClassName, cte.GetType ().Name);
-        Assert.Equal ("application/json", contentType);
-        Assert.Equal ("JSON", language);
+        (cte, contentType, language) = ContentTypeEngineBase.CreateContentTypeEngine(input);
+        Assert.NotNull(cte);
+        Assert.Equal(ContentTypeEngineBase.DefaultSyntaxHighlighterCteNameClassName, cte.GetType().Name);
+        Assert.Equal("application/json", contentType);
+        Assert.Equal("JSON", language);
 
         input = "csharp";
-        (cte, contentType, language) = ContentTypeEngineBase.CreateContentTypeEngine (input);
-        Assert.NotNull (cte);
-        Assert.Equal (ContentTypeEngineBase.DefaultSyntaxHighlighterCteNameClassName, cte.GetType ().Name);
-        Assert.Equal ("text/x-csharp", contentType);
-        Assert.Equal ("C#", language);
+        (cte, contentType, language) = ContentTypeEngineBase.CreateContentTypeEngine(input);
+        Assert.NotNull(cte);
+        Assert.Equal(ContentTypeEngineBase.DefaultSyntaxHighlighterCteNameClassName, cte.GetType().Name);
+        Assert.Equal("text/x-csharp", contentType);
+        Assert.Equal("C#", language);
 
         //contentType = "markup";
         //(cte, language) = ContentTypeEngineBase.CreateContentTypeEngine(contentType);
@@ -151,74 +151,74 @@ public class BaseCteTests
         //Assert.Equal(contentType, language);
 
         input = "text";
-        (cte, contentType, language) = ContentTypeEngineBase.CreateContentTypeEngine (input);
-        Assert.NotNull (cte);
-        Assert.Equal (ModelLocator.Current.Settings.DefaultCteClassName, cte.GetType ().Name);
-        Assert.Equal ("text/plain", contentType);
-        Assert.Equal ("Plain Text", language);
+        (cte, contentType, language) = ContentTypeEngineBase.CreateContentTypeEngine(input);
+        Assert.NotNull(cte);
+        Assert.Equal(ModelLocator.Current.Settings.DefaultCteClassName, cte.GetType().Name);
+        Assert.Equal("text/plain", contentType);
+        Assert.Equal("Plain Text", language);
 
         input = "TextCte";
-        (cte, contentType, language) = ContentTypeEngineBase.CreateContentTypeEngine (input);
-        Assert.NotNull (cte);
-        Assert.Equal (typeof (TextCte).Name, cte.GetType ().Name);
-        Assert.Equal ("text/plain", contentType);
-        Assert.Equal ("Plain Text", language);
+        (cte, contentType, language) = ContentTypeEngineBase.CreateContentTypeEngine(input);
+        Assert.NotNull(cte);
+        Assert.Equal(typeof(TextCte).Name, cte.GetType().Name);
+        Assert.Equal("text/plain", contentType);
+        Assert.Equal("Plain Text", language);
 
         input = "ansi";
-        (cte, contentType, language) = ContentTypeEngineBase.CreateContentTypeEngine (input);
-        Assert.NotNull (cte);
-        Assert.Equal (typeof (AnsiCte).Name, cte.GetType ().Name);
-        Assert.Equal ("text/ansi", contentType);
-        Assert.Equal ("ANSI Text", language);
+        (cte, contentType, language) = ContentTypeEngineBase.CreateContentTypeEngine(input);
+        Assert.NotNull(cte);
+        Assert.Equal(typeof(AnsiCte).Name, cte.GetType().Name);
+        Assert.Equal("text/ansi", contentType);
+        Assert.Equal("ANSI Text", language);
 
         input = "AnsiCte";
-        (cte, contentType, language) = ContentTypeEngineBase.CreateContentTypeEngine (input);
-        Assert.NotNull (cte);
-        Assert.Equal (typeof (AnsiCte).Name, cte.GetType ().Name);
-        Assert.Equal ("text/plain", contentType);
-        Assert.Equal ("Plain Text", language);
+        (cte, contentType, language) = ContentTypeEngineBase.CreateContentTypeEngine(input);
+        Assert.NotNull(cte);
+        Assert.Equal(typeof(AnsiCte).Name, cte.GetType().Name);
+        Assert.Equal("text/plain", contentType);
+        Assert.Equal("Plain Text", language);
 
         input = "html";
-        (cte, contentType, language) = ContentTypeEngineBase.CreateContentTypeEngine (input);
-        Assert.NotNull (cte);
-        Assert.Equal (typeof (HtmlCte).Name, cte.GetType ().Name);
-        Assert.Equal ("text/html", contentType);
-        Assert.Equal ("HTML", language);
+        (cte, contentType, language) = ContentTypeEngineBase.CreateContentTypeEngine(input);
+        Assert.NotNull(cte);
+        Assert.Equal(typeof(HtmlCte).Name, cte.GetType().Name);
+        Assert.Equal("text/html", contentType);
+        Assert.Equal("HTML", language);
 
         input = "HtmlCte";
-        (cte, contentType, language) = ContentTypeEngineBase.CreateContentTypeEngine (input);
-        Assert.NotNull (cte);
-        Assert.Equal (typeof (HtmlCte).Name, cte.GetType ().Name);
-        Assert.Equal ("text/html", contentType);
-        Assert.Equal ("HTML", language);
+        (cte, contentType, language) = ContentTypeEngineBase.CreateContentTypeEngine(input);
+        Assert.NotNull(cte);
+        Assert.Equal(typeof(HtmlCte).Name, cte.GetType().Name);
+        Assert.Equal("text/html", contentType);
+        Assert.Equal("HTML", language);
 
         // text/plain should always use default
         input = "text/plain";
-        (cte, contentType, language) = ContentTypeEngineBase.CreateContentTypeEngine (input);
-        Assert.NotNull (cte);
-        Assert.Equal (ModelLocator.Current.Settings.DefaultCteClassName, cte.GetType ().Name);
-        Assert.Equal (input, contentType);
-        Assert.Equal ("Plain Text", language);
+        (cte, contentType, language) = ContentTypeEngineBase.CreateContentTypeEngine(input);
+        Assert.NotNull(cte);
+        Assert.Equal(ModelLocator.Current.Settings.DefaultCteClassName, cte.GetType().Name);
+        Assert.Equal(input, contentType);
+        Assert.Equal("Plain Text", language);
 
         input = "text/ansi";
-        (cte, contentType, language) = ContentTypeEngineBase.CreateContentTypeEngine (input);
-        Assert.NotNull (cte);
-        Assert.Equal (typeof (AnsiCte).Name, cte.GetType ().Name);
-        Assert.Equal (input, contentType);
-        Assert.Equal ("ANSI Text", language);
+        (cte, contentType, language) = ContentTypeEngineBase.CreateContentTypeEngine(input);
+        Assert.NotNull(cte);
+        Assert.Equal(typeof(AnsiCte).Name, cte.GetType().Name);
+        Assert.Equal(input, contentType);
+        Assert.Equal("ANSI Text", language);
 
         input = "text/html";
-        (cte, contentType, language) = ContentTypeEngineBase.CreateContentTypeEngine (input);
-        Assert.NotNull (cte);
-        Assert.Equal (typeof (HtmlCte).Name, cte.GetType ().Name);
-        Assert.Equal (input, contentType);
-        Assert.Equal ("HTML", language);
+        (cte, contentType, language) = ContentTypeEngineBase.CreateContentTypeEngine(input);
+        Assert.NotNull(cte);
+        Assert.Equal(typeof(HtmlCte).Name, cte.GetType().Name);
+        Assert.Equal(input, contentType);
+        Assert.Equal("HTML", language);
 
         input = "text/x-smalltalk";
-        (cte, contentType, language) = ContentTypeEngineBase.CreateContentTypeEngine (input);
-        Assert.NotNull (cte);
-        Assert.Equal (ContentTypeEngineBase.DefaultSyntaxHighlighterCteNameClassName, cte.GetType ().Name);
-        Assert.Equal (input, contentType);
-        Assert.Equal ("Smalltalk", language);
+        (cte, contentType, language) = ContentTypeEngineBase.CreateContentTypeEngine(input);
+        Assert.NotNull(cte);
+        Assert.Equal(ContentTypeEngineBase.DefaultSyntaxHighlighterCteNameClassName, cte.GetType().Name);
+        Assert.Equal(input, contentType);
+        Assert.Equal("Smalltalk", language);
     }
 }

--- a/tests/WinPrint.Core.UnitTests/Cte/CteRenderingTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Cte/CteRenderingTests.cs
@@ -1,0 +1,158 @@
+using System.Linq;
+using System.Threading.Tasks;
+using WinPrint.Core.Abstractions;
+using WinPrint.Core.ContentTypeEngines;
+using WinPrint.Core.Models;
+using WinPrint.Core.UnitTests.TestSupport;
+using Xunit;
+using Font = WinPrint.Core.Models.Font;
+
+namespace WinPrint.Core.UnitTests.Cte;
+
+/// <summary>
+///     Cross-platform rendering tests for Content Type Engines. These drive the full
+///     SetDocument -> RenderAsync -> PaintPage pipeline using a <see cref="RecordingGraphicsContext" />
+///     (a fixed-pitch, System.Drawing-free graphics double), so reflow (page counting / line wrapping)
+///     and painting (which text is drawn where) can be verified on any platform, including Linux CI.
+///
+///     The recording context uses CharWidth=10 and LineHeight=20, so geometry is exact:
+///     a 100pt-wide page fits 10 chars; a 60pt-tall page fits 3 lines.
+/// </summary>
+public class CteRenderingTests
+{
+    private const float CharWidth = 10f;
+    private const float LineHeight = 20f;
+
+    private static TextCte MakeTextCte (IGraphicsContext measure, float pageWidth, float pageHeight,
+        bool lineNumbers = false)
+    {
+        var cte = new TextCte
+        {
+            ContentSettings = new ContentSettings
+            {
+                Font = new Font { Family = "Courier New", Size = 10 },
+                LineNumbers = lineNumbers,
+                TabSpaces = 4
+            },
+            MeasurementContext = measure,
+            PageSize = new System.Drawing.SizeF (pageWidth, pageHeight)
+        };
+        return cte;
+    }
+
+    private static PrintResolution Dpi96 => new () { X = 96, Y = 96 };
+
+    [Fact]
+    public async Task TextCte_CountsPages_FromLinesPerPage ()
+    {
+        var g = new RecordingGraphicsContext (CharWidth, LineHeight);
+        // Page fits 3 lines (60 / 20). Four short lines => 2 pages.
+        var cte = MakeTextCte (g, pageWidth: 100, pageHeight: 60);
+
+        Assert.True (await cte.SetDocumentAsync ("aaaa\nbbbb\ncccc\ndddd"));
+        int pages = await cte.RenderAsync (Dpi96, null);
+
+        Assert.Equal (2, pages);
+    }
+
+    [Fact]
+    public async Task TextCte_PaintPage_DrawsLinesAtExpectedPositions ()
+    {
+        var measure = new RecordingGraphicsContext (CharWidth, LineHeight);
+        var cte = MakeTextCte (measure, pageWidth: 100, pageHeight: 60);
+
+        Assert.True (await cte.SetDocumentAsync ("aaaa\nbbbb\ncccc\ndddd"));
+        await cte.RenderAsync (Dpi96, null);
+
+        // Page 1: first three lines at y = 0, 20, 40 (x = 0 because line numbers are off).
+        var paint = new RecordingGraphicsContext (CharWidth, LineHeight);
+        cte.PaintPage (paint, 1);
+
+        Assert.Equal (3, paint.DrawnStrings.Count);
+        Assert.Equal (new RecordedString ("aaaa", 0, 0), paint.DrawnStrings[0]);
+        Assert.Equal (new RecordedString ("bbbb", 0, 20), paint.DrawnStrings[1]);
+        Assert.Equal (new RecordedString ("cccc", 0, 40), paint.DrawnStrings[2]);
+
+        // Page 2: the remaining line at the top.
+        var paint2 = new RecordingGraphicsContext (CharWidth, LineHeight);
+        cte.PaintPage (paint2, 2);
+
+        Assert.Equal (new RecordedString ("dddd", 0, 0), Assert.Single (paint2.DrawnStrings));
+    }
+
+    [Fact]
+    public async Task TextCte_WrapsLongLine_ToPageWidth ()
+    {
+        var measure = new RecordingGraphicsContext (CharWidth, LineHeight);
+        // 100pt-wide page fits exactly 10 chars.
+        var cte = MakeTextCte (measure, pageWidth: 100, pageHeight: 200);
+
+        Assert.True (await cte.SetDocumentAsync (new string ('a', 12)));
+        int pages = await cte.RenderAsync (Dpi96, null);
+
+        Assert.Equal (1, pages);
+
+        var paint = new RecordingGraphicsContext (CharWidth, LineHeight);
+        cte.PaintPage (paint, 1);
+
+        // The 12-char line wraps into a 10-char line and a 2-char remainder.
+        Assert.Equal (2, paint.DrawnStrings.Count);
+        Assert.Equal (new string ('a', 10), paint.DrawnStrings[0].Text);
+        Assert.Equal (new string ('a', 2), paint.DrawnStrings[1].Text);
+        Assert.Equal (0, paint.DrawnStrings[1].X);
+        Assert.Equal (LineHeight, paint.DrawnStrings[1].Y);
+    }
+
+    [Fact]
+    public async Task TextCte_WithLineNumbers_DrawsNumberAndIndentsText ()
+    {
+        var measure = new RecordingGraphicsContext (CharWidth, LineHeight);
+        // Line number width = 4 chars * 10 = 40; text area = 100.
+        var cte = MakeTextCte (measure, pageWidth: 140, pageHeight: 60, lineNumbers: true);
+
+        Assert.True (await cte.SetDocumentAsync ("abc"));
+        await cte.RenderAsync (Dpi96, null);
+
+        var paint = new RecordingGraphicsContext (CharWidth, LineHeight);
+        cte.PaintPage (paint, 1);
+
+        // The line number "1" is drawn in the gutter and the text is indented past it (x = gutter width = 40).
+        Assert.Contains (paint.DrawnStrings, s => s.Text == "1" && s.Y == 0);
+        Assert.Contains (new RecordedString ("abc", 40, 0), paint.DrawnStrings);
+        // The line-number separator is drawn as a vertical line in the gutter.
+        Assert.NotEmpty (paint.DrawnLines);
+    }
+
+    [Fact]
+    public async Task MarkdownCte_RendersFlattenedText ()
+    {
+        var measure = new RecordingGraphicsContext (CharWidth, LineHeight);
+        var cte = new MarkdownCte
+        {
+            ContentSettings = new ContentSettings
+            {
+                Font = new Font { Family = "Courier New", Size = 10 },
+                LineNumbers = false,
+                TabSpaces = 4
+            },
+            MeasurementContext = measure,
+            PageSize = new System.Drawing.SizeF (200, 200)
+        };
+
+        Assert.True (await cte.SetDocumentAsync ("# Title\n\nHello world"));
+        int pages = await cte.RenderAsync (Dpi96, null);
+
+        Assert.True (pages >= 1);
+
+        var paint = new RecordingGraphicsContext (CharWidth, LineHeight);
+        for (int p = 1; p <= pages; p++)
+        {
+            cte.PaintPage (paint, p);
+        }
+
+        // Markdown markers are gone; the prose is rendered.
+        Assert.Contains (paint.DrawnStrings, s => s.Text.Contains ("Title"));
+        Assert.Contains (paint.DrawnStrings, s => s.Text.Contains ("Hello world"));
+        Assert.DoesNotContain (paint.DrawnStrings, s => s.Text.Contains ("#"));
+    }
+}

--- a/tests/WinPrint.Core.UnitTests/Cte/CteRenderingTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Cte/CteRenderingTests.cs
@@ -124,6 +124,38 @@ public class CteRenderingTests
     }
 
     [Fact]
+    public async Task TextMateCte_RendersTokenizedText_CrossPlatform ()
+    {
+        var measure = new RecordingGraphicsContext (CharWidth, LineHeight);
+        var cte = new TextMateCte
+        {
+            ContentSettings = new ContentSettings
+            {
+                Font = new Font { Family = "Courier New", Size = 10 },
+                LineNumbers = false,
+                TabSpaces = 4,
+                Style = "VisualStudioLight"
+            },
+            MeasurementContext = measure,
+            PageSize = new System.Drawing.SizeF (200, 60)
+        };
+
+        Assert.True (await cte.SetDocumentAsync ("hello\nworld"));
+        int pages = await cte.RenderAsync (Dpi96, null);
+
+        Assert.True (pages >= 1);
+
+        var paint = new RecordingGraphicsContext (CharWidth, LineHeight);
+        for (int p = 1; p <= pages; p++)
+        {
+            cte.PaintPage (paint, p);
+        }
+
+        Assert.Contains (paint.DrawnStrings, s => s.Text.Contains ("hello"));
+        Assert.Contains (paint.DrawnStrings, s => s.Text.Contains ("world"));
+    }
+
+    [Fact]
     public async Task MarkdownCte_RendersFlattenedText ()
     {
         var measure = new RecordingGraphicsContext (CharWidth, LineHeight);

--- a/tests/WinPrint.Core.UnitTests/Cte/CteRenderingTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Cte/CteRenderingTests.cs
@@ -23,7 +23,7 @@ public class CteRenderingTests
     private const float CharWidth = 10f;
     private const float LineHeight = 20f;
 
-    private static TextCte MakeTextCte (IGraphicsContext measure, float pageWidth, float pageHeight,
+    private static TextCte MakeTextCte(IGraphicsContext measure, float pageWidth, float pageHeight,
         bool lineNumbers = false)
     {
         var cte = new TextCte
@@ -35,98 +35,98 @@ public class CteRenderingTests
                 TabSpaces = 4
             },
             MeasurementContext = measure,
-            PageSize = new System.Drawing.SizeF (pageWidth, pageHeight)
+            PageSize = new System.Drawing.SizeF(pageWidth, pageHeight)
         };
         return cte;
     }
 
-    private static PrintResolution Dpi96 => new () { X = 96, Y = 96 };
+    private static PrintResolution Dpi96 => new() { X = 96, Y = 96 };
 
     [Fact]
-    public async Task TextCte_CountsPages_FromLinesPerPage ()
+    public async Task TextCte_CountsPages_FromLinesPerPage()
     {
-        var g = new RecordingGraphicsContext (CharWidth, LineHeight);
+        var g = new RecordingGraphicsContext();
         // Page fits 3 lines (60 / 20). Four short lines => 2 pages.
-        var cte = MakeTextCte (g, pageWidth: 100, pageHeight: 60);
+        TextCte cte = MakeTextCte(g, 100, 60);
 
-        Assert.True (await cte.SetDocumentAsync ("aaaa\nbbbb\ncccc\ndddd"));
-        int pages = await cte.RenderAsync (Dpi96, null);
+        Assert.True(await cte.SetDocumentAsync("aaaa\nbbbb\ncccc\ndddd"));
+        int pages = await cte.RenderAsync(Dpi96, null);
 
-        Assert.Equal (2, pages);
+        Assert.Equal(2, pages);
     }
 
     [Fact]
-    public async Task TextCte_PaintPage_DrawsLinesAtExpectedPositions ()
+    public async Task TextCte_PaintPage_DrawsLinesAtExpectedPositions()
     {
-        var measure = new RecordingGraphicsContext (CharWidth, LineHeight);
-        var cte = MakeTextCte (measure, pageWidth: 100, pageHeight: 60);
+        var measure = new RecordingGraphicsContext();
+        TextCte cte = MakeTextCte(measure, 100, 60);
 
-        Assert.True (await cte.SetDocumentAsync ("aaaa\nbbbb\ncccc\ndddd"));
-        await cte.RenderAsync (Dpi96, null);
+        Assert.True(await cte.SetDocumentAsync("aaaa\nbbbb\ncccc\ndddd"));
+        await cte.RenderAsync(Dpi96, null);
 
         // Page 1: first three lines at y = 0, 20, 40 (x = 0 because line numbers are off).
-        var paint = new RecordingGraphicsContext (CharWidth, LineHeight);
-        cte.PaintPage (paint, 1);
+        var paint = new RecordingGraphicsContext();
+        cte.PaintPage(paint, 1);
 
-        Assert.Equal (3, paint.DrawnStrings.Count);
-        Assert.Equal (new RecordedString ("aaaa", 0, 0), paint.DrawnStrings[0]);
-        Assert.Equal (new RecordedString ("bbbb", 0, 20), paint.DrawnStrings[1]);
-        Assert.Equal (new RecordedString ("cccc", 0, 40), paint.DrawnStrings[2]);
+        Assert.Equal(3, paint.DrawnStrings.Count);
+        Assert.Equal(new RecordedString("aaaa", 0, 0), paint.DrawnStrings[0]);
+        Assert.Equal(new RecordedString("bbbb", 0, 20), paint.DrawnStrings[1]);
+        Assert.Equal(new RecordedString("cccc", 0, 40), paint.DrawnStrings[2]);
 
         // Page 2: the remaining line at the top.
-        var paint2 = new RecordingGraphicsContext (CharWidth, LineHeight);
-        cte.PaintPage (paint2, 2);
+        var paint2 = new RecordingGraphicsContext();
+        cte.PaintPage(paint2, 2);
 
-        Assert.Equal (new RecordedString ("dddd", 0, 0), Assert.Single (paint2.DrawnStrings));
+        Assert.Equal(new RecordedString("dddd", 0, 0), Assert.Single(paint2.DrawnStrings));
     }
 
     [Fact]
-    public async Task TextCte_WrapsLongLine_ToPageWidth ()
+    public async Task TextCte_WrapsLongLine_ToPageWidth()
     {
-        var measure = new RecordingGraphicsContext (CharWidth, LineHeight);
+        var measure = new RecordingGraphicsContext();
         // 100pt-wide page fits exactly 10 chars.
-        var cte = MakeTextCte (measure, pageWidth: 100, pageHeight: 200);
+        TextCte cte = MakeTextCte(measure, 100, 200);
 
-        Assert.True (await cte.SetDocumentAsync (new string ('a', 12)));
-        int pages = await cte.RenderAsync (Dpi96, null);
+        Assert.True(await cte.SetDocumentAsync(new string('a', 12)));
+        int pages = await cte.RenderAsync(Dpi96, null);
 
-        Assert.Equal (1, pages);
+        Assert.Equal(1, pages);
 
-        var paint = new RecordingGraphicsContext (CharWidth, LineHeight);
-        cte.PaintPage (paint, 1);
+        var paint = new RecordingGraphicsContext();
+        cte.PaintPage(paint, 1);
 
         // The 12-char line wraps into a 10-char line and a 2-char remainder.
-        Assert.Equal (2, paint.DrawnStrings.Count);
-        Assert.Equal (new string ('a', 10), paint.DrawnStrings[0].Text);
-        Assert.Equal (new string ('a', 2), paint.DrawnStrings[1].Text);
-        Assert.Equal (0, paint.DrawnStrings[1].X);
-        Assert.Equal (LineHeight, paint.DrawnStrings[1].Y);
+        Assert.Equal(2, paint.DrawnStrings.Count);
+        Assert.Equal(new string('a', 10), paint.DrawnStrings[0].Text);
+        Assert.Equal(new string('a', 2), paint.DrawnStrings[1].Text);
+        Assert.Equal(0, paint.DrawnStrings[1].X);
+        Assert.Equal(LineHeight, paint.DrawnStrings[1].Y);
     }
 
     [Fact]
-    public async Task TextCte_WithLineNumbers_DrawsNumberAndIndentsText ()
+    public async Task TextCte_WithLineNumbers_DrawsNumberAndIndentsText()
     {
-        var measure = new RecordingGraphicsContext (CharWidth, LineHeight);
+        var measure = new RecordingGraphicsContext();
         // Line number width = 4 chars * 10 = 40; text area = 100.
-        var cte = MakeTextCte (measure, pageWidth: 140, pageHeight: 60, lineNumbers: true);
+        TextCte cte = MakeTextCte(measure, 140, 60, true);
 
-        Assert.True (await cte.SetDocumentAsync ("abc"));
-        await cte.RenderAsync (Dpi96, null);
+        Assert.True(await cte.SetDocumentAsync("abc"));
+        await cte.RenderAsync(Dpi96, null);
 
-        var paint = new RecordingGraphicsContext (CharWidth, LineHeight);
-        cte.PaintPage (paint, 1);
+        var paint = new RecordingGraphicsContext();
+        cte.PaintPage(paint, 1);
 
         // The line number "1" is drawn in the gutter and the text is indented past it (x = gutter width = 40).
-        Assert.Contains (paint.DrawnStrings, s => s.Text == "1" && s.Y == 0);
-        Assert.Contains (new RecordedString ("abc", 40, 0), paint.DrawnStrings);
+        Assert.Contains(paint.DrawnStrings, s => s.Text == "1" && s.Y == 0);
+        Assert.Contains(new RecordedString("abc", 40, 0), paint.DrawnStrings);
         // The line-number separator is drawn as a vertical line in the gutter.
-        Assert.NotEmpty (paint.DrawnLines);
+        Assert.NotEmpty(paint.DrawnLines);
     }
 
     [Fact]
-    public async Task TextMateCte_RendersTokenizedText_CrossPlatform ()
+    public async Task TextMateCte_RendersTokenizedText_CrossPlatform()
     {
-        var measure = new RecordingGraphicsContext (CharWidth, LineHeight);
+        var measure = new RecordingGraphicsContext();
         var cte = new TextMateCte
         {
             ContentSettings = new ContentSettings
@@ -137,28 +137,28 @@ public class CteRenderingTests
                 Style = "VisualStudioLight"
             },
             MeasurementContext = measure,
-            PageSize = new System.Drawing.SizeF (200, 60)
+            PageSize = new System.Drawing.SizeF(200, 60)
         };
 
-        Assert.True (await cte.SetDocumentAsync ("hello\nworld"));
-        int pages = await cte.RenderAsync (Dpi96, null);
+        Assert.True(await cte.SetDocumentAsync("hello\nworld"));
+        int pages = await cte.RenderAsync(Dpi96, null);
 
-        Assert.True (pages >= 1);
+        Assert.True(pages >= 1);
 
-        var paint = new RecordingGraphicsContext (CharWidth, LineHeight);
+        var paint = new RecordingGraphicsContext();
         for (int p = 1; p <= pages; p++)
         {
-            cte.PaintPage (paint, p);
+            cte.PaintPage(paint, p);
         }
 
-        Assert.Contains (paint.DrawnStrings, s => s.Text.Contains ("hello"));
-        Assert.Contains (paint.DrawnStrings, s => s.Text.Contains ("world"));
+        Assert.Contains(paint.DrawnStrings, s => s.Text.Contains("hello"));
+        Assert.Contains(paint.DrawnStrings, s => s.Text.Contains("world"));
     }
 
     [Fact]
-    public async Task MarkdownCte_RendersFlattenedText ()
+    public async Task MarkdownCte_RendersFlattenedText()
     {
-        var measure = new RecordingGraphicsContext (CharWidth, LineHeight);
+        var measure = new RecordingGraphicsContext();
         var cte = new MarkdownCte
         {
             ContentSettings = new ContentSettings
@@ -168,23 +168,23 @@ public class CteRenderingTests
                 TabSpaces = 4
             },
             MeasurementContext = measure,
-            PageSize = new System.Drawing.SizeF (200, 200)
+            PageSize = new System.Drawing.SizeF(200, 200)
         };
 
-        Assert.True (await cte.SetDocumentAsync ("# Title\n\nHello world"));
-        int pages = await cte.RenderAsync (Dpi96, null);
+        Assert.True(await cte.SetDocumentAsync("# Title\n\nHello world"));
+        int pages = await cte.RenderAsync(Dpi96, null);
 
-        Assert.True (pages >= 1);
+        Assert.True(pages >= 1);
 
-        var paint = new RecordingGraphicsContext (CharWidth, LineHeight);
+        var paint = new RecordingGraphicsContext();
         for (int p = 1; p <= pages; p++)
         {
-            cte.PaintPage (paint, p);
+            cte.PaintPage(paint, p);
         }
 
         // Markdown markers are gone; the prose is rendered.
-        Assert.Contains (paint.DrawnStrings, s => s.Text.Contains ("Title"));
-        Assert.Contains (paint.DrawnStrings, s => s.Text.Contains ("Hello world"));
-        Assert.DoesNotContain (paint.DrawnStrings, s => s.Text.Contains ("#"));
+        Assert.Contains(paint.DrawnStrings, s => s.Text.Contains("Title"));
+        Assert.Contains(paint.DrawnStrings, s => s.Text.Contains("Hello world"));
+        Assert.DoesNotContain(paint.DrawnStrings, s => s.Text.Contains("#"));
     }
 }

--- a/tests/WinPrint.Core.UnitTests/Cte/MarkdownCteTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Cte/MarkdownCteTests.cs
@@ -12,92 +12,92 @@ namespace WinPrint.Core.UnitTests.Cte;
 
 public class MarkdownCteTests
 {
-    private static readonly string CteClassName = typeof (MarkdownCte).Name;
+    private static readonly string CteClassName = typeof(MarkdownCte).Name;
 
-    public MarkdownCteTests (ITestOutputHelper output)
+    public MarkdownCteTests(ITestOutputHelper output)
     {
-        ServiceLocator.Current.LogService.Start (GetType ().Name,
-            new TestOutputSink (output, new MessageTemplateTextFormatter ("{Message:lj}")), true, true);
+        ServiceLocator.Current.LogService.Start(GetType().Name,
+            new TestOutputSink(output, new MessageTemplateTextFormatter("{Message:lj}")), true, true);
     }
 
     [Fact]
-    public void SupportedContentTypesTest ()
+    public void SupportedContentTypesTest()
     {
-        var cte = new MarkdownCte ();
-        Assert.Single (cte.SupportedContentTypes);
-        Assert.Equal ("text/x-markdown", cte.SupportedContentTypes[0]);
+        var cte = new MarkdownCte();
+        Assert.Single(cte.SupportedContentTypes);
+        Assert.Equal("text/x-markdown", cte.SupportedContentTypes[0]);
     }
 
     [Fact]
-    public void NewContentTypeEngineTest ()
+    public void NewContentTypeEngineTest()
     {
-        var svm = new SheetViewModel ();
+        var svm = new SheetViewModel();
         (svm.ContentEngine, svm.ContentType, svm.Language) =
-            ContentTypeEngineBase.CreateContentTypeEngine (CteClassName);
-        Assert.NotNull (svm.ContentEngine);
+            ContentTypeEngineBase.CreateContentTypeEngine(CteClassName);
+        Assert.NotNull(svm.ContentEngine);
 
-        Assert.Equal (CteClassName, svm.ContentEngine!.GetType ().Name);
-        Assert.Equal ("text/x-markdown", svm.ContentType);
+        Assert.Equal(CteClassName, svm.ContentEngine!.GetType().Name);
+        Assert.Equal("text/x-markdown", svm.ContentType);
     }
 
     [Fact]
-    public void CreateContentTypeEngine_RoutesMarkdownContentTypeToMarkdownCte ()
+    public void CreateContentTypeEngine_RoutesMarkdownContentTypeToMarkdownCte()
     {
-        var settings = Settings.CreateDefaultSettings ();
-        ModelLocator.Current.Settings.CopyPropertiesFrom (settings);
+        var settings = Settings.CreateDefaultSettings();
+        ModelLocator.Current.Settings.CopyPropertiesFrom(settings);
 
         (ContentTypeEngineBase? cte, string contentType, string language) =
-            ContentTypeEngineBase.CreateContentTypeEngine ("text/x-markdown");
+            ContentTypeEngineBase.CreateContentTypeEngine("text/x-markdown");
 
-        Assert.NotNull (cte);
-        Assert.Equal (typeof (MarkdownCte).Name, cte!.GetType ().Name);
-        Assert.Equal ("text/x-markdown", contentType);
-        Assert.Equal ("markdown", language);
+        Assert.NotNull(cte);
+        Assert.Equal(typeof(MarkdownCte).Name, cte!.GetType().Name);
+        Assert.Equal("text/x-markdown", contentType);
+        Assert.Equal("markdown", language);
     }
 
     [Fact]
-    public void GetContentTypeTest_MdExtensionMapsToMarkdown ()
+    public void GetContentTypeTest_MdExtensionMapsToMarkdown()
     {
-        var settings = Settings.CreateDefaultSettings ();
-        ModelLocator.Current.Settings.CopyPropertiesFrom (settings);
+        var settings = Settings.CreateDefaultSettings();
+        ModelLocator.Current.Settings.CopyPropertiesFrom(settings);
 
-        Assert.Equal ("text/x-markdown", ContentTypeEngineBase.GetContentType ("README.md"));
+        Assert.Equal("text/x-markdown", ContentTypeEngineBase.GetContentType("README.md"));
     }
 
     [Fact]
-    public async Task SetDocumentAsync_FlattensMarkdownToPlainText ()
+    public async Task SetDocumentAsync_FlattensMarkdownToPlainText()
     {
-        var cte = new MarkdownCte ();
+        var cte = new MarkdownCte();
 
-        Assert.True (await cte.SetDocumentAsync ("# Heading\n\nSome **bold** and *italic* text."));
+        Assert.True(await cte.SetDocumentAsync("# Heading\n\nSome **bold** and *italic* text."));
 
         // Markdig's plain-text renderer strips the formatting markers, leaving readable text.
-        Assert.NotNull (cte.Document);
-        Assert.Contains ("Heading", cte.Document!);
-        Assert.Contains ("Some bold and italic text.", cte.Document!);
-        Assert.DoesNotContain ("**", cte.Document!);
-        Assert.DoesNotContain ("# ", cte.Document!);
+        Assert.NotNull(cte.Document);
+        Assert.Contains("Heading", cte.Document!);
+        Assert.Contains("Some bold and italic text.", cte.Document!);
+        Assert.DoesNotContain("**", cte.Document!);
+        Assert.DoesNotContain("# ", cte.Document!);
     }
 
     [Fact]
-    public async Task SetDocumentAsync_StripsLinkSyntaxKeepingText ()
+    public async Task SetDocumentAsync_StripsLinkSyntaxKeepingText()
     {
-        var cte = new MarkdownCte ();
+        var cte = new MarkdownCte();
 
-        Assert.True (await cte.SetDocumentAsync ("See [the docs](https://example.com) for details."));
+        Assert.True(await cte.SetDocumentAsync("See [the docs](https://example.com) for details."));
 
-        Assert.NotNull (cte.Document);
-        Assert.Contains ("the docs", cte.Document!);
-        Assert.DoesNotContain ("https://example.com", cte.Document!);
-        Assert.DoesNotContain ("](", cte.Document!);
+        Assert.NotNull(cte.Document);
+        Assert.Contains("the docs", cte.Document!);
+        Assert.DoesNotContain("https://example.com", cte.Document!);
+        Assert.DoesNotContain("](", cte.Document!);
     }
 
     [Fact]
-    public async Task SetDocumentAsync_HandlesEmptyDocument ()
+    public async Task SetDocumentAsync_HandlesEmptyDocument()
     {
-        var cte = new MarkdownCte ();
+        var cte = new MarkdownCte();
 
-        Assert.True (await cte.SetDocumentAsync (string.Empty));
-        Assert.NotNull (cte.Document);
+        Assert.True(await cte.SetDocumentAsync(string.Empty));
+        Assert.NotNull(cte.Document);
     }
 }

--- a/tests/WinPrint.Core.UnitTests/Cte/MarkdownCteTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Cte/MarkdownCteTests.cs
@@ -1,0 +1,103 @@
+using System.Threading.Tasks;
+using Serilog.Formatting.Display;
+using Serilog.Sinks.XUnit;
+using WinPrint.Core.ContentTypeEngines;
+using WinPrint.Core.Models;
+using WinPrint.Core.Services;
+using WinPrint.Core.ViewModels;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace WinPrint.Core.UnitTests.Cte;
+
+public class MarkdownCteTests
+{
+    private static readonly string CteClassName = typeof (MarkdownCte).Name;
+
+    public MarkdownCteTests (ITestOutputHelper output)
+    {
+        ServiceLocator.Current.LogService.Start (GetType ().Name,
+            new TestOutputSink (output, new MessageTemplateTextFormatter ("{Message:lj}")), true, true);
+    }
+
+    [Fact]
+    public void SupportedContentTypesTest ()
+    {
+        var cte = new MarkdownCte ();
+        Assert.Single (cte.SupportedContentTypes);
+        Assert.Equal ("text/x-markdown", cte.SupportedContentTypes[0]);
+    }
+
+    [Fact]
+    public void NewContentTypeEngineTest ()
+    {
+        var svm = new SheetViewModel ();
+        (svm.ContentEngine, svm.ContentType, svm.Language) =
+            ContentTypeEngineBase.CreateContentTypeEngine (CteClassName);
+        Assert.NotNull (svm.ContentEngine);
+
+        Assert.Equal (CteClassName, svm.ContentEngine!.GetType ().Name);
+        Assert.Equal ("text/x-markdown", svm.ContentType);
+    }
+
+    [Fact]
+    public void CreateContentTypeEngine_RoutesMarkdownContentTypeToMarkdownCte ()
+    {
+        var settings = Settings.CreateDefaultSettings ();
+        ModelLocator.Current.Settings.CopyPropertiesFrom (settings);
+
+        (ContentTypeEngineBase? cte, string contentType, string language) =
+            ContentTypeEngineBase.CreateContentTypeEngine ("text/x-markdown");
+
+        Assert.NotNull (cte);
+        Assert.Equal (typeof (MarkdownCte).Name, cte!.GetType ().Name);
+        Assert.Equal ("text/x-markdown", contentType);
+        Assert.Equal ("markdown", language);
+    }
+
+    [Fact]
+    public void GetContentTypeTest_MdExtensionMapsToMarkdown ()
+    {
+        var settings = Settings.CreateDefaultSettings ();
+        ModelLocator.Current.Settings.CopyPropertiesFrom (settings);
+
+        Assert.Equal ("text/x-markdown", ContentTypeEngineBase.GetContentType ("README.md"));
+    }
+
+    [Fact]
+    public async Task SetDocumentAsync_FlattensMarkdownToPlainText ()
+    {
+        var cte = new MarkdownCte ();
+
+        Assert.True (await cte.SetDocumentAsync ("# Heading\n\nSome **bold** and *italic* text."));
+
+        // Markdig's plain-text renderer strips the formatting markers, leaving readable text.
+        Assert.NotNull (cte.Document);
+        Assert.Contains ("Heading", cte.Document!);
+        Assert.Contains ("Some bold and italic text.", cte.Document!);
+        Assert.DoesNotContain ("**", cte.Document!);
+        Assert.DoesNotContain ("# ", cte.Document!);
+    }
+
+    [Fact]
+    public async Task SetDocumentAsync_StripsLinkSyntaxKeepingText ()
+    {
+        var cte = new MarkdownCte ();
+
+        Assert.True (await cte.SetDocumentAsync ("See [the docs](https://example.com) for details."));
+
+        Assert.NotNull (cte.Document);
+        Assert.Contains ("the docs", cte.Document!);
+        Assert.DoesNotContain ("https://example.com", cte.Document!);
+        Assert.DoesNotContain ("](", cte.Document!);
+    }
+
+    [Fact]
+    public async Task SetDocumentAsync_HandlesEmptyDocument ()
+    {
+        var cte = new MarkdownCte ();
+
+        Assert.True (await cte.SetDocumentAsync (string.Empty));
+        Assert.NotNull (cte.Document);
+    }
+}

--- a/tests/WinPrint.Core.UnitTests/Cte/TextCteTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Cte/TextCteTests.cs
@@ -15,68 +15,68 @@ namespace WinPrint.Core.UnitTests.Cte;
 
 public class TextCteTests
 {
-    private static readonly string CteClassName = typeof (TextCte).Name;
+    private static readonly string CteClassName = typeof(TextCte).Name;
 
-    public TextCteTests (ITestOutputHelper output)
+    public TextCteTests(ITestOutputHelper output)
     {
-        ServiceLocator.Current.LogService.Start (GetType ().Name,
-            new TestOutputSink (output, new MessageTemplateTextFormatter ("{Message:lj}")), true, true);
+        ServiceLocator.Current.LogService.Start(GetType().Name,
+            new TestOutputSink(output, new MessageTemplateTextFormatter("{Message:lj}")), true, true);
     }
 
     // ContentTypeEngineBase tests
     // Using TextCte since CTE is abstract
     [Fact]
-    public void SupportedContentTypesTest ()
+    public void SupportedContentTypesTest()
     {
-        var cte = new TextCte ();
-        Assert.Single (cte.SupportedContentTypes);
-        Assert.Equal ("text/plain", cte.SupportedContentTypes[0]);
+        var cte = new TextCte();
+        Assert.Single(cte.SupportedContentTypes);
+        Assert.Equal("text/plain", cte.SupportedContentTypes[0]);
     }
 
     [Fact]
-    public void NewContentTypeEngineTest ()
+    public void NewContentTypeEngineTest()
     {
-        var svm = new SheetViewModel ();
+        var svm = new SheetViewModel();
         string lang;
-        (svm.ContentEngine, svm.ContentType, lang) = ContentTypeEngineBase.CreateContentTypeEngine (CteClassName);
-        Assert.NotNull (svm.ContentEngine);
+        (svm.ContentEngine, svm.ContentType, lang) = ContentTypeEngineBase.CreateContentTypeEngine(CteClassName);
+        Assert.NotNull(svm.ContentEngine);
 
-        Assert.Equal (CteClassName, svm.ContentEngine!.GetType ().Name);
-        Assert.Equal ("text/plain", svm.ContentType);
-        Assert.Equal ("Plain Text", lang);
+        Assert.Equal(CteClassName, svm.ContentEngine!.GetType().Name);
+        Assert.Equal("text/plain", svm.ContentType);
+        Assert.Equal("Plain Text", lang);
     }
 
     [Fact]
-    public void GetContentTypeTest ()
+    public void GetContentTypeTest()
     {
         //
         // Setup FileAssocaitons service
-        var settings = Settings.CreateDefaultSettings ();
-        ModelLocator.Current.Settings.CopyPropertiesFrom (settings);
+        var settings = Settings.CreateDefaultSettings();
+        ModelLocator.Current.Settings.CopyPropertiesFrom(settings);
 
         // obviouslly text
         string path = "foo.txt";
-        string type = ContentTypeEngineBase.GetContentType (path);
-        Assert.Equal ("text/plain", type);
+        string type = ContentTypeEngineBase.GetContentType(path);
+        Assert.Equal("text/plain", type);
 
         // html
         path = "foo.html";
-        type = ContentTypeEngineBase.GetContentType (path);
-        Assert.Equal ("text/html", type);
+        type = ContentTypeEngineBase.GetContentType(path);
+        Assert.Equal("text/html", type);
 
         path = "foo.htm";
-        type = ContentTypeEngineBase.GetContentType (path);
-        Assert.Equal ("text/html", type);
+        type = ContentTypeEngineBase.GetContentType(path);
+        Assert.Equal("text/html", type);
 
         // Something handled by prismcte
         path = "foo.cs";
-        type = ContentTypeEngineBase.GetContentType (path);
-        Assert.Equal ("text/x-csharp", type);
+        type = ContentTypeEngineBase.GetContentType(path);
+        Assert.Equal("text/x-csharp", type);
 
         // Defeault
         path = "foo.xxxx";
-        type = ContentTypeEngineBase.GetContentType (path);
-        Assert.Equal ("text/plain", type);
+        type = ContentTypeEngineBase.GetContentType(path);
+        Assert.Equal("text/plain", type);
     }
 
     //private SizeF MeasureString(Graphics g, string text)
@@ -95,141 +95,141 @@ public class TextCteTests
     /// <param name="linesFilled"></param>
     /// <returns></returns>
     [Fact]
-    public async Task RenderAsyncTest_FixedPitch ()
+    public async Task RenderAsyncTest_FixedPitch()
     {
         string shortLine = "This is a line 0123456789";
         string longLine = "This is a line 01234567890";
 
-        var settings = Settings.CreateDefaultSettings ();
-        ModelLocator.Current.Settings.CopyPropertiesFrom (settings);
+        var settings = Settings.CreateDefaultSettings();
+        ModelLocator.Current.Settings.CopyPropertiesFrom(settings);
 
-        var svm = new SheetViewModel ();
+        var svm = new SheetViewModel();
         (svm.ContentEngine, svm.ContentType, svm.Language) =
-            ContentTypeEngineBase.CreateContentTypeEngine (CteClassName);
-        Assert.NotNull (svm.ContentEngine);
-        Assert.Equal ("text/plain", svm.ContentType);
+            ContentTypeEngineBase.CreateContentTypeEngine(CteClassName);
+        Assert.NotNull(svm.ContentEngine);
+        Assert.Equal("text/plain", svm.ContentType);
 
-        svm.ContentEngine!.ContentSettings = new ContentSettings ();
+        svm.ContentEngine!.ContentSettings = new ContentSettings();
 
         // Setup page so only 1 line will fit
-        svm.Margins = new PrintMargins (0, 0, 0, 0);
+        svm.Margins = new PrintMargins(0, 0, 0, 0);
 
         // Setup page so 10 chars can fit across
-        using var bitmap = new Bitmap (1, 1);
-        bitmap.SetResolution (96, 96);
-        var g = Graphics.FromImage (bitmap);
+        using var bitmap = new Bitmap(1, 1);
+        bitmap.SetResolution(96, 96);
+        var g = Graphics.FromImage(bitmap);
         g.PageUnit = GraphicsUnit.Display; // Display is 1/100th"
         g.TextRenderingHint = ContentTypeEngineBase.TextRenderingHint;
 
         // Set a font that's 1" high
         svm.ContentEngine!.ContentSettings.Font =
             new Font { Family = "Courier New", Size = 72 }; // 72 points is 1" high
-        var font = new System.Drawing.Font (svm.ContentEngine!.ContentSettings.Font.Family,
+        var font = new System.Drawing.Font(svm.ContentEngine!.ContentSettings.Font.Family,
             svm.ContentEngine!.ContentSettings.Font.Size / 72F * 96,
             (System.Drawing.FontStyle)svm.ContentEngine!.ContentSettings.Font.Style, GraphicsUnit.Pixel);
 
         // determine width     
         // Use page settings including lineNumberWidth
-        var proposedSize = new SizeF (10000, font.GetHeight () + font.GetHeight () / 2);
-        SizeF size = g.MeasureString (shortLine, font, proposedSize, ContentTypeEngineBase.StringFormat,
+        var proposedSize = new SizeF(10000, font.GetHeight() + font.GetHeight() / 2);
+        SizeF size = g.MeasureString(shortLine, font, proposedSize, ContentTypeEngineBase.StringFormat,
             out int charsFitted, out int linesFilled);
 
-        Assert.IsType<TextCte> (svm.ContentEngine).ContentSettings!.LineNumbers = false;
-        svm.ContentEngine!.PageSize = new SizeF (size.Width, font.GetHeight ()); // a line will be about 108 high
+        Assert.IsType<TextCte>(svm.ContentEngine).ContentSettings!.LineNumbers = false;
+        svm.ContentEngine!.PageSize = new SizeF(size.Width, font.GetHeight()); // a line will be about 108 high
 
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync (shortLine));
-        Assert.Equal (1, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync(shortLine));
+        Assert.Equal(1, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
 
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync ($"{shortLine}\n{shortLine}"));
-        Assert.Equal (2, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync($"{shortLine}\n{shortLine}"));
+        Assert.Equal(2, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
 
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync ($"{shortLine}\n{shortLine}\n{shortLine}"));
-        Assert.Equal (3, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync($"{shortLine}\n{shortLine}\n{shortLine}"));
+        Assert.Equal(3, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
 
         // Test line wrapping
         // 0123456789
         // 0
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync ($"{longLine}"));
-        Assert.Equal (2, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync($"{longLine}"));
+        Assert.Equal(2, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
 
         // 0123456789
         // 0A
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync ($"{longLine}A"));
-        Assert.Equal (2, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync($"{longLine}A"));
+        Assert.Equal(2, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
 
         // 0123456789
         // 0A01234567
         // 89
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync ($"{longLine}A{longLine}"));
-        Assert.Equal (3, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync($"{longLine}A{longLine}"));
+        Assert.Equal(3, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
     }
 
     [Fact]
-    public async Task RenderAsyncTest_VariablePitch ()
+    public async Task RenderAsyncTest_VariablePitch()
     {
         string shortLine = "1 01234567890123456789";
         string longLine = "2 01234567890123456789A";
 
-        var settings = Settings.CreateDefaultSettings ();
-        ModelLocator.Current.Settings.CopyPropertiesFrom (settings);
+        var settings = Settings.CreateDefaultSettings();
+        ModelLocator.Current.Settings.CopyPropertiesFrom(settings);
 
-        var svm = new SheetViewModel ();
+        var svm = new SheetViewModel();
         (svm.ContentEngine, svm.ContentType, svm.Language) =
-            ContentTypeEngineBase.CreateContentTypeEngine (CteClassName);
-        Assert.NotNull (svm.ContentEngine);
-        Assert.Equal ("text/plain", svm.ContentType);
+            ContentTypeEngineBase.CreateContentTypeEngine(CteClassName);
+        Assert.NotNull(svm.ContentEngine);
+        Assert.Equal("text/plain", svm.ContentType);
 
-        svm.ContentEngine!.ContentSettings = new ContentSettings ();
+        svm.ContentEngine!.ContentSettings = new ContentSettings();
 
         // Setup page so only 1 line will fit
-        svm.Margins = new PrintMargins (0, 0, 0, 0);
+        svm.Margins = new PrintMargins(0, 0, 0, 0);
 
         // Setup page so 10 chars can fit across
-        using var bitmap = new Bitmap (1, 1);
-        bitmap.SetResolution (96, 96);
-        var g = Graphics.FromImage (bitmap);
+        using var bitmap = new Bitmap(1, 1);
+        bitmap.SetResolution(96, 96);
+        var g = Graphics.FromImage(bitmap);
         g.PageUnit = GraphicsUnit.Display; // Display is 1/100th"
         g.TextRenderingHint = ContentTypeEngineBase.TextRenderingHint;
 
         // Set a font that's 1" high
         svm.ContentEngine!.ContentSettings.Font = new Font { Family = "Arial", Size = 72 }; // 72 points is 1" high
-        var font = new System.Drawing.Font (svm.ContentEngine!.ContentSettings.Font.Family,
+        var font = new System.Drawing.Font(svm.ContentEngine!.ContentSettings.Font.Family,
             svm.ContentEngine!.ContentSettings.Font.Size / 72F * 96,
             (System.Drawing.FontStyle)svm.ContentEngine!.ContentSettings.Font.Style, GraphicsUnit.Pixel);
 
         // determine width     
         // Use page settings including lineNumberWidth
-        var proposedSize = new SizeF (10000, font.GetHeight () + font.GetHeight () / 2);
-        SizeF size = g.MeasureString (shortLine, font, proposedSize, ContentTypeEngineBase.StringFormat,
+        var proposedSize = new SizeF(10000, font.GetHeight() + font.GetHeight() / 2);
+        SizeF size = g.MeasureString(shortLine, font, proposedSize, ContentTypeEngineBase.StringFormat,
             out int charsFitted, out int linesFilled);
 
-        Assert.IsType<TextCte> (svm.ContentEngine).ContentSettings!.LineNumbers = false;
-        svm.ContentEngine!.PageSize = new SizeF (size.Width, font.GetHeight ()); // a line will be about 108 high
+        Assert.IsType<TextCte>(svm.ContentEngine).ContentSettings!.LineNumbers = false;
+        svm.ContentEngine!.PageSize = new SizeF(size.Width, font.GetHeight()); // a line will be about 108 high
 
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync (shortLine));
-        Assert.Equal (1, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync(shortLine));
+        Assert.Equal(1, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
 
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync ($"{shortLine}\n{shortLine}"));
-        Assert.Equal (2, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync($"{shortLine}\n{shortLine}"));
+        Assert.Equal(2, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
 
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync ($"{shortLine}\n{shortLine}\n{shortLine}"));
-        Assert.Equal (3, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync($"{shortLine}\n{shortLine}\n{shortLine}"));
+        Assert.Equal(3, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
 
         // Test line wrapping
         // 0123456789
         // 0
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync ($"{longLine}"));
-        Assert.Equal (2, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync($"{longLine}"));
+        Assert.Equal(2, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
 
         // 0123456789
         // 0A
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync ($"{longLine}A"));
-        Assert.Equal (2, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync($"{longLine}A"));
+        Assert.Equal(2, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
 
         // 0123456789
         // 0A01234567
         // 89
-        Assert.True (await svm.ContentEngine!.SetDocumentAsync ($"{longLine}A{shortLine}"));
-        Assert.Equal (3, await svm.ContentEngine!.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await svm.ContentEngine!.SetDocumentAsync($"{longLine}A{shortLine}"));
+        Assert.Equal(3, await svm.ContentEngine!.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
     }
 }

--- a/tests/WinPrint.Core.UnitTests/Cte/TextMateCteRenderRegressionTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Cte/TextMateCteRenderRegressionTests.cs
@@ -22,7 +22,7 @@ public class TextMateCteRenderRegressionTests
 {
     private const int Dpi = 96;
 
-    private static TextMateCte MakeCSharpCte (float pageWidthUnits, float pageHeightUnits)
+    private static TextMateCte MakeCSharpCte(float pageWidthUnits, float pageHeightUnits)
     {
         var cte = new TextMateCte
         {
@@ -33,14 +33,14 @@ public class TextMateCteRenderRegressionTests
                 TabSpaces = 4,
                 Style = "VisualStudioLight"
             },
-            PageSize = new SizeF (pageWidthUnits, pageHeightUnits)
+            PageSize = new SizeF(pageWidthUnits, pageHeightUnits)
         };
-        cte.Configure (null, "csharp", "Program.cs");
+        cte.Configure(null, "csharp", "Program.cs");
         return cte;
     }
 
     [Fact]
-    public async Task TokenizedLine_DoesNotDriftWiderThanSingleString ()
+    public async Task TokenizedLine_DoesNotDriftWiderThanSingleString()
     {
         const float pageWidthUnits = 800f; // 8" in 1/100" display units
         const float pageHeightUnits = 100f;
@@ -48,48 +48,48 @@ public class TextMateCteRenderRegressionTests
         int pxH = (int)(pageHeightUnits * Dpi / 100f);
         const string lineText = "var result = parser.Parse(args).WithParsed(o => o.Files);";
 
-        using TextMateCte cte = MakeCSharpCte (pageWidthUnits, pageHeightUnits);
-        Assert.True (await cte.SetDocumentAsync (lineText));
-        int pages = await cte.RenderAsync (new PrintResolution { X = Dpi, Y = Dpi }, null);
-        Assert.True (pages >= 1);
+        using TextMateCte cte = MakeCSharpCte(pageWidthUnits, pageHeightUnits);
+        Assert.True(await cte.SetDocumentAsync(lineText));
+        int pages = await cte.RenderAsync(new PrintResolution { X = Dpi, Y = Dpi }, null);
+        Assert.True(pages >= 1);
 
         // Sanity: the line must split into several syntax runs, otherwise per-token drift can't manifest
         // and the test would be vacuous.
-        var probe = new RecordingGraphicsContext ();
-        cte.PaintPage (probe, 1);
-        Assert.True (probe.DrawnStrings.Count >= 3,
+        var probe = new RecordingGraphicsContext();
+        cte.PaintPage(probe, 1);
+        Assert.True(probe.DrawnStrings.Count >= 3,
             $"Expected the C# line to tokenize into multiple runs; got {probe.DrawnStrings.Count}.");
 
-        using Bitmap tokenized = SystemDrawingPageRenderer.RenderPage (cte, 1, pxW, pxH, Dpi);
-        int tokenizedRight = SystemDrawingPageRenderer.RightmostInkColumn (tokenized);
+        using Bitmap tokenized = SystemDrawingPageRenderer.RenderPage(cte, 1, pxW, pxH);
+        int tokenizedRight = SystemDrawingPageRenderer.RightmostInkColumn(tokenized);
 
         // Baseline: the same characters drawn as ONE string, with the same font and typographic format
         // the engine paints with. On a monospace font the tokenized runs should end at the same x.
-        int baselineRight = RightmostInkOfSingleString (lineText, pxW, pxH);
+        int baselineRight = RightmostInkOfSingleString(lineText, pxW, pxH);
 
-        Assert.True (tokenizedRight > 0, "Tokenized render produced no ink.");
-        Assert.True (baselineRight > 0, "Baseline render produced no ink.");
+        Assert.True(tokenizedRight > 0, "Tokenized render produced no ink.");
+        Assert.True(baselineRight > 0, "Baseline render produced no ink.");
 
         // Pre-fix, ~1/6 em of GDI+ padding was added before every token, drifting the line tens of px wider.
-        Assert.True (Math.Abs (tokenizedRight - baselineRight) <= 6,
+        Assert.True(Math.Abs(tokenizedRight - baselineRight) <= 6,
             $"Tokenized line drifted from single-string width: tokenizedRight={tokenizedRight}, " +
             $"baselineRight={baselineRight} (px).");
     }
 
-    private static int RightmostInkOfSingleString (string text, int pxW, int pxH)
+    private static int RightmostInkOfSingleString(string text, int pxW, int pxH)
     {
-        using var bitmap = new Bitmap (pxW, pxH);
-        bitmap.SetResolution (Dpi, Dpi);
-        using (Graphics g = Graphics.FromImage (bitmap))
+        using var bitmap = new Bitmap(pxW, pxH);
+        bitmap.SetResolution(Dpi, Dpi);
+        using (var g = Graphics.FromImage(bitmap))
         {
-            g.Clear (Color.White);
+            g.Clear(Color.White);
             g.PageUnit = GraphicsUnit.Display;
-            var context = new SystemDrawingGraphicsContext (g);
+            var context = new SystemDrawingGraphicsContext(g);
             using IGraphicsFont font =
-                context.CreateFont ("Consolas", 9, GraphicsFontStyle.Regular, GraphicsFontUnit.Point);
-            context.DrawString (text, font, context.BlackBrush, 0, 0, ContentTypeEngineBase.GraphicsStringFormat);
+                context.CreateFont("Consolas", 9, GraphicsFontStyle.Regular, GraphicsFontUnit.Point);
+            context.DrawString(text, font, context.BlackBrush, 0, 0, ContentTypeEngineBase.GraphicsStringFormat);
         }
 
-        return SystemDrawingPageRenderer.RightmostInkColumn (bitmap);
+        return SystemDrawingPageRenderer.RightmostInkColumn(bitmap);
     }
 }

--- a/tests/WinPrint.Core.UnitTests/Cte/TextMateCteRenderRegressionTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Cte/TextMateCteRenderRegressionTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Drawing;
+using System.Threading.Tasks;
+using WinPrint.Core.Abstractions;
+using WinPrint.Core.ContentTypeEngines;
+using WinPrint.Core.Models;
+using WinPrint.Core.UnitTests.TestSupport;
+using Xunit;
+using Font = WinPrint.Core.Models.Font;
+
+namespace WinPrint.Core.UnitTests.Cte;
+
+/// <summary>
+///     Windows-only visual regression tests for <see cref="TextMateCte" /> that exercise the real GDI+
+///     measurement/draw path via <see cref="SystemDrawingPageRenderer" />. These guard against issues the
+///     fixed-pitch <see cref="RecordingGraphicsContext" /> cannot see — notably the per-token padding drift
+///     that crept in when the engine measured token advances with the no-format
+///     <c>MeasureString</c> overload while drawing with the typographic <c>GraphicsStringFormat</c>,
+///     leaving a visible gap before every token.
+/// </summary>
+public class TextMateCteRenderRegressionTests
+{
+    private const int Dpi = 96;
+
+    private static TextMateCte MakeCSharpCte (float pageWidthUnits, float pageHeightUnits)
+    {
+        var cte = new TextMateCte
+        {
+            ContentSettings = new ContentSettings
+            {
+                Font = new Font { Family = "Consolas", Size = 9 },
+                LineNumbers = false,
+                TabSpaces = 4,
+                Style = "VisualStudioLight"
+            },
+            PageSize = new SizeF (pageWidthUnits, pageHeightUnits)
+        };
+        cte.Configure (null, "csharp", "Program.cs");
+        return cte;
+    }
+
+    [Fact]
+    public async Task TokenizedLine_DoesNotDriftWiderThanSingleString ()
+    {
+        const float pageWidthUnits = 800f; // 8" in 1/100" display units
+        const float pageHeightUnits = 100f;
+        int pxW = (int)(pageWidthUnits * Dpi / 100f);
+        int pxH = (int)(pageHeightUnits * Dpi / 100f);
+        const string lineText = "var result = parser.Parse(args).WithParsed(o => o.Files);";
+
+        using TextMateCte cte = MakeCSharpCte (pageWidthUnits, pageHeightUnits);
+        Assert.True (await cte.SetDocumentAsync (lineText));
+        int pages = await cte.RenderAsync (new PrintResolution { X = Dpi, Y = Dpi }, null);
+        Assert.True (pages >= 1);
+
+        // Sanity: the line must split into several syntax runs, otherwise per-token drift can't manifest
+        // and the test would be vacuous.
+        var probe = new RecordingGraphicsContext ();
+        cte.PaintPage (probe, 1);
+        Assert.True (probe.DrawnStrings.Count >= 3,
+            $"Expected the C# line to tokenize into multiple runs; got {probe.DrawnStrings.Count}.");
+
+        using Bitmap tokenized = SystemDrawingPageRenderer.RenderPage (cte, 1, pxW, pxH, Dpi);
+        int tokenizedRight = SystemDrawingPageRenderer.RightmostInkColumn (tokenized);
+
+        // Baseline: the same characters drawn as ONE string, with the same font and typographic format
+        // the engine paints with. On a monospace font the tokenized runs should end at the same x.
+        int baselineRight = RightmostInkOfSingleString (lineText, pxW, pxH);
+
+        Assert.True (tokenizedRight > 0, "Tokenized render produced no ink.");
+        Assert.True (baselineRight > 0, "Baseline render produced no ink.");
+
+        // Pre-fix, ~1/6 em of GDI+ padding was added before every token, drifting the line tens of px wider.
+        Assert.True (Math.Abs (tokenizedRight - baselineRight) <= 6,
+            $"Tokenized line drifted from single-string width: tokenizedRight={tokenizedRight}, " +
+            $"baselineRight={baselineRight} (px).");
+    }
+
+    private static int RightmostInkOfSingleString (string text, int pxW, int pxH)
+    {
+        using var bitmap = new Bitmap (pxW, pxH);
+        bitmap.SetResolution (Dpi, Dpi);
+        using (Graphics g = Graphics.FromImage (bitmap))
+        {
+            g.Clear (Color.White);
+            g.PageUnit = GraphicsUnit.Display;
+            var context = new SystemDrawingGraphicsContext (g);
+            using IGraphicsFont font =
+                context.CreateFont ("Consolas", 9, GraphicsFontStyle.Regular, GraphicsFontUnit.Point);
+            context.DrawString (text, font, context.BlackBrush, 0, 0, ContentTypeEngineBase.GraphicsStringFormat);
+        }
+
+        return SystemDrawingPageRenderer.RightmostInkColumn (bitmap);
+    }
+}

--- a/tests/WinPrint.Core.UnitTests/Cte/TextMateCteTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Cte/TextMateCteTests.cs
@@ -18,86 +18,86 @@ namespace WinPrint.Core.UnitTests.Cte;
 
 public class TextMateCteTests
 {
-    private static readonly string CteClassName = typeof (TextMateCte).Name;
+    private static readonly string CteClassName = typeof(TextMateCte).Name;
 
-    public TextMateCteTests (ITestOutputHelper output)
+    public TextMateCteTests(ITestOutputHelper output)
     {
-        ServiceLocator.Current.LogService.Start (GetType ().Name,
-            new TestOutputSink (output, new Serilog.Formatting.Display.MessageTemplateTextFormatter ("{Message:lj}")),
+        ServiceLocator.Current.LogService.Start(GetType().Name,
+            new TestOutputSink(output, new Serilog.Formatting.Display.MessageTemplateTextFormatter("{Message:lj}")),
             true, true);
     }
 
     [Fact]
-    public void SupportedContentTypesTest ()
+    public void SupportedContentTypesTest()
     {
-        var cte = new TextMateCte ();
-        Assert.Single (cte.SupportedContentTypes);
-        Assert.Equal ("text/plain", cte.SupportedContentTypes[0]);
+        var cte = new TextMateCte();
+        Assert.Single(cte.SupportedContentTypes);
+        Assert.Equal("text/plain", cte.SupportedContentTypes[0]);
     }
 
     [Fact]
-    public void NewContentTypeEngineTest ()
+    public void NewContentTypeEngineTest()
     {
-        var svm = new SheetViewModel ();
+        var svm = new SheetViewModel();
         (svm.ContentEngine, svm.ContentType, svm.Language) =
-            ContentTypeEngineBase.CreateContentTypeEngine (CteClassName);
-        Assert.NotNull (svm.ContentEngine);
+            ContentTypeEngineBase.CreateContentTypeEngine(CteClassName);
+        Assert.NotNull(svm.ContentEngine);
 
-        Assert.Equal (CteClassName, svm.ContentEngine!.GetType ().Name);
-        Assert.Equal ("text/plain", svm.ContentType);
-        Assert.Equal ("Plain Text", svm.Language);
+        Assert.Equal(CteClassName, svm.ContentEngine!.GetType().Name);
+        Assert.Equal("text/plain", svm.ContentType);
+        Assert.Equal("Plain Text", svm.Language);
     }
 
     [Fact]
-    public void SourceLanguageUsesTextMateByDefaultTest ()
+    public void SourceLanguageUsesTextMateByDefaultTest()
     {
-        var settings = Settings.CreateDefaultSettings ();
-        ModelLocator.Current.Settings.CopyPropertiesFrom (settings);
+        var settings = Settings.CreateDefaultSettings();
+        ModelLocator.Current.Settings.CopyPropertiesFrom(settings);
 
         (ContentTypeEngineBase? cte, string contentType, string language) =
-            ContentTypeEngineBase.CreateContentTypeEngine ("csharp");
+            ContentTypeEngineBase.CreateContentTypeEngine("csharp");
 
-        Assert.IsType<TextMateCte> (cte);
-        Assert.Equal ("text/x-csharp", contentType);
-        Assert.Equal ("C#", language);
+        Assert.IsType<TextMateCte>(cte);
+        Assert.Equal("text/x-csharp", contentType);
+        Assert.Equal("C#", language);
     }
 
     [Fact]
-    public async Task RenderAsyncTest ()
+    public async Task RenderAsyncTest()
     {
-        var settings = Settings.CreateDefaultSettings ();
-        ModelLocator.Current.Settings.CopyPropertiesFrom (settings);
+        var settings = Settings.CreateDefaultSettings();
+        ModelLocator.Current.Settings.CopyPropertiesFrom(settings);
 
-        var svm = new SheetViewModel ();
-        (svm.ContentEngine, svm.ContentType, svm.Language) = ContentTypeEngineBase.CreateContentTypeEngine ("csharp");
-        Assert.IsType<TextMateCte> (svm.ContentEngine);
+        var svm = new SheetViewModel();
+        (svm.ContentEngine, svm.ContentType, svm.Language) = ContentTypeEngineBase.CreateContentTypeEngine("csharp");
+        Assert.IsType<TextMateCte>(svm.ContentEngine);
 
         var cte = (TextMateCte)svm.ContentEngine;
-        cte.Configure (svm.ContentType, svm.Language, "Program.cs");
+        cte.Configure(svm.ContentType, svm.Language, "Program.cs");
         cte.ContentSettings = new ContentSettings
         {
             Font = new Core.Models.Font { Family = "Courier New", Size = 10 },
             LineNumbers = false
         };
 
-        using var bitmap = new Bitmap (1, 1);
-        bitmap.SetResolution (96, 96);
-        using var g = Graphics.FromImage (bitmap);
-        using var font = new System.Drawing.Font (cte.ContentSettings.Font.Family,
+        using var bitmap = new Bitmap(1, 1);
+        bitmap.SetResolution(96, 96);
+        using var g = Graphics.FromImage(bitmap);
+        using var font = new System.Drawing.Font(cte.ContentSettings.Font.Family,
             cte.ContentSettings.Font.Size / 72F * 96,
             (System.Drawing.FontStyle)cte.ContentSettings.Font.Style, GraphicsUnit.Pixel);
 
-        cte.PageSize = new SizeF (1000, font.GetHeight () * 5);
+        cte.PageSize = new SizeF(1000, font.GetHeight() * 5);
 
-        Assert.True (await cte.SetDocumentAsync ("using System;\nConsole.WriteLine(\"hi\");"));
-        Assert.Equal (1, await cte.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null));
+        Assert.True(await cte.SetDocumentAsync("using System;\nConsole.WriteLine(\"hi\");"));
+        Assert.Equal(1, await cte.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null));
     }
 
     [Fact]
-    public async Task RenderAsyncWithFormFeedsAdvancesLogicalLineNumbersTest ()
+    public async Task RenderAsyncWithFormFeedsAdvancesLogicalLineNumbersTest()
     {
-        var cte = new TextMateCte ();
-        cte.Configure ("text/plain", "Plain Text", "notes.txt");
+        var cte = new TextMateCte();
+        cte.Configure("text/plain", "Plain Text", "notes.txt");
         cte.ContentSettings = new ContentSettings
         {
             Font = new Core.Models.Font { Family = "Courier New", Size = 10 },
@@ -105,39 +105,41 @@ public class TextMateCteTests
             NewPageOnFormFeed = true
         };
 
-        using var bitmap = new Bitmap (1, 1);
-        bitmap.SetResolution (96, 96);
-        using var font = new System.Drawing.Font (cte.ContentSettings.Font.Family,
+        using var bitmap = new Bitmap(1, 1);
+        bitmap.SetResolution(96, 96);
+        using var font = new System.Drawing.Font(cte.ContentSettings.Font.Family,
             cte.ContentSettings.Font.Size / 72F * 96,
             (System.Drawing.FontStyle)cte.ContentSettings.Font.Style, GraphicsUnit.Pixel);
 
-        cte.PageSize = new SizeF (1000, font.GetHeight () * 5);
+        cte.PageSize = new SizeF(1000, font.GetHeight() * 5);
 
-        Assert.True (await cte.SetDocumentAsync ("alpha\fbravo\ncharlie"));
-        await cte.RenderAsync (new PrintResolution { X = 96, Y = 96 }, null);
+        Assert.True(await cte.SetDocumentAsync("alpha\fbravo\ncharlie"));
+        await cte.RenderAsync(new PrintResolution { X = 96, Y = 96 }, null);
 
-        FieldInfo? wrappedLinesField = typeof (TextMateCte).GetField ("_wrappedLines",
+        FieldInfo? wrappedLinesField = typeof(TextMateCte).GetField("_wrappedLines",
             BindingFlags.Instance | BindingFlags.NonPublic);
-        Assert.NotNull (wrappedLinesField);
-        IEnumerable wrappedLines = Assert.IsAssignableFrom<IEnumerable> (wrappedLinesField.GetValue (cte));
-        int[] lineNumbers = wrappedLines.Cast<object> ()
-            .Select (line => (int)line.GetType ().GetProperty ("NonWrappedLineNumber")!.GetValue (line)!)
-            .Where (lineNumber => lineNumber > 0)
-            .ToArray ();
+        Assert.NotNull(wrappedLinesField);
+        IEnumerable wrappedLines = Assert.IsAssignableFrom<IEnumerable>(wrappedLinesField.GetValue(cte));
+        int[] lineNumbers =
+        [
+            .. wrappedLines.Cast<object>()
+                .Select(line => (int)line.GetType().GetProperty("NonWrappedLineNumber")!.GetValue(line)!)
+                .Where(lineNumber => lineNumber > 0)
+        ];
 
-        Assert.Equal ([1, 2, 3], lineNumbers);
+        Assert.Equal([1, 2, 3], lineNumbers);
     }
 
     [Fact]
-    public void GetForegroundColorUsesFirstColorMapEntryTest ()
+    public void GetForegroundColorUsesFirstColorMapEntryTest()
     {
         MethodInfo? method =
-            typeof (TextMateCte).GetMethod ("GetForegroundColor", BindingFlags.NonPublic | BindingFlags.Static);
-        Assert.NotNull (method);
+            typeof(TextMateCte).GetMethod("GetForegroundColor", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
 
-        int metadata = EncodedTokenAttributes.Set (0, 0, 0, null, TextMateFontStyle.NotSet, 1, 0);
-        Color color = Assert.IsType<Color> (method.Invoke (null, [metadata, new[] { "#123456" }]));
+        int metadata = EncodedTokenAttributes.Set(0, 0, 0, null, TextMateFontStyle.NotSet, 1, 0);
+        Color color = Assert.IsType<Color>(method.Invoke(null, [metadata, new[] { "#123456" }]));
 
-        Assert.Equal (ColorTranslator.FromHtml ("#123456").ToArgb (), color.ToArgb ());
+        Assert.Equal(ColorTranslator.FromHtml("#123456").ToArgb(), color.ToArgb());
     }
 }

--- a/tests/WinPrint.Core.UnitTests/Models/FontTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Models/FontTests.cs
@@ -8,108 +8,108 @@ namespace WinPrint.Core.UnitTests.Models;
 
 public class FontTests : TestModelsBase
 {
-    public FontTests (ITestOutputHelper output) : base (output)
+    public FontTests(ITestOutputHelper output) : base(output)
     {
     }
 
     [Fact]
-    public void TestFont ()
+    public void TestFont()
     {
-        var font = new Font ();
-        Assert.Equal (8, font.Size);
-        Assert.Equal (FontStyle.Regular, font.Style);
-        Assert.Equal ("sansserif", font.Family);
+        var font = new Font();
+        Assert.Equal(8, font.Size);
+        Assert.Equal(FontStyle.Regular, font.Style);
+        Assert.Equal("sansserif", font.Family);
     }
 
     [Fact]
-    public void TestSetFamily ()
+    public void TestSetFamily()
     {
         var font = new Font
         {
             Family = "Cascadia Code"
         };
-        Assert.Equal ("Cascadia Code", font.Family);
+        Assert.Equal("Cascadia Code", font.Family);
     }
 
     [Fact]
-    public void TestSetSize ()
+    public void TestSetSize()
     {
-        var font = new Font ();
-        Assert.Equal (8, font.Size);
+        var font = new Font();
+        Assert.Equal(8, font.Size);
 
         font.Size = 10;
-        Assert.Equal (10, font.Size);
+        Assert.Equal(10, font.Size);
     }
 
     [Fact]
-    public void TestSetStyle ()
+    public void TestSetStyle()
     {
-        var font = new Font ();
-        Assert.Equal (8, font.Size);
+        var font = new Font();
+        Assert.Equal(8, font.Size);
 
         font.Style = FontStyle.Italic;
-        Assert.Equal (FontStyle.Italic, font.Style);
+        Assert.Equal(FontStyle.Italic, font.Style);
 
         //font.Style = (FontStyle)88;
         //Assert.AreEqual(FontStyle.Regular, font.Style, "Invalid style was not converted properly");
     }
 
     [Fact]
-    public void TestPersistence ()
+    public void TestPersistence()
     {
-        var font = new Font ();
+        var font = new Font();
 
-        string json = JsonSerializer.Serialize (font, jsonOptions);
+        string json = JsonSerializer.Serialize(font, jsonOptions);
 
-        Assert.NotNull (json);
-        Assert.True (json.Length > 0);
+        Assert.NotNull(json);
+        Assert.True(json.Length > 0);
 
-        Font? font2 = JsonSerializer.Deserialize<Font> (json);
-        Assert.NotNull (font2);
-        Assert.Equal (font.Family, font2.Family);
-        Assert.Equal (font.Size, font2.Size);
-        Assert.Equal (font.Style, font2.Style);
+        Font? font2 = JsonSerializer.Deserialize<Font>(json);
+        Assert.NotNull(font2);
+        Assert.Equal(font.Family, font2.Family);
+        Assert.Equal(font.Size, font2.Size);
+        Assert.Equal(font.Style, font2.Style);
     }
 
     [Fact]
-    public void TestDeserialize ()
+    public void TestDeserialize()
     {
         // Defaults
         string json = "{\"Family\":\"Microsoft Sans Serif\",\"Style\":\"Regular\",\"Size\":8}";
-        Font? font = JsonSerializer.Deserialize<Font> (json, jsonOptions);
-        Assert.NotNull (font);
-        Assert.Equal ("Microsoft Sans Serif", font.Family);
-        Assert.Equal (8, font.Size);
-        Assert.Equal (FontStyle.Regular, font.Style);
+        Font? font = JsonSerializer.Deserialize<Font>(json, jsonOptions);
+        Assert.NotNull(font);
+        Assert.Equal("Microsoft Sans Serif", font.Family);
+        Assert.Equal(8, font.Size);
+        Assert.Equal(FontStyle.Regular, font.Style);
 
         // Non Defaults
         json = "{\"Family\":\"Cascadia Code\",\"Style\":\"Italic\",\"Size\":10}";
-        font = JsonSerializer.Deserialize<Font> (json, jsonOptions);
-        Assert.NotNull (font);
-        Assert.Equal ("Cascadia Code", font.Family);
-        Assert.Equal (10, font.Size);
-        Assert.Equal (FontStyle.Italic, font.Style);
+        font = JsonSerializer.Deserialize<Font>(json, jsonOptions);
+        Assert.NotNull(font);
+        Assert.Equal("Cascadia Code", font.Family);
+        Assert.Equal(10, font.Size);
+        Assert.Equal(FontStyle.Italic, font.Style);
 
         // Numeric enum value
         json = "{\"Family\":\"Microsoft Sans Serif\",\"Style\":1,\"Size\":8}";
-        font = JsonSerializer.Deserialize<Font> (json, jsonOptions);
-        Assert.NotNull (font);
-        Assert.Equal (FontStyle.Bold, font.Style);
+        font = JsonSerializer.Deserialize<Font>(json, jsonOptions);
+        Assert.NotNull(font);
+        Assert.Equal(FontStyle.Bold, font.Style);
 
         // Camel casing
         json = "{\"family\":\"Cascadia Code\",\"style\":\"Italic\",\"size\":10}";
-        font = JsonSerializer.Deserialize<Font> (json, jsonOptions);
-        Assert.NotNull (font);
-        Assert.Equal ("Cascadia Code", font.Family);
-        Assert.Equal (10, font.Size);
-        Assert.Equal (FontStyle.Italic, font.Style);
+        font = JsonSerializer.Deserialize<Font>(json, jsonOptions);
+        Assert.NotNull(font);
+        Assert.Equal("Cascadia Code", font.Family);
+        Assert.Equal(10, font.Size);
+        Assert.Equal(FontStyle.Italic, font.Style);
 
         // Mixed casing
         json = "{\"FAMILY\":\"Cascadia Code\",\"STYLE\":\"Italic\",\"SIzE\":10}";
-        font = JsonSerializer.Deserialize<Font> (json, jsonOptions);
-        Assert.NotNull (font);
-        Assert.Equal ("Cascadia Code", font.Family);
-        Assert.Equal (10, font.Size);
-        Assert.Equal (FontStyle.Italic, font.Style);
+        font = JsonSerializer.Deserialize<Font>(json, jsonOptions);
+        Assert.NotNull(font);
+        Assert.Equal("Cascadia Code", font.Family);
+        Assert.Equal(10, font.Size);
+        Assert.Equal(FontStyle.Italic, font.Style);
     }
 }

--- a/tests/WinPrint.Core.UnitTests/Models/MacrosTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Models/MacrosTests.cs
@@ -13,19 +13,19 @@ public class MacrosTests : TestModelsBase
 {
     private readonly string EmptyName = "";
 
-    public MacrosTests (ITestOutputHelper output) : base (output)
+    public MacrosTests(ITestOutputHelper output) : base(output)
     {
     }
 
     // Test file paths
-    private string ExistingFile => Path.GetTempFileName ();
+    private string ExistingFile => Path.GetTempFileName();
 
     private string ExistingFileNoExtension
     {
         get
         {
-            string f = Path.GetTempPath () + Path.GetFileNameWithoutExtension (Path.GetTempFileName ());
-            File.Create (f).Close ();
+            string f = Path.GetTempPath() + Path.GetFileNameWithoutExtension(Path.GetTempFileName());
+            File.Create(f).Close();
             return f;
         }
     }
@@ -35,7 +35,7 @@ public class MacrosTests : TestModelsBase
         get
         {
             string f = ExistingFile;
-            File.Delete (f);
+            File.Delete(f);
             return f;
         }
     }
@@ -45,343 +45,343 @@ public class MacrosTests : TestModelsBase
         get
         {
             string f = ExistingFileNoExtension;
-            File.Delete (f);
+            File.Delete(f);
             return f;
         }
     }
 
     private string InvalidFileName =>
-        Path.GetTempFileName ().Replace (@"\tmp", @$"\{Path.GetInvalidFileNameChars ()[0]}mp");
+        Path.GetTempFileName().Replace(@"\tmp", @$"\{Path.GetInvalidFileNameChars()[0]}mp");
 
     private string InvalidDirectoryName =>
-        Path.GetTempFileName ().Replace (@"\Temp", $@"\{Path.GetInvalidPathChars ()[0]}emp");
+        Path.GetTempFileName().Replace(@"\Temp", $@"\{Path.GetInvalidPathChars()[0]}emp");
 
     private string? NullName => null;
 
     [Fact]
-    public void RealFileName_Test ()
+    public void RealFileName_Test()
     {
-        string file = Path.GetTempFileName ();
+        string file = Path.GetTempFileName();
 
         var svm = new SheetViewModel
         {
             File = file,
-            ContentEngine = new TextCte ()
+            ContentEngine = new TextCte()
         };
-        var macros = new Macros (svm);
+        var macros = new Macros(svm);
 
-        Assert.Equal (Path.GetExtension (file), macros.ReplaceMacros (@"{FileExtension}"));
-        Assert.Equal (Path.GetFileName (file), macros.ReplaceMacros (@"{FileName}"));
-        Assert.Equal (Path.GetFileNameWithoutExtension (file), macros.ReplaceMacros (@"{FileNameWithoutExtension}"));
-        Assert.Equal (Path.GetDirectoryName (file), macros.ReplaceMacros (@"{FileDirectoryName}"));
-        Assert.Equal (Path.GetFullPath (file), macros.ReplaceMacros (@"{FullPath}"));
-        Assert.Equal ($"{File.GetLastWriteTime (file)}", macros.ReplaceMacros (@"{DateRevised}"));
-        Assert.Equal ($"{File.GetCreationTime (file)}", macros.ReplaceMacros (@"{DateCreated}"));
+        Assert.Equal(Path.GetExtension(file), macros.ReplaceMacros(@"{FileExtension}"));
+        Assert.Equal(Path.GetFileName(file), macros.ReplaceMacros(@"{FileName}"));
+        Assert.Equal(Path.GetFileNameWithoutExtension(file), macros.ReplaceMacros(@"{FileNameWithoutExtension}"));
+        Assert.Equal(Path.GetDirectoryName(file), macros.ReplaceMacros(@"{FileDirectoryName}"));
+        Assert.Equal(Path.GetFullPath(file), macros.ReplaceMacros(@"{FullPath}"));
+        Assert.Equal($"{File.GetLastWriteTime(file)}", macros.ReplaceMacros(@"{DateRevised}"));
+        Assert.Equal($"{File.GetCreationTime(file)}", macros.ReplaceMacros(@"{DateCreated}"));
 
-        File.Delete (svm.File);
+        File.Delete(svm.File);
     }
 
     [Fact]
-    public void NonExistantGoodFileName_Test ()
+    public void NonExistantGoodFileName_Test()
     {
-        string file = Path.GetTempFileName ();
-        File.Delete (file);
+        string file = Path.GetTempFileName();
+        File.Delete(file);
 
         var svm = new SheetViewModel
         {
             File = file,
-            ContentEngine = new TextCte ()
+            ContentEngine = new TextCte()
         };
-        var macros = new Macros (svm);
+        var macros = new Macros(svm);
 
-        Assert.Equal (Path.GetExtension (file), macros.ReplaceMacros (@"{FileExtension}"));
-        Assert.Equal (Path.GetFileName (file), macros.ReplaceMacros (@"{FileName}"));
-        Assert.Equal (Path.GetFileNameWithoutExtension (file), macros.ReplaceMacros (@"{FileNameWithoutExtension}"));
-        Assert.Equal (Path.GetDirectoryName (file), macros.ReplaceMacros (@"{FileDirectoryName}"));
-        Assert.Equal (Path.GetFullPath (file), macros.ReplaceMacros (@"{FullPath}"));
+        Assert.Equal(Path.GetExtension(file), macros.ReplaceMacros(@"{FileExtension}"));
+        Assert.Equal(Path.GetFileName(file), macros.ReplaceMacros(@"{FileName}"));
+        Assert.Equal(Path.GetFileNameWithoutExtension(file), macros.ReplaceMacros(@"{FileNameWithoutExtension}"));
+        Assert.Equal(Path.GetDirectoryName(file), macros.ReplaceMacros(@"{FileDirectoryName}"));
+        Assert.Equal(Path.GetFullPath(file), macros.ReplaceMacros(@"{FullPath}"));
         // it's not a real file so, dates should be minvalue
-        Assert.Equal ($"{DateTime.MinValue}", macros.ReplaceMacros (@"{DateRevised}"));
-        Assert.Equal ($"{DateTime.MinValue}", macros.ReplaceMacros (@"{DateCreated}"));
+        Assert.Equal($"{DateTime.MinValue}", macros.ReplaceMacros(@"{DateRevised}"));
+        Assert.Equal($"{DateTime.MinValue}", macros.ReplaceMacros(@"{DateCreated}"));
     }
 
     [Fact]
-    public void NonExistantBogusPathFileName_Test ()
+    public void NonExistantBogusPathFileName_Test()
     {
-        string file = Path.GetTempFileName ();
-        File.Delete (file);
+        string file = Path.GetTempFileName();
+        File.Delete(file);
 
         // Relpace the T in Temp with an invalid char
-        file = file.Replace ('T', Path.GetInvalidPathChars ()[0]);
+        file = file.Replace('T', Path.GetInvalidPathChars()[0]);
 
         var svm = new SheetViewModel
         {
             File = file,
-            ContentEngine = new TextCte ()
+            ContentEngine = new TextCte()
         };
-        var macros = new Macros (svm);
+        var macros = new Macros(svm);
 
-        Assert.Equal (Path.GetExtension (file), macros.ReplaceMacros (@"{FileExtension}"));
-        Assert.Equal (Path.GetFileName (file), macros.ReplaceMacros (@"{FileName}"));
-        Assert.Equal (Path.GetFileNameWithoutExtension (file), macros.ReplaceMacros (@"{FileNameWithoutExtension}"));
+        Assert.Equal(Path.GetExtension(file), macros.ReplaceMacros(@"{FileExtension}"));
+        Assert.Equal(Path.GetFileName(file), macros.ReplaceMacros(@"{FileName}"));
+        Assert.Equal(Path.GetFileNameWithoutExtension(file), macros.ReplaceMacros(@"{FileNameWithoutExtension}"));
         // return original path
-        Assert.Equal (Path.GetDirectoryName (file), macros.ReplaceMacros (@"{FileDirectoryName}"));
-        Assert.Equal (Path.GetFullPath (file), macros.ReplaceMacros (@"{FullPath}"));
+        Assert.Equal(Path.GetDirectoryName(file), macros.ReplaceMacros(@"{FileDirectoryName}"));
+        Assert.Equal(Path.GetFullPath(file), macros.ReplaceMacros(@"{FullPath}"));
         // it's not a real file so, dates should be minvalue
-        Assert.Equal ($"{DateTime.MinValue}", macros.ReplaceMacros (@"{DateRevised}"));
-        Assert.Equal ($"{DateTime.MinValue}", macros.ReplaceMacros (@"{DateCreated}"));
+        Assert.Equal($"{DateTime.MinValue}", macros.ReplaceMacros(@"{DateRevised}"));
+        Assert.Equal($"{DateTime.MinValue}", macros.ReplaceMacros(@"{DateCreated}"));
     }
 
     [Fact]
-    public void NonExistantBogusFileNameFileName_Test ()
+    public void NonExistantBogusFileNameFileName_Test()
     {
-        string file = Path.GetTempFileName ();
-        File.Delete (file);
+        string file = Path.GetTempFileName();
+        File.Delete(file);
 
         // Make filename invalid 
-        file = file.Replace (@"\tmp", @$"\{Path.GetInvalidFileNameChars ()[0]}mp");
+        file = file.Replace(@"\tmp", @$"\{Path.GetInvalidFileNameChars()[0]}mp");
 
         var svm = new SheetViewModel
         {
             File = file,
-            ContentEngine = new TextCte ()
+            ContentEngine = new TextCte()
         };
-        var macros = new Macros (svm);
+        var macros = new Macros(svm);
 
         // return original file
-        Assert.Equal (Path.GetExtension (file), macros.ReplaceMacros (@"{FileExtension}"));
-        Assert.Equal (Path.GetFileName (file), macros.ReplaceMacros (@"{FileName}"));
-        Assert.Equal (Path.GetFileNameWithoutExtension (file), macros.ReplaceMacros (@"{FileNameWithoutExtension}"));
-        Assert.Equal (Path.GetDirectoryName (file), macros.ReplaceMacros (@"{FileDirectoryName}"));
-        Assert.Equal (Path.GetFullPath (file), macros.ReplaceMacros (@"{FullPath}"));
+        Assert.Equal(Path.GetExtension(file), macros.ReplaceMacros(@"{FileExtension}"));
+        Assert.Equal(Path.GetFileName(file), macros.ReplaceMacros(@"{FileName}"));
+        Assert.Equal(Path.GetFileNameWithoutExtension(file), macros.ReplaceMacros(@"{FileNameWithoutExtension}"));
+        Assert.Equal(Path.GetDirectoryName(file), macros.ReplaceMacros(@"{FileDirectoryName}"));
+        Assert.Equal(Path.GetFullPath(file), macros.ReplaceMacros(@"{FullPath}"));
         // it's not a real file so, dates should be minvalue
-        Assert.Equal ($"{DateTime.MinValue}", macros.ReplaceMacros (@"{DateRevised}"));
-        Assert.Equal ($"{DateTime.MinValue}", macros.ReplaceMacros (@"{DateCreated}"));
+        Assert.Equal($"{DateTime.MinValue}", macros.ReplaceMacros(@"{DateRevised}"));
+        Assert.Equal($"{DateTime.MinValue}", macros.ReplaceMacros(@"{DateCreated}"));
     }
 
-    private SheetViewModel SetupSVM ()
+    private SheetViewModel SetupSVM()
     {
         var svm = new SheetViewModel
         {
-            ContentEngine = new TextCte ()
+            ContentEngine = new TextCte()
         };
         return svm;
     }
 
 
     [Fact]
-    public void FileExtension ()
+    public void FileExtension()
     {
-        SheetViewModel svm = SetupSVM ();
-        var macros = new Macros (svm);
+        SheetViewModel svm = SetupSVM();
+        var macros = new Macros(svm);
 
         svm.File = ExistingFile;
-        Assert.Equal (Path.GetExtension (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal(Path.GetExtension(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = ExistingFileNoExtension;
-        Assert.Equal (Path.GetExtension (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal(Path.GetExtension(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = NonExistingFile;
-        File.Delete (svm.File);
-        Assert.Equal (Path.GetExtension (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        File.Delete(svm.File);
+        Assert.Equal(Path.GetExtension(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = NonExistingFileNoExtension;
-        File.Delete (svm.File);
-        Assert.Equal (Path.GetExtension (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        File.Delete(svm.File);
+        Assert.Equal(Path.GetExtension(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = InvalidFileName;
-        Assert.Equal (Path.GetExtension (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal(Path.GetExtension(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = InvalidDirectoryName;
-        Assert.Equal (Path.GetExtension (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal(Path.GetExtension(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = NullName!; // Intentional null input exercises macro fallback.
-        Assert.Equal ("", macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal("", macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = EmptyName;
-        Assert.Equal ("", macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal("", macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
     }
 
     [Fact]
-    public void FileName ()
+    public void FileName()
     {
-        SheetViewModel svm = SetupSVM ();
-        var macros = new Macros (svm);
+        SheetViewModel svm = SetupSVM();
+        var macros = new Macros(svm);
 
         svm.File = ExistingFile;
-        Assert.Equal (Path.GetFileName (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal(Path.GetFileName(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = ExistingFileNoExtension;
-        Assert.Equal (Path.GetFileName (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal(Path.GetFileName(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = NonExistingFile;
-        File.Delete (svm.File);
-        Assert.Equal (Path.GetFileName (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        File.Delete(svm.File);
+        Assert.Equal(Path.GetFileName(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = NonExistingFileNoExtension;
-        File.Delete (svm.File);
-        Assert.Equal (Path.GetFileName (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        File.Delete(svm.File);
+        Assert.Equal(Path.GetFileName(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = InvalidFileName;
-        Assert.Equal (Path.GetFileName (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal(Path.GetFileName(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = InvalidDirectoryName;
-        Assert.Equal (Path.GetFileName (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal(Path.GetFileName(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = NullName!; // Intentional null input exercises macro fallback.
-        Assert.Equal ("", macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal("", macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = EmptyName;
-        Assert.Equal ("", macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal("", macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
     }
 
     [Fact]
-    public void Title ()
+    public void Title()
     {
-        SheetViewModel svm = SetupSVM ();
-        var macros = new Macros (svm);
+        SheetViewModel svm = SetupSVM();
+        var macros = new Macros(svm);
 
         svm.Title = ExistingFile;
-        Assert.Equal (svm.Title, macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal(svm.Title, macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
     }
 
     [Fact]
-    public void FileNameWithoutExtension ()
+    public void FileNameWithoutExtension()
     {
-        SheetViewModel svm = SetupSVM ();
-        var macros = new Macros (svm);
+        SheetViewModel svm = SetupSVM();
+        var macros = new Macros(svm);
 
         svm.File = ExistingFile;
-        Assert.Equal (Path.GetFileNameWithoutExtension (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal(Path.GetFileNameWithoutExtension(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = ExistingFileNoExtension;
-        Assert.Equal (Path.GetFileNameWithoutExtension (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal(Path.GetFileNameWithoutExtension(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = NonExistingFile;
-        File.Delete (svm.File);
-        Assert.Equal (Path.GetFileNameWithoutExtension (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        File.Delete(svm.File);
+        Assert.Equal(Path.GetFileNameWithoutExtension(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = NonExistingFileNoExtension;
-        File.Delete (svm.File);
-        Assert.Equal (Path.GetFileNameWithoutExtension (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        File.Delete(svm.File);
+        Assert.Equal(Path.GetFileNameWithoutExtension(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = InvalidFileName;
-        Assert.Equal (Path.GetFileNameWithoutExtension (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal(Path.GetFileNameWithoutExtension(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = InvalidDirectoryName;
-        Assert.Equal (Path.GetFileNameWithoutExtension (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal(Path.GetFileNameWithoutExtension(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = NullName!; // Intentional null input exercises macro fallback.
-        Assert.Equal ("", macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal("", macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = EmptyName;
-        Assert.Equal ("", macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal("", macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
     }
 
     [Fact]
-    public void FileDirectoryName ()
+    public void FileDirectoryName()
     {
-        SheetViewModel svm = SetupSVM ();
-        var macros = new Macros (svm);
+        SheetViewModel svm = SetupSVM();
+        var macros = new Macros(svm);
 
         svm.File = ExistingFile;
-        Assert.Equal (Path.GetDirectoryName (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal(Path.GetDirectoryName(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = ExistingFileNoExtension;
-        Assert.Equal (Path.GetDirectoryName (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal(Path.GetDirectoryName(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = NonExistingFile;
-        File.Delete (svm.File);
-        Assert.Equal (Path.GetDirectoryName (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        File.Delete(svm.File);
+        Assert.Equal(Path.GetDirectoryName(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = NonExistingFileNoExtension;
-        File.Delete (svm.File);
-        Assert.Equal (Path.GetDirectoryName (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        File.Delete(svm.File);
+        Assert.Equal(Path.GetDirectoryName(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = InvalidFileName;
-        Assert.Equal (Path.GetDirectoryName (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal(Path.GetDirectoryName(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = InvalidDirectoryName;
-        Assert.Equal (Path.GetDirectoryName (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal(Path.GetDirectoryName(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = NullName!; // Intentional null input exercises macro fallback.
-        Assert.Equal ("", macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal("", macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = EmptyName;
-        Assert.Equal ("", macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal("", macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
     }
 
     [Fact]
-    public void FullPath ()
+    public void FullPath()
     {
-        SheetViewModel svm = SetupSVM ();
-        var macros = new Macros (svm);
+        SheetViewModel svm = SetupSVM();
+        var macros = new Macros(svm);
 
         svm.File = ExistingFile;
-        Assert.Equal (Path.GetFullPath (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal(Path.GetFullPath(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = ExistingFileNoExtension;
-        Assert.Equal (Path.GetFullPath (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal(Path.GetFullPath(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = NonExistingFile;
-        File.Delete (svm.File);
-        Assert.Equal (Path.GetFullPath (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        File.Delete(svm.File);
+        Assert.Equal(Path.GetFullPath(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = NonExistingFileNoExtension;
-        File.Delete (svm.File);
-        Assert.Equal (Path.GetFullPath (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        File.Delete(svm.File);
+        Assert.Equal(Path.GetFullPath(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = InvalidFileName;
-        Assert.Equal (Path.GetFullPath (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal(Path.GetFullPath(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = InvalidDirectoryName;
-        Assert.Equal (Path.GetFullPath (svm.File),
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal(Path.GetFullPath(svm.File),
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = NullName!; // Intentional null input exercises macro fallback.
-        Assert.Equal ("", macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal("", macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = EmptyName;
-        Assert.Equal ("", macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal("", macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
     }
 
     [Fact]
-    public void DateFormatStrings ()
+    public void DateFormatStrings()
     {
-        SheetViewModel svm = SetupSVM ();
-        var macros = new Macros (svm);
+        SheetViewModel svm = SetupSVM();
+        var macros = new Macros(svm);
 
         // Invalid - :c is not a valid datetime format specifier - instead of throwing an exception we return invalid macro
         string test = "{DatePrinted:c}";
-        Assert.Equal (test, macros.ReplaceMacros (test));
+        Assert.Equal(test, macros.ReplaceMacros(test));
 
         // Invalid - :c is not a valid datetime format specifier - instead of throwing an exception we return invalid macro
         // string.Format doesn't fail on this, thus we can't detect it
@@ -390,11 +390,11 @@ public class MacrosTests : TestModelsBase
 
         // Invalid - too many braces
         test = "{abc}}";
-        Assert.Equal (test, macros.ReplaceMacros (test));
+        Assert.Equal(test, macros.ReplaceMacros(test));
 
         // Invalid - too many braces
         test = "{{abc}";
-        Assert.Equal (test, macros.ReplaceMacros (test));
+        Assert.Equal(test, macros.ReplaceMacros(test));
 
         // Valid - embedded braces
         //test = "{{DateTime:u}}";
@@ -402,326 +402,326 @@ public class MacrosTests : TestModelsBase
 
         // Valid? - embedded newline
         test = "{\n}";
-        Assert.Equal (test, macros.ReplaceMacros (test));
+        Assert.Equal(test, macros.ReplaceMacros(test));
     }
 
     [Fact]
-    public void DatePrinted ()
+    public void DatePrinted()
     {
         // No way to test since uses DateTime.Now - assume DateRevised tests cover
-        SheetViewModel svm = SetupSVM ();
-        var macros = new Macros (svm);
+        SheetViewModel svm = SetupSVM();
+        var macros = new Macros(svm);
 
         // https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings
         //  "u" Universal sortable date / time pattern.
         //  2009 - 06 - 15 13:45:30Z
-        Assert.StartsWith ($"{DateTime.Now:u}"[..^3],
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}:u}}"));
+        Assert.StartsWith($"{DateTime.Now:u}"[..^3],
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}:u}}"));
     }
 
     [Fact]
-    public void DateRevised ()
+    public void DateRevised()
     {
-        SheetViewModel svm = SetupSVM ();
-        var macros = new Macros (svm);
+        SheetViewModel svm = SetupSVM();
+        var macros = new Macros(svm);
 
         svm.File = ExistingFile;
-        Assert.Equal ($"{File.GetLastWriteTime (svm.File)}",
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal($"{File.GetLastWriteTime(svm.File)}",
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = ExistingFileNoExtension;
-        Assert.Equal ($"{File.GetLastWriteTime (svm.File)}",
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal($"{File.GetLastWriteTime(svm.File)}",
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = NonExistingFile;
-        File.Delete (svm.File);
-        Assert.Equal ($"{DateTime.MinValue}", macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        File.Delete(svm.File);
+        Assert.Equal($"{DateTime.MinValue}", macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = NonExistingFileNoExtension;
-        File.Delete (svm.File);
-        Assert.Equal ($"{DateTime.MinValue}", macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        File.Delete(svm.File);
+        Assert.Equal($"{DateTime.MinValue}", macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = InvalidFileName;
-        Assert.Equal ($"{DateTime.MinValue}", macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal($"{DateTime.MinValue}", macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = InvalidDirectoryName;
-        Assert.Equal ($"{DateTime.MinValue}", macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal($"{DateTime.MinValue}", macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = NullName!; // Intentional null input exercises macro fallback.
-        Assert.Equal ($"{DateTime.MinValue}", macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal($"{DateTime.MinValue}", macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = EmptyName;
-        Assert.Equal ($"{DateTime.MinValue}", macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal($"{DateTime.MinValue}", macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
     }
 
 
     [Fact]
-    public void DateCreated ()
+    public void DateCreated()
     {
-        SheetViewModel svm = SetupSVM ();
-        var macros = new Macros (svm);
+        SheetViewModel svm = SetupSVM();
+        var macros = new Macros(svm);
 
         svm.File = ExistingFile;
-        Assert.Equal ($"{File.GetCreationTime (svm.File)}",
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal($"{File.GetCreationTime(svm.File)}",
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = ExistingFileNoExtension;
-        Assert.Equal ($"{File.GetCreationTime (svm.File)}",
-            macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal($"{File.GetCreationTime(svm.File)}",
+            macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = NonExistingFile;
-        File.Delete (svm.File);
-        Assert.Equal ($"{DateTime.MinValue}", macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        File.Delete(svm.File);
+        Assert.Equal($"{DateTime.MinValue}", macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = NonExistingFileNoExtension;
-        File.Delete (svm.File);
-        Assert.Equal ($"{DateTime.MinValue}", macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        File.Delete(svm.File);
+        Assert.Equal($"{DateTime.MinValue}", macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = InvalidFileName;
-        Assert.Equal ($"{DateTime.MinValue}", macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal($"{DateTime.MinValue}", macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = InvalidDirectoryName;
-        Assert.Equal ($"{DateTime.MinValue}", macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal($"{DateTime.MinValue}", macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = NullName!; // Intentional null input exercises macro fallback.
-        Assert.Equal ($"{DateTime.MinValue}", macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal($"{DateTime.MinValue}", macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         svm.File = EmptyName;
-        Assert.Equal ($"{DateTime.MinValue}", macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal($"{DateTime.MinValue}", macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
     }
 
     [Fact]
-    public void CteName ()
+    public void CteName()
     {
         // https://stackoverflow.com/questions/22598323/movenext-instead-of-actual-method-task-name
         string macroName = "CteName";
 
-        var svm = new SheetViewModel ();
-        var macros = new Macros (svm);
+        var svm = new SheetViewModel();
+        var macros = new Macros(svm);
 
         // TODO: Mock this out
-        ServiceLocator.Current.SettingsService.SettingsFileName = $"WinPrint.{GetType ().Name}.json";
-        File.Delete (ServiceLocator.Current.SettingsService.SettingsFileName);
+        ServiceLocator.Current.SettingsService.SettingsFileName = $"WinPrint.{GetType().Name}.json";
+        File.Delete(ServiceLocator.Current.SettingsService.SettingsFileName);
 
-        Settings? settings = ServiceLocator.Current.SettingsService.ReadSettings ();
-        ModelLocator.Current.Settings.CopyPropertiesFrom (settings);
+        Settings? settings = ServiceLocator.Current.SettingsService.ReadSettings();
+        ModelLocator.Current.Settings.CopyPropertiesFrom(settings);
 
-        foreach (ContentTypeEngineBase cte in ContentTypeEngineBase.GetDerivedClassesCollection ())
+        foreach (ContentTypeEngineBase cte in ContentTypeEngineBase.GetDerivedClassesCollection())
         {
             (svm.ContentEngine, svm.ContentType, svm.Language) =
-                ContentTypeEngineBase.CreateContentTypeEngine (cte.GetType ().Name);
-            Assert.Equal (svm.ContentEngine!.GetType ().Name, macros.ReplaceMacros ($"{{{macroName}}}"));
+                ContentTypeEngineBase.CreateContentTypeEngine(cte.GetType().Name);
+            Assert.Equal(svm.ContentEngine!.GetType().Name, macros.ReplaceMacros($"{{{macroName}}}"));
         }
     }
 
     [Fact]
-    public void Language ()
+    public void Language()
     {
         // https://stackoverflow.com/questions/22598323/movenext-instead-of-actual-method-task-name
         string macroName = "Language";
 
-        var svm = new SheetViewModel ();
-        var macros = new Macros (svm);
+        var svm = new SheetViewModel();
+        var macros = new Macros(svm);
 
         // TODO: Mock out
-        ServiceLocator.Current.SettingsService.SettingsFileName = $"WinPrint.{GetType ().Name}.json";
-        File.Delete (ServiceLocator.Current.SettingsService.SettingsFileName);
+        ServiceLocator.Current.SettingsService.SettingsFileName = $"WinPrint.{GetType().Name}.json";
+        File.Delete(ServiceLocator.Current.SettingsService.SettingsFileName);
 
-        Settings? settings = ServiceLocator.Current.SettingsService.ReadSettings ();
-        ModelLocator.Current.Settings.CopyPropertiesFrom (settings);
+        Settings? settings = ServiceLocator.Current.SettingsService.ReadSettings();
+        ModelLocator.Current.Settings.CopyPropertiesFrom(settings);
         string input;
         string expectedLang;
         string contentType;
 
         input = "text/plain";
-        (svm.ContentEngine, svm.ContentType, svm.Language) = ContentTypeEngineBase.CreateContentTypeEngine (input);
-        Assert.Equal ("Plain Text", macros.ReplaceMacros ($"{{{macroName}}}"));
+        (svm.ContentEngine, svm.ContentType, svm.Language) = ContentTypeEngineBase.CreateContentTypeEngine(input);
+        Assert.Equal("Plain Text", macros.ReplaceMacros($"{{{macroName}}}"));
 
         input = "text/html";
-        (svm.ContentEngine, svm.ContentType, svm.Language) = ContentTypeEngineBase.CreateContentTypeEngine (input);
-        Assert.Equal ("HTML", macros.ReplaceMacros ($"{{{macroName}}}"));
+        (svm.ContentEngine, svm.ContentType, svm.Language) = ContentTypeEngineBase.CreateContentTypeEngine(input);
+        Assert.Equal("HTML", macros.ReplaceMacros($"{{{macroName}}}"));
 
         input = "text/ansi";
         expectedLang = "ANSI Text";
-        (svm.ContentEngine, svm.ContentType, svm.Language) = ContentTypeEngineBase.CreateContentTypeEngine (input);
-        Assert.Equal (expectedLang, macros.ReplaceMacros ($"{{{macroName}}}"));
+        (svm.ContentEngine, svm.ContentType, svm.Language) = ContentTypeEngineBase.CreateContentTypeEngine(input);
+        Assert.Equal(expectedLang, macros.ReplaceMacros($"{{{macroName}}}"));
 
         contentType = "text";
         expectedLang = "Plain Text";
         (svm.ContentEngine, svm.ContentType, svm.Language) =
-            ContentTypeEngineBase.CreateContentTypeEngine (contentType);
-        Assert.Equal (expectedLang, macros.ReplaceMacros ($"{{{macroName}}}"));
+            ContentTypeEngineBase.CreateContentTypeEngine(contentType);
+        Assert.Equal(expectedLang, macros.ReplaceMacros($"{{{macroName}}}"));
 
         contentType = "TEXT";
         expectedLang = "Plain Text";
         (svm.ContentEngine, svm.ContentType, svm.Language) =
-            ContentTypeEngineBase.CreateContentTypeEngine (contentType);
-        Assert.Equal (expectedLang, macros.ReplaceMacros ($"{{{macroName}}}"));
+            ContentTypeEngineBase.CreateContentTypeEngine(contentType);
+        Assert.Equal(expectedLang, macros.ReplaceMacros($"{{{macroName}}}"));
 
         contentType = "*.ans";
         expectedLang = "ANSI Text";
         (svm.ContentEngine, svm.ContentType, svm.Language) =
-            ContentTypeEngineBase.CreateContentTypeEngine (contentType);
-        Assert.Equal (expectedLang, macros.ReplaceMacros ($"{{{macroName}}}"));
+            ContentTypeEngineBase.CreateContentTypeEngine(contentType);
+        Assert.Equal(expectedLang, macros.ReplaceMacros($"{{{macroName}}}"));
 
         contentType = "*.cs";
         expectedLang = "C#";
         (svm.ContentEngine, svm.ContentType, svm.Language) =
-            ContentTypeEngineBase.CreateContentTypeEngine (contentType);
-        Assert.Equal (expectedLang, macros.ReplaceMacros ($"{{{macroName}}}"));
+            ContentTypeEngineBase.CreateContentTypeEngine(contentType);
+        Assert.Equal(expectedLang, macros.ReplaceMacros($"{{{macroName}}}"));
 
         contentType = "*.CS";
         expectedLang = "C#";
         (svm.ContentEngine, svm.ContentType, svm.Language) =
-            ContentTypeEngineBase.CreateContentTypeEngine (contentType);
-        Assert.Equal (expectedLang, macros.ReplaceMacros ($"{{{macroName}}}"));
+            ContentTypeEngineBase.CreateContentTypeEngine(contentType);
+        Assert.Equal(expectedLang, macros.ReplaceMacros($"{{{macroName}}}"));
 
         contentType = "csharp";
         expectedLang = "C#";
         (svm.ContentEngine, svm.ContentType, svm.Language) =
-            ContentTypeEngineBase.CreateContentTypeEngine (contentType);
-        Assert.Equal (expectedLang, macros.ReplaceMacros ($"{{{macroName}}}"));
+            ContentTypeEngineBase.CreateContentTypeEngine(contentType);
+        Assert.Equal(expectedLang, macros.ReplaceMacros($"{{{macroName}}}"));
 
         contentType = "cSharp";
         expectedLang = "C#";
         (svm.ContentEngine, svm.ContentType, svm.Language) =
-            ContentTypeEngineBase.CreateContentTypeEngine (contentType);
-        Assert.Equal (expectedLang, macros.ReplaceMacros ($"{{{macroName}}}"));
+            ContentTypeEngineBase.CreateContentTypeEngine(contentType);
+        Assert.Equal(expectedLang, macros.ReplaceMacros($"{{{macroName}}}"));
 
         contentType = "C#";
         expectedLang = "C#";
         (svm.ContentEngine, svm.ContentType, svm.Language) =
-            ContentTypeEngineBase.CreateContentTypeEngine (contentType);
-        Assert.Equal (expectedLang, macros.ReplaceMacros ($"{{{macroName}}}"));
+            ContentTypeEngineBase.CreateContentTypeEngine(contentType);
+        Assert.Equal(expectedLang, macros.ReplaceMacros($"{{{macroName}}}"));
 
         contentType = "c#";
         expectedLang = "C#";
         (svm.ContentEngine, svm.ContentType, svm.Language) =
-            ContentTypeEngineBase.CreateContentTypeEngine (contentType);
-        Assert.Equal (expectedLang, macros.ReplaceMacros ($"{{{macroName}}}"));
+            ContentTypeEngineBase.CreateContentTypeEngine(contentType);
+        Assert.Equal(expectedLang, macros.ReplaceMacros($"{{{macroName}}}"));
 
         contentType = "text/x-csharp";
         expectedLang = "C#";
         (svm.ContentEngine, svm.ContentType, svm.Language) =
-            ContentTypeEngineBase.CreateContentTypeEngine (contentType);
-        Assert.Equal (expectedLang, macros.ReplaceMacros ($"{{{macroName}}}"));
+            ContentTypeEngineBase.CreateContentTypeEngine(contentType);
+        Assert.Equal(expectedLang, macros.ReplaceMacros($"{{{macroName}}}"));
 
         contentType = "text/x-smalltalk";
         expectedLang = "Smalltalk";
         (svm.ContentEngine, svm.ContentType, svm.Language) =
-            ContentTypeEngineBase.CreateContentTypeEngine (contentType);
-        Assert.Equal (expectedLang, macros.ReplaceMacros ($"{{{macroName}}}"));
+            ContentTypeEngineBase.CreateContentTypeEngine(contentType);
+        Assert.Equal(expectedLang, macros.ReplaceMacros($"{{{macroName}}}"));
     }
 
 
     [Fact]
-    public void ContentType ()
+    public void ContentType()
     {
         // https://stackoverflow.com/questions/22598323/movenext-instead-of-actual-method-task-name
         string macroName = "ContentType";
 
-        var svm = new SheetViewModel ();
-        var macros = new Macros (svm);
+        var svm = new SheetViewModel();
+        var macros = new Macros(svm);
 
         // TODO: Mock out
-        ServiceLocator.Current.SettingsService.SettingsFileName = $"WinPrint.{GetType ().Name}.json";
-        File.Delete (ServiceLocator.Current.SettingsService.SettingsFileName);
+        ServiceLocator.Current.SettingsService.SettingsFileName = $"WinPrint.{GetType().Name}.json";
+        File.Delete(ServiceLocator.Current.SettingsService.SettingsFileName);
 
-        Settings? settings = ServiceLocator.Current.SettingsService.ReadSettings ();
-        ModelLocator.Current.Settings.CopyPropertiesFrom (settings);
+        Settings? settings = ServiceLocator.Current.SettingsService.ReadSettings();
+        ModelLocator.Current.Settings.CopyPropertiesFrom(settings);
 
         string input = "text/plain";
-        (svm.ContentEngine, svm.ContentType, svm.Language) = ContentTypeEngineBase.CreateContentTypeEngine (input);
-        Assert.Equal (input, svm.ContentType);
-        Assert.Equal (input, macros.ReplaceMacros ($"{{{macroName}}}"));
+        (svm.ContentEngine, svm.ContentType, svm.Language) = ContentTypeEngineBase.CreateContentTypeEngine(input);
+        Assert.Equal(input, svm.ContentType);
+        Assert.Equal(input, macros.ReplaceMacros($"{{{macroName}}}"));
 
         input = "text/plain";
-        (svm.ContentEngine, svm.ContentType, svm.Language) = ContentTypeEngineBase.CreateContentTypeEngine (input);
-        Assert.Equal (input, svm.ContentType);
-        Assert.Equal (input, macros.ReplaceMacros ($"{{{macroName}}}"));
+        (svm.ContentEngine, svm.ContentType, svm.Language) = ContentTypeEngineBase.CreateContentTypeEngine(input);
+        Assert.Equal(input, svm.ContentType);
+        Assert.Equal(input, macros.ReplaceMacros($"{{{macroName}}}"));
 
         input = "text/ansi";
-        (svm.ContentEngine, svm.ContentType, svm.Language) = ContentTypeEngineBase.CreateContentTypeEngine (input);
-        Assert.Equal (input, svm.ContentType);
-        Assert.Equal (input, macros.ReplaceMacros ($"{{{macroName}}}"));
+        (svm.ContentEngine, svm.ContentType, svm.Language) = ContentTypeEngineBase.CreateContentTypeEngine(input);
+        Assert.Equal(input, svm.ContentType);
+        Assert.Equal(input, macros.ReplaceMacros($"{{{macroName}}}"));
 
         input = "text/html";
-        (svm.ContentEngine, svm.ContentType, svm.Language) = ContentTypeEngineBase.CreateContentTypeEngine (input);
-        Assert.Equal (input, svm.ContentType);
-        Assert.Equal (input, macros.ReplaceMacros ($"{{{macroName}}}"));
+        (svm.ContentEngine, svm.ContentType, svm.Language) = ContentTypeEngineBase.CreateContentTypeEngine(input);
+        Assert.Equal(input, svm.ContentType);
+        Assert.Equal(input, macros.ReplaceMacros($"{{{macroName}}}"));
 
         string contentType = "text";
         string expectedCT = "text/plain";
         (svm.ContentEngine, svm.ContentType, svm.Language) =
-            ContentTypeEngineBase.CreateContentTypeEngine (contentType);
-        Assert.Equal (expectedCT, svm.ContentType);
-        Assert.Equal (expectedCT, macros.ReplaceMacros ($"{{{macroName}}}"));
+            ContentTypeEngineBase.CreateContentTypeEngine(contentType);
+        Assert.Equal(expectedCT, svm.ContentType);
+        Assert.Equal(expectedCT, macros.ReplaceMacros($"{{{macroName}}}"));
 
         contentType = "text/plain";
         expectedCT = contentType;
         (svm.ContentEngine, svm.ContentType, svm.Language) =
-            ContentTypeEngineBase.CreateContentTypeEngine (contentType);
-        Assert.Equal (expectedCT, svm.ContentType);
-        Assert.Equal (expectedCT, macros.ReplaceMacros ($"{{{macroName}}}"));
+            ContentTypeEngineBase.CreateContentTypeEngine(contentType);
+        Assert.Equal(expectedCT, svm.ContentType);
+        Assert.Equal(expectedCT, macros.ReplaceMacros($"{{{macroName}}}"));
 
         contentType = "text/html";
         expectedCT = contentType;
         (svm.ContentEngine, svm.ContentType, svm.Language) =
-            ContentTypeEngineBase.CreateContentTypeEngine (contentType);
-        Assert.Equal (expectedCT, svm.ContentType);
-        Assert.Equal (expectedCT, macros.ReplaceMacros ($"{{{macroName}}}"));
+            ContentTypeEngineBase.CreateContentTypeEngine(contentType);
+        Assert.Equal(expectedCT, svm.ContentType);
+        Assert.Equal(expectedCT, macros.ReplaceMacros($"{{{macroName}}}"));
 
         contentType = "text/ansi";
         expectedCT = contentType;
         (svm.ContentEngine, svm.ContentType, svm.Language) =
-            ContentTypeEngineBase.CreateContentTypeEngine (contentType);
-        Assert.Equal (expectedCT, svm.ContentType);
-        Assert.Equal (expectedCT, macros.ReplaceMacros ($"{{{macroName}}}"));
+            ContentTypeEngineBase.CreateContentTypeEngine(contentType);
+        Assert.Equal(expectedCT, svm.ContentType);
+        Assert.Equal(expectedCT, macros.ReplaceMacros($"{{{macroName}}}"));
 
         contentType = "*.ans";
         expectedCT = "text/ansi";
         (svm.ContentEngine, svm.ContentType, svm.Language) =
-            ContentTypeEngineBase.CreateContentTypeEngine (contentType);
-        Assert.Equal (expectedCT, svm.ContentType);
-        Assert.Equal (expectedCT, macros.ReplaceMacros ($"{{{macroName}}}"));
+            ContentTypeEngineBase.CreateContentTypeEngine(contentType);
+        Assert.Equal(expectedCT, svm.ContentType);
+        Assert.Equal(expectedCT, macros.ReplaceMacros($"{{{macroName}}}"));
 
         contentType = "*.cs";
         expectedCT = "text/x-csharp";
         (svm.ContentEngine, svm.ContentType, svm.Language) =
-            ContentTypeEngineBase.CreateContentTypeEngine (contentType);
-        Assert.Equal (expectedCT, svm.ContentType);
-        Assert.Equal (expectedCT, macros.ReplaceMacros ($"{{{macroName}}}"));
+            ContentTypeEngineBase.CreateContentTypeEngine(contentType);
+        Assert.Equal(expectedCT, svm.ContentType);
+        Assert.Equal(expectedCT, macros.ReplaceMacros($"{{{macroName}}}"));
 
         contentType = "csharp";
         expectedCT = "text/x-csharp";
         (svm.ContentEngine, svm.ContentType, svm.Language) =
-            ContentTypeEngineBase.CreateContentTypeEngine (contentType);
-        Assert.Equal (expectedCT, svm.ContentType);
-        Assert.Equal (expectedCT, macros.ReplaceMacros ($"{{{macroName}}}"));
+            ContentTypeEngineBase.CreateContentTypeEngine(contentType);
+        Assert.Equal(expectedCT, svm.ContentType);
+        Assert.Equal(expectedCT, macros.ReplaceMacros($"{{{macroName}}}"));
     }
 
     [Fact]
-    public void NumPages ()
+    public void NumPages()
     {
-        SheetViewModel svm = SetupSVM ();
-        var macros = new Macros (svm);
+        SheetViewModel svm = SetupSVM();
+        var macros = new Macros(svm);
 
-        Assert.Equal ($"{0}", macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal($"{0}", macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         // Hex
-        Assert.Equal ($"{0:X8}", macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}:X8}}"));
+        Assert.Equal($"{0:X8}", macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}:X8}}"));
     }
 
 
     [Fact]
-    public void Page ()
+    public void Page()
     {
-        SheetViewModel svm = SetupSVM ();
-        var macros = new Macros (svm);
+        SheetViewModel svm = SetupSVM();
+        var macros = new Macros(svm);
 
-        Assert.Equal ($"{0}", macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}}}"));
+        Assert.Equal($"{0}", macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}}}"));
 
         // Hex
-        Assert.Equal ($"{0:X8}", macros.ReplaceMacros ($"{{{MethodBase.GetCurrentMethod ()!.Name}:X8}}"));
+        Assert.Equal($"{0:X8}", macros.ReplaceMacros($"{{{MethodBase.GetCurrentMethod()!.Name}:X8}}"));
     }
 }

--- a/tests/WinPrint.Core.UnitTests/Models/PrintMarginsRegressionTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Models/PrintMarginsRegressionTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Drawing.Printing;
+using System.Drawing.Printing;
 using System.Linq;
 using WinPrint.Core;
 using WinPrint.Core.Abstractions;
@@ -10,59 +10,59 @@ namespace WinPrint.Core.UnitTests.Models;
 public class PrintMarginsRegressionTests
 {
     [Fact]
-    public void PrintMargins_CannotBeCastToSystemDrawingMargins ()
+    public void PrintMargins_CannotBeCastToSystemDrawingMargins()
     {
         // Arrange - simulate what happens during file open
-        var settings = Settings.CreateDefaultSettings ();
-        ModelLocator.Current.Settings.CopyPropertiesFrom (settings);
+        var settings = Settings.CreateDefaultSettings();
+        ModelLocator.Current.Settings.CopyPropertiesFrom(settings);
 
-        var svm = new SheetViewModel ();
-        var sheetSettings = settings.Sheets.Values.First ();
-        svm.SetSheet (sheetSettings);
+        var svm = new SheetViewModel();
+        SheetSettings sheetSettings = settings.Sheets.Values.First();
+        svm.SetSheet(sheetSettings);
 
         // Act - this is the old code that was crashing
-        object clone = svm.Margins.Clone ();
+        object clone = svm.Margins.Clone();
 
         // Assert - verify the cast FAILS (proving the bug exists without the fix)
-        Assert.IsType<PrintMargins> (clone);
-        Assert.False (clone is Margins, "PrintMargins should NOT be castable to System.Drawing.Printing.Margins");
+        Assert.IsType<PrintMargins>(clone);
+        Assert.False(clone is Margins, "PrintMargins should NOT be castable to System.Drawing.Printing.Margins");
     }
 
     [Fact]
-    public void PrintMargins_ConversionToSystemDrawingMargins_Works ()
+    public void PrintMargins_ConversionToSystemDrawingMargins_Works()
     {
         // Arrange
-        var pm = new PrintMargins (50, 50, 30, 30);
+        var pm = new PrintMargins(50, 50, 30, 30);
 
         // Act - the correct way to convert
-        var m = new Margins (pm.Left, pm.Right, pm.Top, pm.Bottom);
+        var m = new Margins(pm.Left, pm.Right, pm.Top, pm.Bottom);
 
         // Assert
-        Assert.Equal (50, m.Left);
-        Assert.Equal (50, m.Right);
-        Assert.Equal (30, m.Top);
-        Assert.Equal (30, m.Bottom);
+        Assert.Equal(50, m.Left);
+        Assert.Equal(50, m.Right);
+        Assert.Equal(30, m.Top);
+        Assert.Equal(30, m.Bottom);
     }
 
     [Fact]
-    public void SheetViewModel_SetSheet_MarginsArePrintMargins ()
+    public void SheetViewModel_SetSheet_MarginsArePrintMargins()
     {
         // Arrange
-        var settings = Settings.CreateDefaultSettings ();
-        ModelLocator.Current.Settings.CopyPropertiesFrom (settings);
-        var svm = new SheetViewModel ();
-        var sheetSettings = settings.Sheets.Values.First ();
+        var settings = Settings.CreateDefaultSettings();
+        ModelLocator.Current.Settings.CopyPropertiesFrom(settings);
+        var svm = new SheetViewModel();
+        SheetSettings sheetSettings = settings.Sheets.Values.First();
 
         // Act
-        svm.SetSheet (sheetSettings);
+        svm.SetSheet(sheetSettings);
 
         // Assert - Margins should be PrintMargins, not System.Drawing.Printing.Margins
-        Assert.IsType<PrintMargins> (svm.Margins);
-        Assert.Equal (sheetSettings.Margins.Left, svm.Margins.Left);
+        Assert.IsType<PrintMargins>(svm.Margins);
+        Assert.Equal(sheetSettings.Margins.Left, svm.Margins.Left);
     }
 
     [Fact]
-    public void FullFileOpenFlow_NoInvalidCastException ()
+    public void FullFileOpenFlow_NoInvalidCastException()
     {
         // This test simulates the full WinForms file-open flow:
         // 1. Settings loaded, SetSheet called
@@ -71,33 +71,33 @@ public class PrintMarginsRegressionTests
         // 4. ReflowAsync called
         // 5. PropertyChanged fires for Margins - handler converts to System.Drawing.Printing.Margins
 
-        var settings = Settings.CreateDefaultSettings ();
-        ModelLocator.Current.Settings.CopyPropertiesFrom (settings);
+        var settings = Settings.CreateDefaultSettings();
+        ModelLocator.Current.Settings.CopyPropertiesFrom(settings);
 
-        var svm = new SheetViewModel ();
-        var sheetSettings = settings.Sheets.Values.First ();
-        svm.SetSheet (sheetSettings);
+        var svm = new SheetViewModel();
+        SheetSettings sheetSettings = settings.Sheets.Values.First();
+        svm.SetSheet(sheetSettings);
 
         // Simulate the PropertyChanged handler converting margins
         // This is what MainWindow does when "Margins" property changes
-        var printMargins = svm.Margins;
-        Assert.NotNull (printMargins);
+        PrintMargins printMargins = svm.Margins;
+        Assert.NotNull(printMargins);
 
         // The FIX: construct new Margins instead of casting
-        var sdpMargins = new Margins (printMargins.Left, printMargins.Right, printMargins.Top, printMargins.Bottom);
-        Assert.Equal (printMargins.Left, sdpMargins.Left);
-        Assert.Equal (printMargins.Right, sdpMargins.Right);
-        Assert.Equal (printMargins.Top, sdpMargins.Top);
-        Assert.Equal (printMargins.Bottom, sdpMargins.Bottom);
+        var sdpMargins = new Margins(printMargins.Left, printMargins.Right, printMargins.Top, printMargins.Bottom);
+        Assert.Equal(printMargins.Left, sdpMargins.Left);
+        Assert.Equal(printMargins.Right, sdpMargins.Right);
+        Assert.Equal(printMargins.Top, sdpMargins.Top);
+        Assert.Equal(printMargins.Bottom, sdpMargins.Bottom);
 
         // Now simulate SetPrinterPageSettings with a real PrintDocument
-        using var printDoc = new PrintDocument ();
+        using var printDoc = new PrintDocument();
         printDoc.DefaultPageSettings.Landscape = svm.Landscape;
 
         // This should NOT throw
-        svm.SetPrinterPageSettings (printDoc.DefaultPageSettings);
+        svm.SetPrinterPageSettings(printDoc.DefaultPageSettings);
 
         // Verify margins are still PrintMargins after page settings are set
-        Assert.IsType<PrintMargins> (svm.Margins);
+        Assert.IsType<PrintMargins>(svm.Margins);
     }
 }

--- a/tests/WinPrint.Core.UnitTests/Models/SheetSettingsTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Models/SheetSettingsTests.cs
@@ -8,15 +8,15 @@ namespace WinPrint.Core.UnitTests.Models;
 
 public class SheetSettingsTests : TestModelsBase
 {
-    public SheetSettingsTests (ITestOutputHelper output) : base (output)
+    public SheetSettingsTests(ITestOutputHelper output) : base(output)
     {
     }
 
     [Fact]
-    public void TestNew ()
+    public void TestNew()
     {
-        var doc = new SheetSettings ();
-        Assert.NotNull (doc);
+        var doc = new SheetSettings();
+        Assert.NotNull(doc);
 
         //Assert.AreEqual("sansserif", doc.DiagnosticRulesFont.Family);
 
@@ -25,70 +25,70 @@ public class SheetSettingsTests : TestModelsBase
     }
 
     [Fact]
-    public void TestPersist ()
+    public void TestPersist()
     {
-        var doc = new SheetSettings ();
+        var doc = new SheetSettings();
 
-        string json = JsonSerializer.Serialize (doc, jsonOptions);
-        Assert.NotNull (json);
+        string json = JsonSerializer.Serialize(doc, jsonOptions);
+        Assert.NotNull(json);
 
-        Assert.True (json.Length > 0);
+        Assert.True(json.Length > 0);
 
-        SheetSettings? doc2 = JsonSerializer.Deserialize<SheetSettings> (json);
-        Assert.NotNull (doc2);
+        SheetSettings? doc2 = JsonSerializer.Deserialize<SheetSettings>(json);
+        Assert.NotNull(doc2);
     }
 
     [Fact]
-    public void TestSerializeToFile ()
+    public void TestSerializeToFile()
     {
-        var doc = new SheetSettings ();
+        var doc = new SheetSettings();
 
         // Use the name of the test file as the Document.File property
         string file = "WinPrint.Test.New.json";
-        Assert.Equal ("WinPrint.Test.New.json", file);
+        Assert.Equal("WinPrint.Test.New.json", file);
 
-        string jsonString = JsonSerializer.Serialize (doc, jsonOptions);
+        string jsonString = JsonSerializer.Serialize(doc, jsonOptions);
         ;
 
         var writerOptions = new JsonWriterOptions { Indented = true };
         var documentOptions = new JsonDocumentOptions { CommentHandling = JsonCommentHandling.Skip };
 
         // Use the name of the test file as the Document.File property
-        using (FileStream fs = File.Create (file))
+        using (FileStream fs = File.Create(file))
 
-        using (var writer = new Utf8JsonWriter (fs, writerOptions))
-        using (var document = JsonDocument.Parse (jsonString, documentOptions))
+        using (var writer = new Utf8JsonWriter(fs, writerOptions))
+        using (var document = JsonDocument.Parse(jsonString, documentOptions))
         {
             JsonElement root = document.RootElement;
 
             if (root.ValueKind == JsonValueKind.Object)
             {
-                writer.WriteStartObject ();
+                writer.WriteStartObject();
             }
             else
             {
                 return;
             }
 
-            foreach (JsonProperty property in root.EnumerateObject ())
+            foreach (JsonProperty property in root.EnumerateObject())
             {
-                property.WriteTo (writer);
+                property.WriteTo(writer);
             }
 
-            writer.WriteEndObject ();
+            writer.WriteEndObject();
 
-            writer.Flush ();
+            writer.Flush();
         }
 
-        SheetSettings docCopy = DeserializeFromFile (file);
-        string jsonCopy = JsonSerializer.Serialize (docCopy, jsonOptions);
-        Assert.NotNull (jsonCopy);
+        SheetSettings docCopy = DeserializeFromFile(file);
+        string jsonCopy = JsonSerializer.Serialize(docCopy, jsonOptions);
+        Assert.NotNull(jsonCopy);
 
-        Assert.Equal (jsonCopy, jsonString);
+        Assert.Equal(jsonCopy, jsonString);
     }
 
     [Fact]
-    public void TestDeserializeDefaults ()
+    public void TestDeserializeDefaults()
     {
         //tring file = "TestFiles\\WinPrint.Test.json";
         // Test with a default file
@@ -97,7 +97,7 @@ public class SheetSettingsTests : TestModelsBase
     }
 
     [Fact]
-    public void TestDeserializeAllPropertiesSet ()
+    public void TestDeserializeAllPropertiesSet()
     {
         //string file = "TestFiles\\WinPrint.EveryPropertySet.json";
         // Test with a file with all properties cahnged
@@ -105,13 +105,13 @@ public class SheetSettingsTests : TestModelsBase
         //Assert.AreEqual("Test.txt", doc., $"File property of {file} should have been {file}");
     }
 
-    public SheetSettings DeserializeFromFile (string file)
+    public SheetSettings DeserializeFromFile(string file)
     {
-        string jsonString = File.ReadAllText (file);
-        Assert.NotNull (jsonString);
+        string jsonString = File.ReadAllText(file);
+        Assert.NotNull(jsonString);
 
-        return JsonSerializer.Deserialize<SheetSettings> (jsonString, jsonOptions) ??
-               throw new JsonException ("SheetSettings deserialized to null.");
+        return JsonSerializer.Deserialize<SheetSettings>(jsonString, jsonOptions) ??
+               throw new JsonException("SheetSettings deserialized to null.");
     }
 
     //public void TestHeaderFooter(Core.Models.SheetSettings doc) {

--- a/tests/WinPrint.Core.UnitTests/Models/TestModelsBase.cs
+++ b/tests/WinPrint.Core.UnitTests/Models/TestModelsBase.cs
@@ -11,10 +11,10 @@ public class TestModelsBase
 {
     public JsonSerializerOptions jsonOptions;
 
-    public TestModelsBase (ITestOutputHelper output)
+    public TestModelsBase(ITestOutputHelper output)
     {
-        ServiceLocator.Current.LogService.Start (GetType ().Name,
-            new TestOutputSink (output, new MessageTemplateTextFormatter ("{Message:lj}")), true, true);
+        ServiceLocator.Current.LogService.Start(GetType().Name,
+            new TestOutputSink(output, new MessageTemplateTextFormatter("{Message:lj}")), true, true);
 
         jsonOptions = new JsonSerializerOptions
         {
@@ -24,6 +24,6 @@ public class TestModelsBase
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             ReadCommentHandling = JsonCommentHandling.Skip
         };
-        jsonOptions.Converters.Add (new JsonStringEnumConverter (JsonNamingPolicy.CamelCase));
+        jsonOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
     }
 }

--- a/tests/WinPrint.Core.UnitTests/Services/FileTypeMappingServiceTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Services/FileTypeMappingServiceTests.cs
@@ -11,118 +11,118 @@ namespace WinPrint.Core.UnitTests.Services;
 
 public class FileTypeMappingServiceTests : TestServicesBase
 {
-    public FileTypeMappingServiceTests (ITestOutputHelper output) : base (output)
+    public FileTypeMappingServiceTests(ITestOutputHelper output) : base(output)
     {
     }
 
     [Fact]
-    public void TestDefaultConfigFiletypeMappkng ()
+    public void TestDefaultConfigFiletypeMappkng()
     {
-        ServiceLocator.Current.SettingsService.SettingsFileName = $"WinPrint.{GetType ().Name}.json";
-        File.Delete (ServiceLocator.Current.SettingsService.SettingsFileName);
+        ServiceLocator.Current.SettingsService.SettingsFileName = $"WinPrint.{GetType().Name}.json";
+        File.Delete(ServiceLocator.Current.SettingsService.SettingsFileName);
 
-        Settings? settings = ServiceLocator.Current.SettingsService.ReadSettings ();
-        ModelLocator.Current.Settings.CopyPropertiesFrom (settings);
+        Settings? settings = ServiceLocator.Current.SettingsService.ReadSettings();
+        ModelLocator.Current.Settings.CopyPropertiesFrom(settings);
 
         // There are three assocations defined in default .config
         // settings.LanguageAssociations = new FileAssociations() 
         // ...
 
         Dictionary<string, string> files = ModelLocator.Current.Settings.FileTypeMapping.FilesAssociations;
-        Assert.NotNull (files);
-        Assert.Equal (4, files.Count);
+        Assert.NotNull(files);
+        Assert.Equal(4, files.Count);
 
 
         //{ "*.config", "application/json" },
         //{ "*.htm", "text/html" },
         //{ "*.html", "text/html" }
-        Assert.Equal ("application/json", files.First (l => l.Key == "*.config").Value);
-        Assert.Equal ("text/html", files.First (l => l.Key == "*.htm").Value);
-        Assert.Equal ("text/html", files.First (l => l.Key == "*.html").Value);
-        Assert.Equal ("text/unicon", files.First (l => l.Key == "*.icon").Value);
+        Assert.Equal("application/json", files.First(l => l.Key == "*.config").Value);
+        Assert.Equal("text/html", files.First(l => l.Key == "*.htm").Value);
+        Assert.Equal("text/html", files.First(l => l.Key == "*.html").Value);
+        Assert.Equal("text/unicon", files.First(l => l.Key == "*.icon").Value);
     }
 
     [Fact]
-    public void TestDefaultConfigLanguages ()
+    public void TestDefaultConfigLanguages()
     {
-        ServiceLocator.Current.SettingsService.SettingsFileName = $"WinPrint.{GetType ().Name}.json";
-        File.Delete (ServiceLocator.Current.SettingsService.SettingsFileName);
+        ServiceLocator.Current.SettingsService.SettingsFileName = $"WinPrint.{GetType().Name}.json";
+        File.Delete(ServiceLocator.Current.SettingsService.SettingsFileName);
 
-        Settings? settings = ServiceLocator.Current.SettingsService.ReadSettings ();
-        ModelLocator.Current.Settings.CopyPropertiesFrom (settings);
+        Settings? settings = ServiceLocator.Current.SettingsService.ReadSettings();
+        ModelLocator.Current.Settings.CopyPropertiesFrom(settings);
 
         // We define these file types in default settings:
         // text/plain - because it is not defined by Pygments
         // text/ansi- because it is not defined by Pygments
         // icon - Icon is so esoteric it makes a good test
         FileTypeMapping ftm = ModelLocator.Current.Settings.FileTypeMapping;
-        Assert.NotNull (ftm);
+        Assert.NotNull(ftm);
         IList<ContentType> langs = ftm.ContentTypes;
-        Assert.NotNull (langs);
-        Assert.Equal (2, langs.Count);
+        Assert.NotNull(langs);
+        Assert.Equal(2, langs.Count);
 
         // Find Title by Id
-        Assert.Equal ("Plain Text", langs.First (l => l.Id == "text/plain").Title);
+        Assert.Equal("Plain Text", langs.First(l => l.Id == "text/plain").Title);
 
         // Find Title by Alias
-        Assert.Equal ("Plain Text", langs.First (l => l.Aliases.Contains ("text")).Title);
-        Assert.Equal ("ANSI Text", langs.First (l => l.Aliases.Contains ("ansi")).Title);
+        Assert.Equal("Plain Text", langs.First(l => l.Aliases.Contains("text")).Title);
+        Assert.Equal("ANSI Text", langs.First(l => l.Aliases.Contains("ansi")).Title);
 
         // Prove not found
-        Assert.DoesNotContain (langs, l => l.Id == "txt");
+        Assert.DoesNotContain(langs, l => l.Id == "txt");
 
         // Find Title by ext
-        Assert.Equal ("Plain Text", langs.First (l => l.Extensions.Contains ("*.txt")).Title);
+        Assert.Equal("Plain Text", langs.First(l => l.Extensions.Contains("*.txt")).Title);
 
         // Find Id by ext
-        Assert.Equal ("text/plain", langs.First (l => l.Extensions.Contains ("*.txt")).Id);
+        Assert.Equal("text/plain", langs.First(l => l.Extensions.Contains("*.txt")).Id);
     }
 
     [Fact]
-    public void TestLanguages ()
+    public void TestLanguages()
     {
-        ServiceLocator.Current.SettingsService.SettingsFileName = $"WinPrint.{GetType ().Name}.json";
-        File.Delete (ServiceLocator.Current.SettingsService.SettingsFileName);
+        ServiceLocator.Current.SettingsService.SettingsFileName = $"WinPrint.{GetType().Name}.json";
+        File.Delete(ServiceLocator.Current.SettingsService.SettingsFileName);
 
-        Settings? settings = ServiceLocator.Current.SettingsService.ReadSettings ();
-        ModelLocator.Current.Settings.CopyPropertiesFrom (settings);
+        Settings? settings = ServiceLocator.Current.SettingsService.ReadSettings();
+        ModelLocator.Current.Settings.CopyPropertiesFrom(settings);
 
-        FileTypeMapping ftm = ServiceLocator.Current.FileTypeMappingService.Load ();
-        Assert.NotNull (ftm);
+        FileTypeMapping ftm = ServiceLocator.Current.FileTypeMappingService.Load();
+        Assert.NotNull(ftm);
         IList<ContentType> langs = ftm.ContentTypes;
-        Assert.NotNull (langs);
-        Assert.True (langs.Count > 1);
+        Assert.NotNull(langs);
+        Assert.True(langs.Count > 1);
 
         // Find Title by Id
-        Assert.Equal ("Brainfuck", langs.First (l => l.Id == "application/x-brainfuck").Title);
+        Assert.Equal("Brainfuck", langs.First(l => l.Id == "application/x-brainfuck").Title);
 
         // Find Title by Alias
-        Assert.Equal ("Brainfuck", langs.First (l => l.Aliases.Contains ("brainfuck")).Title);
-        Assert.Equal ("Brainfuck", langs.First (l => l.Aliases.Contains ("bf")).Title);
+        Assert.Equal("Brainfuck", langs.First(l => l.Aliases.Contains("brainfuck")).Title);
+        Assert.Equal("Brainfuck", langs.First(l => l.Aliases.Contains("bf")).Title);
 
         // Find Title by ext
-        Assert.Equal ("Brainfuck", langs.First (l => l.Extensions.Contains ("*.bf")).Title);
+        Assert.Equal("Brainfuck", langs.First(l => l.Extensions.Contains("*.bf")).Title);
 
         // Find Id by ext
-        Assert.Equal ("application/x-brainfuck", langs.First (l => l.Extensions.Contains ("*.bf")).Id);
+        Assert.Equal("application/x-brainfuck", langs.First(l => l.Extensions.Contains("*.bf")).Id);
 
         // Test a merge of .config and .json
         // Find Title by Id
-        Assert.Equal ("JSON", langs.First (l => l.Id == "application/json").Title);
+        Assert.Equal("JSON", langs.First(l => l.Id == "application/json").Title);
 
         // Find Title by Alias
-        Assert.Equal ("JSON", langs.First (l => l.Aliases.Contains ("json")).Title);
+        Assert.Equal("JSON", langs.First(l => l.Aliases.Contains("json")).Title);
 
         // This should fail
-        Assert.Throws<InvalidOperationException> (() => langs.First (l => l.Aliases.Contains ("application/json")));
+        Assert.Throws<InvalidOperationException>(() => langs.First(l => l.Aliases.Contains("application/json")));
 
         // Find Title by ext
-        Assert.Equal ("JSON", langs.First (l => l.Extensions.Contains ("*.json")).Title);
+        Assert.Equal("JSON", langs.First(l => l.Extensions.Contains("*.json")).Title);
 
         // *.config was added via the settings file!
         //Assert.Equal("JSON", langs.First(l => l.Extensions.Contains("*.config")).Title);
 
         // Find Id by ext
-        Assert.Equal ("application/json", langs.First (l => l.Extensions.Contains ("*.json")).Id);
+        Assert.Equal("application/json", langs.First(l => l.Extensions.Contains("*.json")).Id);
     }
 }

--- a/tests/WinPrint.Core.UnitTests/Services/PygmentsConverterServiceTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Services/PygmentsConverterServiceTests.cs
@@ -10,27 +10,27 @@ namespace WinPrint.Core.UnitTests.Cte;
 
 public class PygmentsConverterServiceTests
 {
-    private static string CteClassName = typeof (TextCte).Name;
+    private static string CteClassName = typeof(TextCte).Name;
 
-    public PygmentsConverterServiceTests (ITestOutputHelper output)
+    public PygmentsConverterServiceTests(ITestOutputHelper output)
     {
-        ServiceLocator.Current.LogService.Start (GetType ().Name,
-            new TestOutputSink (output, new MessageTemplateTextFormatter ("{Message:lj}")), true, true);
+        ServiceLocator.Current.LogService.Start(GetType().Name,
+            new TestOutputSink(output, new MessageTemplateTextFormatter("{Message:lj}")), true, true);
     }
 
 #if CI_BUILD
 #else
     [Fact]
-    public async Task ConvertAsyncTest ()
+    public async Task ConvertAsyncTest()
     {
-        var ps = new PygmentsConverterService ();
+        var ps = new PygmentsConverterService();
         string input = @"using system;";
         // "using system;" | out-file using.cs
         // pygmentize -O 16m,style=friendly .\using.cs | out-file using.ans
         string expectedOutput =
             "\u001b[38;2;0;112;32;01musing\u001b[39;00m\u001b[38;2;187;187;187m \u001b[39m\u001b[38;2;14;132;181;01msystem\u001b[39;00m;";
-        string output = await ps.ConvertAsync (input, "friendly", "c#");
-        Assert.Equal (expectedOutput, output);
+        string output = await ps.ConvertAsync(input, "friendly", "c#");
+        Assert.Equal(expectedOutput, output);
     }
 #endif
 }

--- a/tests/WinPrint.Core.UnitTests/Services/SettingsPersistenceTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Services/SettingsPersistenceTests.cs
@@ -15,206 +15,206 @@ namespace WinPrint.Core.UnitTests.Services;
 /// </summary>
 public class SettingsPersistenceTests : TestServicesBase
 {
-    public SettingsPersistenceTests (ITestOutputHelper output) : base (output)
+    public SettingsPersistenceTests(ITestOutputHelper output) : base(output)
     {
     }
 
     [Fact]
-    public void WindowState_Normal_PersistsAndRestores ()
+    public void WindowState_Normal_PersistsAndRestores()
     {
-        var settings = Settings.CreateDefaultSettings ();
+        var settings = Settings.CreateDefaultSettings();
         settings.WindowState = FormWindowState.Normal;
-        settings.Size = new WindowSize (1024, 768);
-        settings.Location = new WindowLocation (100, 50);
+        settings.Size = new WindowSize(1024, 768);
+        settings.Location = new WindowLocation(100, 50);
 
-        Settings? restored = SaveAndReload (settings);
+        Settings? restored = SaveAndReload(settings);
 
-        Assert.NotNull (restored);
-        Assert.Equal (FormWindowState.Normal, restored.WindowState);
-        Assert.Equal (1024, restored.Size!.Width);
-        Assert.Equal (768, restored.Size.Height);
-        Assert.Equal (100, restored.Location!.X);
-        Assert.Equal (50, restored.Location.Y);
+        Assert.NotNull(restored);
+        Assert.Equal(FormWindowState.Normal, restored.WindowState);
+        Assert.Equal(1024, restored.Size!.Width);
+        Assert.Equal(768, restored.Size.Height);
+        Assert.Equal(100, restored.Location!.X);
+        Assert.Equal(50, restored.Location.Y);
     }
 
     [Fact]
-    public void WindowState_Maximized_PersistsAndRestores ()
+    public void WindowState_Maximized_PersistsAndRestores()
     {
-        var settings = Settings.CreateDefaultSettings ();
+        var settings = Settings.CreateDefaultSettings();
         settings.WindowState = FormWindowState.Maximized;
         // When maximized, persist the "restore bounds" (last normal size)
-        settings.Size = new WindowSize (800, 600);
-        settings.Location = new WindowLocation (200, 100);
+        settings.Size = new WindowSize(800, 600);
+        settings.Location = new WindowLocation(200, 100);
 
-        Settings? restored = SaveAndReload (settings);
+        Settings? restored = SaveAndReload(settings);
 
-        Assert.NotNull (restored);
-        Assert.Equal (FormWindowState.Maximized, restored.WindowState);
-        Assert.Equal (800, restored.Size!.Width);
-        Assert.Equal (600, restored.Size.Height);
-        Assert.Equal (200, restored.Location!.X);
-        Assert.Equal (100, restored.Location.Y);
+        Assert.NotNull(restored);
+        Assert.Equal(FormWindowState.Maximized, restored.WindowState);
+        Assert.Equal(800, restored.Size!.Width);
+        Assert.Equal(600, restored.Size.Height);
+        Assert.Equal(200, restored.Location!.X);
+        Assert.Equal(100, restored.Location.Y);
     }
 
     [Fact]
-    public void DefaultSheet_PersistsAndRestores ()
+    public void DefaultSheet_PersistsAndRestores()
     {
-        var settings = Settings.CreateDefaultSettings ();
-        var newDefault = Uuid.DefaultSheet1Up;
+        var settings = Settings.CreateDefaultSettings();
+        Guid newDefault = Uuid.DefaultSheet1Up;
         settings.DefaultSheet = newDefault;
 
-        Settings? restored = SaveAndReload (settings);
+        Settings? restored = SaveAndReload(settings);
 
-        Assert.NotNull (restored);
-        Assert.Equal (newDefault, restored.DefaultSheet);
+        Assert.NotNull(restored);
+        Assert.Equal(newDefault, restored.DefaultSheet);
     }
 
     [Fact]
-    public void SheetLandscape_PersistsAndRestores ()
+    public void SheetLandscape_PersistsAndRestores()
     {
-        var settings = Settings.CreateDefaultSettings ();
-        string sheetKey = settings.DefaultSheet.ToString ();
-        Assert.True (settings.Sheets.ContainsKey (sheetKey));
+        var settings = Settings.CreateDefaultSettings();
+        string sheetKey = settings.DefaultSheet.ToString();
+        Assert.True(settings.Sheets.ContainsKey(sheetKey));
 
         // Default 2-Up sheet is landscape=true; toggle it
         settings.Sheets[sheetKey].Landscape = false;
 
-        Settings? restored = SaveAndReload (settings);
+        Settings? restored = SaveAndReload(settings);
 
-        Assert.NotNull (restored);
-        Assert.True (restored.Sheets.ContainsKey (sheetKey));
-        Assert.False (restored.Sheets[sheetKey].Landscape);
+        Assert.NotNull(restored);
+        Assert.True(restored.Sheets.ContainsKey(sheetKey));
+        Assert.False(restored.Sheets[sheetKey].Landscape);
     }
 
     [Fact]
-    public void SheetMargins_PersistsAndRestores ()
+    public void SheetMargins_PersistsAndRestores()
     {
-        var settings = Settings.CreateDefaultSettings ();
-        string sheetKey = settings.DefaultSheet.ToString ();
+        var settings = Settings.CreateDefaultSettings();
+        string sheetKey = settings.DefaultSheet.ToString();
 
-        settings.Sheets[sheetKey].Margins = new PrintMargins (50, 75, 100, 125);
+        settings.Sheets[sheetKey].Margins = new PrintMargins(50, 75, 100, 125);
 
-        Settings? restored = SaveAndReload (settings);
+        Settings? restored = SaveAndReload(settings);
 
-        Assert.NotNull (restored);
-        var margins = restored.Sheets[sheetKey].Margins;
-        Assert.Equal (50, margins.Left);
-        Assert.Equal (75, margins.Right);
-        Assert.Equal (100, margins.Top);
-        Assert.Equal (125, margins.Bottom);
+        Assert.NotNull(restored);
+        PrintMargins margins = restored.Sheets[sheetKey].Margins;
+        Assert.Equal(50, margins.Left);
+        Assert.Equal(75, margins.Right);
+        Assert.Equal(100, margins.Top);
+        Assert.Equal(125, margins.Bottom);
     }
 
     [Fact]
-    public void SheetRowsColumns_PersistsAndRestores ()
+    public void SheetRowsColumns_PersistsAndRestores()
     {
-        var settings = Settings.CreateDefaultSettings ();
-        string sheetKey = settings.DefaultSheet.ToString ();
+        var settings = Settings.CreateDefaultSettings();
+        string sheetKey = settings.DefaultSheet.ToString();
 
         settings.Sheets[sheetKey].Rows = 2;
         settings.Sheets[sheetKey].Columns = 3;
 
-        Settings? restored = SaveAndReload (settings);
+        Settings? restored = SaveAndReload(settings);
 
-        Assert.NotNull (restored);
-        Assert.Equal (2, restored.Sheets[sheetKey].Rows);
-        Assert.Equal (3, restored.Sheets[sheetKey].Columns);
+        Assert.NotNull(restored);
+        Assert.Equal(2, restored.Sheets[sheetKey].Rows);
+        Assert.Equal(3, restored.Sheets[sheetKey].Columns);
     }
 
     [Fact]
-    public void SheetHeaderFooter_PersistsAndRestores ()
+    public void SheetHeaderFooter_PersistsAndRestores()
     {
-        var settings = Settings.CreateDefaultSettings ();
-        string sheetKey = settings.DefaultSheet.ToString ();
+        var settings = Settings.CreateDefaultSettings();
+        string sheetKey = settings.DefaultSheet.ToString();
 
         settings.Sheets[sheetKey].Header.Text = "Custom Header {FileName}";
         settings.Sheets[sheetKey].Header.Enabled = false;
         settings.Sheets[sheetKey].Footer.Text = "Custom Footer {Page}";
         settings.Sheets[sheetKey].Footer.Enabled = true;
 
-        Settings? restored = SaveAndReload (settings);
+        Settings? restored = SaveAndReload(settings);
 
-        Assert.NotNull (restored);
-        Assert.Equal ("Custom Header {FileName}", restored.Sheets[sheetKey].Header.Text);
-        Assert.False (restored.Sheets[sheetKey].Header.Enabled);
-        Assert.Equal ("Custom Footer {Page}", restored.Sheets[sheetKey].Footer.Text);
-        Assert.True (restored.Sheets[sheetKey].Footer.Enabled);
+        Assert.NotNull(restored);
+        Assert.Equal("Custom Header {FileName}", restored.Sheets[sheetKey].Header.Text);
+        Assert.False(restored.Sheets[sheetKey].Header.Enabled);
+        Assert.Equal("Custom Footer {Page}", restored.Sheets[sheetKey].Footer.Text);
+        Assert.True(restored.Sheets[sheetKey].Footer.Enabled);
     }
 
     [Fact]
-    public void SheetLineNumbers_PersistsAndRestores ()
+    public void SheetLineNumbers_PersistsAndRestores()
     {
-        var settings = Settings.CreateDefaultSettings ();
-        string sheetKey = Uuid.DefaultSheet1Up.ToString ();
-        Assert.True (settings.Sheets.ContainsKey (sheetKey));
+        var settings = Settings.CreateDefaultSettings();
+        string sheetKey = Uuid.DefaultSheet1Up.ToString();
+        Assert.True(settings.Sheets.ContainsKey(sheetKey));
 
         // Default 1-Up has LineNumbers = true
-        Assert.True (settings.Sheets[sheetKey].ContentSettings!.LineNumbers);
+        Assert.True(settings.Sheets[sheetKey].ContentSettings!.LineNumbers);
 
         settings.Sheets[sheetKey].ContentSettings!.LineNumbers = false;
 
-        Settings? restored = SaveAndReload (settings);
+        Settings? restored = SaveAndReload(settings);
 
-        Assert.NotNull (restored);
-        Assert.False (restored.Sheets[sheetKey].ContentSettings!.LineNumbers);
+        Assert.NotNull(restored);
+        Assert.False(restored.Sheets[sheetKey].ContentSettings!.LineNumbers);
     }
 
     [Fact]
-    public void SheetPadding_PersistsAndRestores ()
+    public void SheetPadding_PersistsAndRestores()
     {
-        var settings = Settings.CreateDefaultSettings ();
-        string sheetKey = settings.DefaultSheet.ToString ();
+        var settings = Settings.CreateDefaultSettings();
+        string sheetKey = settings.DefaultSheet.ToString();
 
         settings.Sheets[sheetKey].Padding = 500;
         settings.Sheets[sheetKey].PageSeparator = true;
 
-        Settings? restored = SaveAndReload (settings);
+        Settings? restored = SaveAndReload(settings);
 
-        Assert.NotNull (restored);
-        Assert.Equal (500, restored.Sheets[sheetKey].Padding);
-        Assert.True (restored.Sheets[sheetKey].PageSeparator);
+        Assert.NotNull(restored);
+        Assert.Equal(500, restored.Sheets[sheetKey].Padding);
+        Assert.True(restored.Sheets[sheetKey].PageSeparator);
     }
 
     [Fact]
-    public void LastPrinter_PersistsAndRestores ()
+    public void LastPrinter_PersistsAndRestores()
     {
-        var settings = Settings.CreateDefaultSettings ();
+        var settings = Settings.CreateDefaultSettings();
         settings.LastPrinter = "Brother HL-L2350DW";
 
-        Settings? restored = SaveAndReload (settings);
+        Settings? restored = SaveAndReload(settings);
 
-        Assert.NotNull (restored);
-        Assert.Equal ("Brother HL-L2350DW", restored.LastPrinter);
+        Assert.NotNull(restored);
+        Assert.Equal("Brother HL-L2350DW", restored.LastPrinter);
     }
 
     [Fact]
-    public void LastPaperSize_PersistsAndRestores ()
+    public void LastPaperSize_PersistsAndRestores()
     {
-        var settings = Settings.CreateDefaultSettings ();
+        var settings = Settings.CreateDefaultSettings();
         settings.LastPaperSize = "A4";
 
-        Settings? restored = SaveAndReload (settings);
+        Settings? restored = SaveAndReload(settings);
 
-        Assert.NotNull (restored);
-        Assert.Equal ("A4", restored.LastPaperSize);
+        Assert.NotNull(restored);
+        Assert.Equal("A4", restored.LastPaperSize);
     }
 
     /// <summary>
     ///     Helper: saves settings to a temp file and reloads them.
     /// </summary>
-    private Settings? SaveAndReload (Settings settings)
+    private Settings? SaveAndReload(Settings settings)
     {
-        string fileName = $"WinPrint.{nameof (SettingsPersistenceTests)}.{Guid.NewGuid ():N}.json";
+        string fileName = $"WinPrint.{nameof(SettingsPersistenceTests)}.{Guid.NewGuid():N}.json";
         try
         {
             var service = new SettingsService { SettingsFileName = fileName };
-            service.SaveSettings (settings);
-            return service.ReadSettings ();
+            service.SaveSettings(settings);
+            return service.ReadSettings();
         }
         finally
         {
-            if (File.Exists (fileName))
+            if (File.Exists(fileName))
             {
-                File.Delete (fileName);
+                File.Delete(fileName);
             }
         }
     }

--- a/tests/WinPrint.Core.UnitTests/Services/SettingsServiceTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Services/SettingsServiceTests.cs
@@ -9,102 +9,102 @@ namespace WinPrint.Core.UnitTests.Services;
 
 public class SettingsServiceTests : TestServicesBase
 {
-    public SettingsServiceTests (ITestOutputHelper output) : base (output)
+    public SettingsServiceTests(ITestOutputHelper output) : base(output)
     {
     }
 
     [Fact]
-    public void TestGetTelemetryDictionary ()
+    public void TestGetTelemetryDictionary()
     {
         var settings = new Settings
         {
             Sheets = new Dictionary<string, SheetSettings>
             {
-                { "test", new SheetSettings () }
+                { "test", new SheetSettings() }
             }
         };
-        IDictionary<string, string?> dict = settings.GetTelemetryDictionary ();
-        Assert.NotNull (dict);
+        IDictionary<string, string?> dict = settings.GetTelemetryDictionary();
+        Assert.NotNull(dict);
     }
 
     [Fact]
-    public void TestSave ()
+    public void TestSave()
     {
         var settings = new Settings
         {
             Sheets = new Dictionary<string, SheetSettings>
             {
-                { "test", new SheetSettings () }
-            }
-        };
-        var settingsService = new SettingsService
-        {
-            SettingsFileName = $"WinPrint.{GetType ().Name}.json"
-        };
-        File.Delete (ServiceLocator.Current.SettingsService.SettingsFileName);
-
-        settingsService.SaveSettings (settings);
-
-        Settings? settingsCopy = settingsService.ReadSettings ();
-
-        Assert.NotNull (settingsCopy);
-
-        Assert.True (settingsCopy.Sheets.ContainsKey ("test"));
-    }
-
-    [Fact]
-    public void TestSaveExistingFile ()
-    {
-        var settings = new Settings
-        {
-            Sheets = new Dictionary<string, SheetSettings>
-            {
-                { "test", new SheetSettings () }
+                { "test", new SheetSettings() }
             }
         };
         var settingsService = new SettingsService
         {
-            SettingsFileName = $"WinPrint.{GetType ().Name}.json"
+            SettingsFileName = $"WinPrint.{GetType().Name}.json"
         };
+        File.Delete(ServiceLocator.Current.SettingsService.SettingsFileName);
 
-        settingsService.SaveSettings (settings);
+        settingsService.SaveSettings(settings);
 
-        Settings? settingsCopy = settingsService.ReadSettings ();
+        Settings? settingsCopy = settingsService.ReadSettings();
 
-        Assert.NotNull (settingsCopy);
+        Assert.NotNull(settingsCopy);
 
-        Assert.True (settingsCopy.Sheets.ContainsKey ("test"));
+        Assert.True(settingsCopy.Sheets.ContainsKey("test"));
     }
 
     [Fact]
-    public void TestReadMicrosoftExtensionsConfigurationSchema ()
+    public void TestSaveExistingFile()
     {
-        string settingsFileName = $"WinPrint.{GetType ().Name}.Mec.json";
-        File.WriteAllText (settingsFileName, """
-                                             {
-                                               "defaultContentType": "text/plain",
-                                               "defaultCteClassName": "TextMateCte",
-                                               "defaultSyntaxHighlighterCteNameClassName": "TextMateCte",
-                                               "textMateContentTypeEngineSettings": {
-                                                 "contentSettings": {
-                                                   "style": "VisualStudioDark"
-                                                 }
-                                               },
-                                               "fileTypeMapping": {
-                                                 "filesAssociations": {
-                                                   "*.foo": "text/foo"
-                                                 },
-                                                 "contentTypes": [
-                                                   {
-                                                     "id": "text/foo",
-                                                     "title": "Foo",
-                                                     "extensions": [ "*.foo" ],
-                                                     "aliases": [ "foo" ]
-                                                   }
-                                                 ]
-                                               }
-                                             }
-                                             """);
+        var settings = new Settings
+        {
+            Sheets = new Dictionary<string, SheetSettings>
+            {
+                { "test", new SheetSettings() }
+            }
+        };
+        var settingsService = new SettingsService
+        {
+            SettingsFileName = $"WinPrint.{GetType().Name}.json"
+        };
+
+        settingsService.SaveSettings(settings);
+
+        Settings? settingsCopy = settingsService.ReadSettings();
+
+        Assert.NotNull(settingsCopy);
+
+        Assert.True(settingsCopy.Sheets.ContainsKey("test"));
+    }
+
+    [Fact]
+    public void TestReadMicrosoftExtensionsConfigurationSchema()
+    {
+        string settingsFileName = $"WinPrint.{GetType().Name}.Mec.json";
+        File.WriteAllText(settingsFileName, """
+                                            {
+                                              "defaultContentType": "text/plain",
+                                              "defaultCteClassName": "TextMateCte",
+                                              "defaultSyntaxHighlighterCteNameClassName": "TextMateCte",
+                                              "textMateContentTypeEngineSettings": {
+                                                "contentSettings": {
+                                                  "style": "VisualStudioDark"
+                                                }
+                                              },
+                                              "fileTypeMapping": {
+                                                "filesAssociations": {
+                                                  "*.foo": "text/foo"
+                                                },
+                                                "contentTypes": [
+                                                  {
+                                                    "id": "text/foo",
+                                                    "title": "Foo",
+                                                    "extensions": [ "*.foo" ],
+                                                    "aliases": [ "foo" ]
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                            """);
 
         try
         {
@@ -113,18 +113,18 @@ public class SettingsServiceTests : TestServicesBase
                 SettingsFileName = settingsFileName
             };
 
-            Settings? settings = settingsService.ReadSettings ();
+            Settings? settings = settingsService.ReadSettings();
 
-            Assert.NotNull (settings);
-            Assert.Equal ("text/plain", settings.DefaultContentType);
-            Assert.Equal ("TextMateCte", settings.DefaultCteClassName);
-            Assert.Equal ("VisualStudioDark", settings.TextMateContentTypeEngineSettings.ContentSettings!.Style);
-            Assert.Equal ("text/foo", settings.FileTypeMapping.FilesAssociations["*.foo"]);
-            Assert.Contains (settings.FileTypeMapping.ContentTypes, contentType => contentType.Id == "text/foo");
+            Assert.NotNull(settings);
+            Assert.Equal("text/plain", settings.DefaultContentType);
+            Assert.Equal("TextMateCte", settings.DefaultCteClassName);
+            Assert.Equal("VisualStudioDark", settings.TextMateContentTypeEngineSettings.ContentSettings!.Style);
+            Assert.Equal("text/foo", settings.FileTypeMapping.FilesAssociations["*.foo"]);
+            Assert.Contains(settings.FileTypeMapping.ContentTypes, contentType => contentType.Id == "text/foo");
         }
         finally
         {
-            File.Delete (settingsFileName);
+            File.Delete(settingsFileName);
         }
     }
 }

--- a/tests/WinPrint.Core.UnitTests/Services/TestServicesBase.cs
+++ b/tests/WinPrint.Core.UnitTests/Services/TestServicesBase.cs
@@ -11,10 +11,10 @@ public class TestServicesBase
 {
     public JsonSerializerOptions jsonOptions;
 
-    public TestServicesBase (ITestOutputHelper output)
+    public TestServicesBase(ITestOutputHelper output)
     {
-        ServiceLocator.Current.LogService.Start (GetType ().Name,
-            new TestOutputSink (output, new MessageTemplateTextFormatter ("{Message:lj}")), true, true);
+        ServiceLocator.Current.LogService.Start(GetType().Name,
+            new TestOutputSink(output, new MessageTemplateTextFormatter("{Message:lj}")), true, true);
         jsonOptions = new JsonSerializerOptions
         {
             WriteIndented = true,
@@ -23,6 +23,6 @@ public class TestServicesBase
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             ReadCommentHandling = JsonCommentHandling.Skip
         };
-        jsonOptions.Converters.Add (new JsonStringEnumConverter (JsonNamingPolicy.CamelCase));
+        jsonOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
     }
 }

--- a/tests/WinPrint.Core.UnitTests/TestSupport/RecordedLine.cs
+++ b/tests/WinPrint.Core.UnitTests/TestSupport/RecordedLine.cs
@@ -1,0 +1,4 @@
+namespace WinPrint.Core.UnitTests.TestSupport;
+
+/// <summary>A line-drawing operation captured by <see cref="RecordingGraphicsContext" />.</summary>
+public readonly record struct RecordedLine (float X1, float Y1, float X2, float Y2);

--- a/tests/WinPrint.Core.UnitTests/TestSupport/RecordedLine.cs
+++ b/tests/WinPrint.Core.UnitTests/TestSupport/RecordedLine.cs
@@ -1,4 +1,4 @@
 namespace WinPrint.Core.UnitTests.TestSupport;
 
 /// <summary>A line-drawing operation captured by <see cref="RecordingGraphicsContext" />.</summary>
-public readonly record struct RecordedLine (float X1, float Y1, float X2, float Y2);
+public readonly record struct RecordedLine(float X1, float Y1, float X2, float Y2);

--- a/tests/WinPrint.Core.UnitTests/TestSupport/RecordedRect.cs
+++ b/tests/WinPrint.Core.UnitTests/TestSupport/RecordedRect.cs
@@ -1,4 +1,4 @@
 namespace WinPrint.Core.UnitTests.TestSupport;
 
 /// <summary>A rectangle-drawing operation captured by <see cref="RecordingGraphicsContext" />.</summary>
-public readonly record struct RecordedRect (float X, float Y, float Width, float Height);
+public readonly record struct RecordedRect(float X, float Y, float Width, float Height);

--- a/tests/WinPrint.Core.UnitTests/TestSupport/RecordedRect.cs
+++ b/tests/WinPrint.Core.UnitTests/TestSupport/RecordedRect.cs
@@ -1,0 +1,4 @@
+namespace WinPrint.Core.UnitTests.TestSupport;
+
+/// <summary>A rectangle-drawing operation captured by <see cref="RecordingGraphicsContext" />.</summary>
+public readonly record struct RecordedRect (float X, float Y, float Width, float Height);

--- a/tests/WinPrint.Core.UnitTests/TestSupport/RecordedString.cs
+++ b/tests/WinPrint.Core.UnitTests/TestSupport/RecordedString.cs
@@ -1,4 +1,4 @@
 namespace WinPrint.Core.UnitTests.TestSupport;
 
 /// <summary>A text-drawing operation captured by <see cref="RecordingGraphicsContext" />.</summary>
-public readonly record struct RecordedString (string Text, float X, float Y);
+public readonly record struct RecordedString(string Text, float X, float Y);

--- a/tests/WinPrint.Core.UnitTests/TestSupport/RecordedString.cs
+++ b/tests/WinPrint.Core.UnitTests/TestSupport/RecordedString.cs
@@ -1,0 +1,4 @@
+namespace WinPrint.Core.UnitTests.TestSupport;
+
+/// <summary>A text-drawing operation captured by <see cref="RecordingGraphicsContext" />.</summary>
+public readonly record struct RecordedString (string Text, float X, float Y);

--- a/tests/WinPrint.Core.UnitTests/TestSupport/RecordingGraphicsContext.cs
+++ b/tests/WinPrint.Core.UnitTests/TestSupport/RecordingGraphicsContext.cs
@@ -1,0 +1,144 @@
+using System.Collections.Generic;
+using WinPrint.Core.Abstractions;
+
+namespace WinPrint.Core.UnitTests.TestSupport;
+
+/// <summary>
+///     A platform-neutral <see cref="IGraphicsContext" /> test double that records drawing operations
+///     and measures text using a deterministic fixed-pitch (monospace) model. Because it has no
+///     dependency on System.Drawing/GDI+, it lets Content Type Engine rendering be exercised and
+///     verified cross-platform (including on Linux CI).
+///
+///     Measurement model: every glyph is <see cref="CharWidth" /> wide and every line is
+///     <see cref="LineHeight" /> tall, regardless of font. This makes page counts and wrap points
+///     exactly predictable in tests.
+/// </summary>
+public sealed class RecordingGraphicsContext : IGraphicsContext
+{
+    private readonly IGraphicsBrush _brush = new RecordingResource ();
+    private readonly IGraphicsPen _pen = new RecordingResource ();
+
+    public RecordingGraphicsContext (float charWidth = 10f, float lineHeight = 20f, float dpi = 96f)
+    {
+        CharWidth = charWidth;
+        LineHeight = lineHeight;
+        DpiX = dpi;
+        DpiY = dpi;
+    }
+
+    public float CharWidth { get; }
+    public float LineHeight { get; }
+
+    /// <summary>Every <see cref="DrawString" /> call, in order, for assertions.</summary>
+    public List<RecordedString> DrawnStrings { get; } = new ();
+
+    public List<RecordedLine> DrawnLines { get; } = new ();
+    public List<RecordedRect> DrawnRectangles { get; } = new ();
+    public List<RecordedRect> FilledRectangles { get; } = new ();
+
+    public float DpiX { get; }
+    public float DpiY { get; }
+    public bool IsDisplayUnit => true;
+
+    public IGraphicsBrush BlackBrush => _brush;
+    public IGraphicsBrush GrayBrush => _brush;
+    public IGraphicsBrush DarkGrayBrush => _brush;
+    public IGraphicsPen BlackPen => _pen;
+    public IGraphicsPen GrayPen => _pen;
+    public IGraphicsPen RedPen => _pen;
+
+    public IGraphicsState Save ()
+    {
+        return new RecordingState ();
+    }
+
+    public void Restore (IGraphicsState state) { }
+
+    public void TranslateTransform (float dx, float dy) { }
+
+    public void ScaleTransform (float sx, float sy) { }
+
+    public void SetClip (GraphicsRectF rect) { }
+
+    public void ExcludeClip (GraphicsRectF rect) { }
+
+    public void ResetClip () { }
+
+    public void SetTextRenderingMode (GraphicsTextRenderingMode mode) { }
+
+    public IGraphicsFont CreateFont (string family, float size, GraphicsFontStyle style, GraphicsFontUnit unit)
+    {
+        return new RecordingGraphicsFont (family, size, style, unit, CharWidth, LineHeight);
+    }
+
+    public IGraphicsBrush CreateSolidBrush (GraphicsColor color)
+    {
+        return _brush;
+    }
+
+    public IGraphicsPen CreatePen (GraphicsColor color, float width = 1f)
+    {
+        return _pen;
+    }
+
+    public GraphicsSizeF MeasureString (string text, IGraphicsFont font)
+    {
+        return new GraphicsSizeF (text.Length * CharWidth, LineHeight);
+    }
+
+    public GraphicsSizeF MeasureString (string text, IGraphicsFont font, int width, GraphicsStringFormat format)
+    {
+        return new GraphicsSizeF (text.Length * CharWidth, LineHeight);
+    }
+
+    public GraphicsSizeF MeasureString (string text, IGraphicsFont font, GraphicsSizeF proposedSize,
+        GraphicsStringFormat format, out int charsFitted, out int linesFilled)
+    {
+        int maxChars = CharWidth <= 0 ? text.Length : (int)(proposedSize.Width / CharWidth);
+        charsFitted = text.Length < maxChars ? text.Length : maxChars;
+        if (charsFitted < 0)
+        {
+            charsFitted = 0;
+        }
+
+        linesFilled = text.Length == 0 ? 0 : 1;
+        return new GraphicsSizeF (text.Length * CharWidth, LineHeight);
+    }
+
+    public void DrawString (string text, IGraphicsFont font, IGraphicsBrush brush, float x, float y,
+        GraphicsStringFormat? format = null)
+    {
+        DrawnStrings.Add (new RecordedString (text, x, y));
+    }
+
+    public void DrawString (string text, IGraphicsFont font, IGraphicsBrush brush, GraphicsRectF rect,
+        GraphicsStringFormat? format = null)
+    {
+        DrawnStrings.Add (new RecordedString (text, rect.X, rect.Y));
+    }
+
+    public void DrawLine (IGraphicsPen pen, float x1, float y1, float x2, float y2)
+    {
+        DrawnLines.Add (new RecordedLine (x1, y1, x2, y2));
+    }
+
+    public void DrawLine (IGraphicsPen pen, GraphicsPointF start, GraphicsPointF end)
+    {
+        DrawnLines.Add (new RecordedLine (start.X, start.Y, end.X, end.Y));
+    }
+
+    public void DrawRectangle (IGraphicsPen pen, float x, float y, float width, float height)
+    {
+        DrawnRectangles.Add (new RecordedRect (x, y, width, height));
+    }
+
+    public void FillRectangle (IGraphicsBrush brush, GraphicsRectF rect)
+    {
+        FilledRectangles.Add (new RecordedRect (rect.X, rect.Y, rect.Width, rect.Height));
+    }
+
+    public void FillRectangle (IGraphicsBrush brush, float x, float y, float width, float height)
+    {
+        FilledRectangles.Add (new RecordedRect (x, y, width, height));
+    }
+}

--- a/tests/WinPrint.Core.UnitTests/TestSupport/RecordingGraphicsContext.cs
+++ b/tests/WinPrint.Core.UnitTests/TestSupport/RecordingGraphicsContext.cs
@@ -15,10 +15,10 @@ namespace WinPrint.Core.UnitTests.TestSupport;
 /// </summary>
 public sealed class RecordingGraphicsContext : IGraphicsContext
 {
-    private readonly IGraphicsBrush _brush = new RecordingResource ();
-    private readonly IGraphicsPen _pen = new RecordingResource ();
+    private readonly IGraphicsBrush _brush = new RecordingResource();
+    private readonly IGraphicsPen _pen = new RecordingResource();
 
-    public RecordingGraphicsContext (float charWidth = 10f, float lineHeight = 20f, float dpi = 96f)
+    public RecordingGraphicsContext(float charWidth = 10f, float lineHeight = 20f, float dpi = 96f)
     {
         CharWidth = charWidth;
         LineHeight = lineHeight;
@@ -30,11 +30,11 @@ public sealed class RecordingGraphicsContext : IGraphicsContext
     public float LineHeight { get; }
 
     /// <summary>Every <see cref="DrawString" /> call, in order, for assertions.</summary>
-    public List<RecordedString> DrawnStrings { get; } = new ();
+    public List<RecordedString> DrawnStrings { get; } = [];
 
-    public List<RecordedLine> DrawnLines { get; } = new ();
-    public List<RecordedRect> DrawnRectangles { get; } = new ();
-    public List<RecordedRect> FilledRectangles { get; } = new ();
+    public List<RecordedLine> DrawnLines { get; } = [];
+    public List<RecordedRect> DrawnRectangles { get; } = [];
+    public List<RecordedRect> FilledRectangles { get; } = [];
 
     public float DpiX { get; }
     public float DpiY { get; }
@@ -47,51 +47,65 @@ public sealed class RecordingGraphicsContext : IGraphicsContext
     public IGraphicsPen GrayPen => _pen;
     public IGraphicsPen RedPen => _pen;
 
-    public IGraphicsState Save ()
+    public IGraphicsState Save()
     {
-        return new RecordingState ();
+        return new RecordingState();
     }
 
-    public void Restore (IGraphicsState state) { }
-
-    public void TranslateTransform (float dx, float dy) { }
-
-    public void ScaleTransform (float sx, float sy) { }
-
-    public void SetClip (GraphicsRectF rect) { }
-
-    public void ExcludeClip (GraphicsRectF rect) { }
-
-    public void ResetClip () { }
-
-    public void SetTextRenderingMode (GraphicsTextRenderingMode mode) { }
-
-    public IGraphicsFont CreateFont (string family, float size, GraphicsFontStyle style, GraphicsFontUnit unit)
+    public void Restore(IGraphicsState state)
     {
-        return new RecordingGraphicsFont (family, size, style, unit, CharWidth, LineHeight);
     }
 
-    public IGraphicsBrush CreateSolidBrush (GraphicsColor color)
+    public void TranslateTransform(float dx, float dy)
+    {
+    }
+
+    public void ScaleTransform(float sx, float sy)
+    {
+    }
+
+    public void SetClip(GraphicsRectF rect)
+    {
+    }
+
+    public void ExcludeClip(GraphicsRectF rect)
+    {
+    }
+
+    public void ResetClip()
+    {
+    }
+
+    public void SetTextRenderingMode(GraphicsTextRenderingMode mode)
+    {
+    }
+
+    public IGraphicsFont CreateFont(string family, float size, GraphicsFontStyle style, GraphicsFontUnit unit)
+    {
+        return new RecordingGraphicsFont(family, size, style, unit, CharWidth, LineHeight);
+    }
+
+    public IGraphicsBrush CreateSolidBrush(GraphicsColor color)
     {
         return _brush;
     }
 
-    public IGraphicsPen CreatePen (GraphicsColor color, float width = 1f)
+    public IGraphicsPen CreatePen(GraphicsColor color, float width = 1f)
     {
         return _pen;
     }
 
-    public GraphicsSizeF MeasureString (string text, IGraphicsFont font)
+    public GraphicsSizeF MeasureString(string text, IGraphicsFont font)
     {
-        return new GraphicsSizeF (text.Length * CharWidth, LineHeight);
+        return new GraphicsSizeF(text.Length * CharWidth, LineHeight);
     }
 
-    public GraphicsSizeF MeasureString (string text, IGraphicsFont font, int width, GraphicsStringFormat format)
+    public GraphicsSizeF MeasureString(string text, IGraphicsFont font, int width, GraphicsStringFormat format)
     {
-        return new GraphicsSizeF (text.Length * CharWidth, LineHeight);
+        return new GraphicsSizeF(text.Length * CharWidth, LineHeight);
     }
 
-    public GraphicsSizeF MeasureString (string text, IGraphicsFont font, GraphicsSizeF proposedSize,
+    public GraphicsSizeF MeasureString(string text, IGraphicsFont font, GraphicsSizeF proposedSize,
         GraphicsStringFormat format, out int charsFitted, out int linesFilled)
     {
         int maxChars = CharWidth <= 0 ? text.Length : (int)(proposedSize.Width / CharWidth);
@@ -102,43 +116,43 @@ public sealed class RecordingGraphicsContext : IGraphicsContext
         }
 
         linesFilled = text.Length == 0 ? 0 : 1;
-        return new GraphicsSizeF (text.Length * CharWidth, LineHeight);
+        return new GraphicsSizeF(text.Length * CharWidth, LineHeight);
     }
 
-    public void DrawString (string text, IGraphicsFont font, IGraphicsBrush brush, float x, float y,
+    public void DrawString(string text, IGraphicsFont font, IGraphicsBrush brush, float x, float y,
         GraphicsStringFormat? format = null)
     {
-        DrawnStrings.Add (new RecordedString (text, x, y));
+        DrawnStrings.Add(new RecordedString(text, x, y));
     }
 
-    public void DrawString (string text, IGraphicsFont font, IGraphicsBrush brush, GraphicsRectF rect,
+    public void DrawString(string text, IGraphicsFont font, IGraphicsBrush brush, GraphicsRectF rect,
         GraphicsStringFormat? format = null)
     {
-        DrawnStrings.Add (new RecordedString (text, rect.X, rect.Y));
+        DrawnStrings.Add(new RecordedString(text, rect.X, rect.Y));
     }
 
-    public void DrawLine (IGraphicsPen pen, float x1, float y1, float x2, float y2)
+    public void DrawLine(IGraphicsPen pen, float x1, float y1, float x2, float y2)
     {
-        DrawnLines.Add (new RecordedLine (x1, y1, x2, y2));
+        DrawnLines.Add(new RecordedLine(x1, y1, x2, y2));
     }
 
-    public void DrawLine (IGraphicsPen pen, GraphicsPointF start, GraphicsPointF end)
+    public void DrawLine(IGraphicsPen pen, GraphicsPointF start, GraphicsPointF end)
     {
-        DrawnLines.Add (new RecordedLine (start.X, start.Y, end.X, end.Y));
+        DrawnLines.Add(new RecordedLine(start.X, start.Y, end.X, end.Y));
     }
 
-    public void DrawRectangle (IGraphicsPen pen, float x, float y, float width, float height)
+    public void DrawRectangle(IGraphicsPen pen, float x, float y, float width, float height)
     {
-        DrawnRectangles.Add (new RecordedRect (x, y, width, height));
+        DrawnRectangles.Add(new RecordedRect(x, y, width, height));
     }
 
-    public void FillRectangle (IGraphicsBrush brush, GraphicsRectF rect)
+    public void FillRectangle(IGraphicsBrush brush, GraphicsRectF rect)
     {
-        FilledRectangles.Add (new RecordedRect (rect.X, rect.Y, rect.Width, rect.Height));
+        FilledRectangles.Add(new RecordedRect(rect.X, rect.Y, rect.Width, rect.Height));
     }
 
-    public void FillRectangle (IGraphicsBrush brush, float x, float y, float width, float height)
+    public void FillRectangle(IGraphicsBrush brush, float x, float y, float width, float height)
     {
-        FilledRectangles.Add (new RecordedRect (x, y, width, height));
+        FilledRectangles.Add(new RecordedRect(x, y, width, height));
     }
 }

--- a/tests/WinPrint.Core.UnitTests/TestSupport/RecordingGraphicsFont.cs
+++ b/tests/WinPrint.Core.UnitTests/TestSupport/RecordingGraphicsFont.cs
@@ -10,7 +10,7 @@ internal sealed class RecordingGraphicsFont : IGraphicsFont
 {
     private readonly float _lineHeight;
 
-    public RecordingGraphicsFont (string family, float size, GraphicsFontStyle style, GraphicsFontUnit unit,
+    public RecordingGraphicsFont(string family, float size, GraphicsFontStyle style, GraphicsFontUnit unit,
         float charWidth, float lineHeight)
     {
         Family = family;
@@ -27,10 +27,12 @@ internal sealed class RecordingGraphicsFont : IGraphicsFont
     public GraphicsFontUnit Unit { get; }
     public float CharWidth { get; }
 
-    public float GetHeight (float dpi)
+    public float GetHeight(float dpi)
     {
         return _lineHeight;
     }
 
-    public void Dispose () { }
+    public void Dispose()
+    {
+    }
 }

--- a/tests/WinPrint.Core.UnitTests/TestSupport/RecordingGraphicsFont.cs
+++ b/tests/WinPrint.Core.UnitTests/TestSupport/RecordingGraphicsFont.cs
@@ -1,0 +1,36 @@
+using WinPrint.Core.Abstractions;
+
+namespace WinPrint.Core.UnitTests.TestSupport;
+
+/// <summary>
+///     A fixed-pitch font used by <see cref="RecordingGraphicsContext" />. Carries the deterministic
+///     per-character width and line height used for measurement.
+/// </summary>
+internal sealed class RecordingGraphicsFont : IGraphicsFont
+{
+    private readonly float _lineHeight;
+
+    public RecordingGraphicsFont (string family, float size, GraphicsFontStyle style, GraphicsFontUnit unit,
+        float charWidth, float lineHeight)
+    {
+        Family = family;
+        Size = size;
+        Style = style;
+        Unit = unit;
+        CharWidth = charWidth;
+        _lineHeight = lineHeight;
+    }
+
+    public string Family { get; }
+    public float Size { get; }
+    public GraphicsFontStyle Style { get; }
+    public GraphicsFontUnit Unit { get; }
+    public float CharWidth { get; }
+
+    public float GetHeight (float dpi)
+    {
+        return _lineHeight;
+    }
+
+    public void Dispose () { }
+}

--- a/tests/WinPrint.Core.UnitTests/TestSupport/RecordingResource.cs
+++ b/tests/WinPrint.Core.UnitTests/TestSupport/RecordingResource.cs
@@ -5,5 +5,7 @@ namespace WinPrint.Core.UnitTests.TestSupport;
 /// <summary>A no-op brush/pen used by <see cref="RecordingGraphicsContext" />.</summary>
 internal sealed class RecordingResource : IGraphicsBrush, IGraphicsPen
 {
-    public void Dispose () { }
+    public void Dispose()
+    {
+    }
 }

--- a/tests/WinPrint.Core.UnitTests/TestSupport/RecordingResource.cs
+++ b/tests/WinPrint.Core.UnitTests/TestSupport/RecordingResource.cs
@@ -1,0 +1,9 @@
+using WinPrint.Core.Abstractions;
+
+namespace WinPrint.Core.UnitTests.TestSupport;
+
+/// <summary>A no-op brush/pen used by <see cref="RecordingGraphicsContext" />.</summary>
+internal sealed class RecordingResource : IGraphicsBrush, IGraphicsPen
+{
+    public void Dispose () { }
+}

--- a/tests/WinPrint.Core.UnitTests/TestSupport/RecordingState.cs
+++ b/tests/WinPrint.Core.UnitTests/TestSupport/RecordingState.cs
@@ -3,4 +3,6 @@ using WinPrint.Core.Abstractions;
 namespace WinPrint.Core.UnitTests.TestSupport;
 
 /// <summary>A no-op graphics state used by <see cref="RecordingGraphicsContext" />.</summary>
-internal sealed class RecordingState : IGraphicsState { }
+internal sealed class RecordingState : IGraphicsState
+{
+}

--- a/tests/WinPrint.Core.UnitTests/TestSupport/RecordingState.cs
+++ b/tests/WinPrint.Core.UnitTests/TestSupport/RecordingState.cs
@@ -1,0 +1,6 @@
+using WinPrint.Core.Abstractions;
+
+namespace WinPrint.Core.UnitTests.TestSupport;
+
+/// <summary>A no-op graphics state used by <see cref="RecordingGraphicsContext" />.</summary>
+internal sealed class RecordingState : IGraphicsState { }

--- a/tests/WinPrint.Core.UnitTests/TestSupport/SystemDrawingPageRenderer.cs
+++ b/tests/WinPrint.Core.UnitTests/TestSupport/SystemDrawingPageRenderer.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using WinPrint.Core.Abstractions;
+using WinPrint.Core.ContentTypeEngines;
+
+namespace WinPrint.Core.UnitTests.TestSupport;
+
+/// <summary>
+///     Renders a Content Type Engine page to an in-memory <see cref="Bitmap" /> using the production
+///     <see cref="SystemDrawingGraphicsContext" /> (real GDI+), mirroring the print-preview setup
+///     (<see cref="GraphicsUnit.Display" />, i.e. 1/100"). This gives regression tests a faithful,
+///     headless rendering of the real measurement/draw path — unlike <see cref="RecordingGraphicsContext" />,
+///     which is fixed-pitch and cannot surface GDI+ measurement issues (e.g. per-token padding drift).
+///
+///     Because it uses System.Drawing, it only runs on Windows; on non-Windows hosts the GDI+ calls
+///     throw (an environment limitation, consistent with the other System.Drawing-based tests).
+/// </summary>
+public static class SystemDrawingPageRenderer
+{
+    /// <summary>
+    ///     Paints <paramref name="pageNum" /> of an already-reflowed <paramref name="cte" /> onto a white
+    ///     bitmap of the given pixel size. The caller owns (and must dispose) the returned bitmap.
+    /// </summary>
+    public static Bitmap RenderPage (ContentTypeEngineBase cte, int pageNum, int pixelWidth, int pixelHeight,
+        int dpi = 96)
+    {
+        var bitmap = new Bitmap (pixelWidth, pixelHeight);
+        bitmap.SetResolution (dpi, dpi);
+        using (Graphics g = Graphics.FromImage (bitmap))
+        {
+            g.Clear (Color.White);
+            g.PageUnit = GraphicsUnit.Display; // 1/100" — same as the WinForms preview
+            var context = new SystemDrawingGraphicsContext (g);
+            cte.PaintPage (context, pageNum);
+        }
+
+        return bitmap;
+    }
+
+    /// <summary>
+    ///     Returns the x of the right-most "inked" (non-white) pixel in the bitmap, or -1 if the bitmap is
+    ///     blank. Useful for asserting that drawn content does not drift wider than expected.
+    /// </summary>
+    public static int RightmostInkColumn (Bitmap bitmap, int whiteThreshold = 750)
+    {
+        for (int x = bitmap.Width - 1; x >= 0; x--)
+        {
+            for (int y = 0; y < bitmap.Height; y++)
+            {
+                Color c = bitmap.GetPixel (x, y);
+                if (c.R + c.G + c.B < whiteThreshold)
+                {
+                    return x;
+                }
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>Saves the bitmap as a PNG (handy for eyeballing a failing regression locally).</summary>
+    public static void SavePng (Bitmap bitmap, string path)
+    {
+        if (bitmap is null)
+        {
+            throw new ArgumentNullException (nameof (bitmap));
+        }
+
+        bitmap.Save (path, ImageFormat.Png);
+    }
+}

--- a/tests/WinPrint.Core.UnitTests/TestSupport/SystemDrawingPageRenderer.cs
+++ b/tests/WinPrint.Core.UnitTests/TestSupport/SystemDrawingPageRenderer.cs
@@ -22,17 +22,17 @@ public static class SystemDrawingPageRenderer
     ///     Paints <paramref name="pageNum" /> of an already-reflowed <paramref name="cte" /> onto a white
     ///     bitmap of the given pixel size. The caller owns (and must dispose) the returned bitmap.
     /// </summary>
-    public static Bitmap RenderPage (ContentTypeEngineBase cte, int pageNum, int pixelWidth, int pixelHeight,
+    public static Bitmap RenderPage(ContentTypeEngineBase cte, int pageNum, int pixelWidth, int pixelHeight,
         int dpi = 96)
     {
-        var bitmap = new Bitmap (pixelWidth, pixelHeight);
-        bitmap.SetResolution (dpi, dpi);
-        using (Graphics g = Graphics.FromImage (bitmap))
+        var bitmap = new Bitmap(pixelWidth, pixelHeight);
+        bitmap.SetResolution(dpi, dpi);
+        using (var g = Graphics.FromImage(bitmap))
         {
-            g.Clear (Color.White);
+            g.Clear(Color.White);
             g.PageUnit = GraphicsUnit.Display; // 1/100" — same as the WinForms preview
-            var context = new SystemDrawingGraphicsContext (g);
-            cte.PaintPage (context, pageNum);
+            var context = new SystemDrawingGraphicsContext(g);
+            cte.PaintPage(context, pageNum);
         }
 
         return bitmap;
@@ -42,13 +42,13 @@ public static class SystemDrawingPageRenderer
     ///     Returns the x of the right-most "inked" (non-white) pixel in the bitmap, or -1 if the bitmap is
     ///     blank. Useful for asserting that drawn content does not drift wider than expected.
     /// </summary>
-    public static int RightmostInkColumn (Bitmap bitmap, int whiteThreshold = 750)
+    public static int RightmostInkColumn(Bitmap bitmap, int whiteThreshold = 750)
     {
         for (int x = bitmap.Width - 1; x >= 0; x--)
         {
             for (int y = 0; y < bitmap.Height; y++)
             {
-                Color c = bitmap.GetPixel (x, y);
+                Color c = bitmap.GetPixel(x, y);
                 if (c.R + c.G + c.B < whiteThreshold)
                 {
                     return x;
@@ -60,13 +60,13 @@ public static class SystemDrawingPageRenderer
     }
 
     /// <summary>Saves the bitmap as a PNG (handy for eyeballing a failing regression locally).</summary>
-    public static void SavePng (Bitmap bitmap, string path)
+    public static void SavePng(Bitmap bitmap, string path)
     {
         if (bitmap is null)
         {
-            throw new ArgumentNullException (nameof (bitmap));
+            throw new ArgumentNullException(nameof(bitmap));
         }
 
-        bitmap.Save (path, ImageFormat.Png);
+        bitmap.Save(path, ImageFormat.Png);
     }
 }

--- a/tests/WinPrint.Core.UnitTests/ViewModels/AppViewModelTests.cs
+++ b/tests/WinPrint.Core.UnitTests/ViewModels/AppViewModelTests.cs
@@ -2,6 +2,7 @@
 // Published under the MIT License at https://github.com/tig/winprint
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using WinPrint.Core.Abstractions;
@@ -21,17 +22,18 @@ namespace WinPrint.Core.UnitTests.ViewModels;
 /// </summary>
 public class AppViewModelTests : TestServicesBase
 {
-    public AppViewModelTests (ITestOutputHelper output) : base (output)
+    public AppViewModelTests(ITestOutputHelper output) : base(output)
     {
         // Reset the singleton Settings to a known baseline. ModelLocator.Settings is
         // read-only (IoC), so mutate the existing instance in place.
-        var fresh = Settings.CreateDefaultSettings ();
-        var live = ModelLocator.Current.Settings;
-        live.Sheets.Clear ();
-        foreach (var kvp in fresh.Sheets)
+        var fresh = Settings.CreateDefaultSettings();
+        Settings live = ModelLocator.Current.Settings;
+        live.Sheets.Clear();
+        foreach (KeyValuePair<string, SheetSettings> kvp in fresh.Sheets)
         {
             live.Sheets[kvp.Key] = kvp.Value;
         }
+
         live.DefaultSheet = fresh.DefaultSheet;
         live.LastPrinter = null;
         live.LastPaperSize = null;
@@ -40,9 +42,9 @@ public class AppViewModelTests : TestServicesBase
         live.Location = null;
     }
 
-    private static AppViewModel CreateVm ()
+    private static AppViewModel CreateVm()
     {
-        var sheetVM = new SheetViewModel ();
+        var sheetVM = new SheetViewModel();
         var pageSetup = new PrintPageSetup
         {
             PaperWidth = 850,
@@ -50,155 +52,155 @@ public class AppViewModelTests : TestServicesBase
             DpiX = 96,
             DpiY = 96
         };
-        return new AppViewModel (sheetVM, pageSetup);
+        return new AppViewModel(sheetVM, pageSetup);
     }
 
     [Fact]
-    public void LoadSheets_PopulatesNamesAndSelectsDefaultSheet ()
+    public void LoadSheets_PopulatesNamesAndSelectsDefaultSheet()
     {
-        var vm = CreateVm ();
-        vm.LoadSheets ();
+        AppViewModel vm = CreateVm();
+        vm.LoadSheets();
 
-        Assert.NotEmpty (vm.SheetNames);
-        Assert.True (vm.SelectedSheetIndex >= 0);
-        Assert.NotNull (vm.CurrentSheet);
-        Assert.Equal (
-            ModelLocator.Current.Settings.DefaultSheet.ToString (),
+        Assert.NotEmpty(vm.SheetNames);
+        Assert.True(vm.SelectedSheetIndex >= 0);
+        Assert.NotNull(vm.CurrentSheet);
+        Assert.Equal(
+            ModelLocator.Current.Settings.DefaultSheet.ToString(),
             vm.SheetKeys[vm.SelectedSheetIndex]);
     }
 
     [Fact]
-    public void SelectSheetByIndex_HooksLiveSettingsReference ()
+    public void SelectSheetByIndex_HooksLiveSettingsReference()
     {
-        var vm = CreateVm ();
-        vm.LoadSheets ();
+        AppViewModel vm = CreateVm();
+        vm.LoadSheets();
 
         // Mutating CurrentSheet must mutate the live Settings.Sheets entry.
-        var key = vm.SheetKeys[vm.SelectedSheetIndex];
+        string key = vm.SheetKeys[vm.SelectedSheetIndex];
         bool original = ModelLocator.Current.Settings.Sheets[key].Landscape;
         vm.CurrentSheet!.Landscape = !original;
-        Assert.Equal (!original, ModelLocator.Current.Settings.Sheets[key].Landscape);
+        Assert.Equal(!original, ModelLocator.Current.Settings.Sheets[key].Landscape);
     }
 
     [Fact]
-    public void SetLandscape_PersistsToCurrentSheet ()
+    public void SetLandscape_PersistsToCurrentSheet()
     {
-        var vm = CreateVm ();
-        vm.LoadSheets ();
-        var key = vm.SheetKeys[vm.SelectedSheetIndex];
+        AppViewModel vm = CreateVm();
+        vm.LoadSheets();
+        string key = vm.SheetKeys[vm.SelectedSheetIndex];
 
-        vm.SetLandscape (true);
-        Assert.True (ModelLocator.Current.Settings.Sheets[key].Landscape);
-        Assert.True (vm.CurrentPageSetup.Landscape);
+        vm.SetLandscape(true);
+        Assert.True(ModelLocator.Current.Settings.Sheets[key].Landscape);
+        Assert.True(vm.CurrentPageSetup.Landscape);
 
-        vm.SetLandscape (false);
-        Assert.False (ModelLocator.Current.Settings.Sheets[key].Landscape);
-        Assert.False (vm.CurrentPageSetup.Landscape);
+        vm.SetLandscape(false);
+        Assert.False(ModelLocator.Current.Settings.Sheets[key].Landscape);
+        Assert.False(vm.CurrentPageSetup.Landscape);
     }
 
     [Fact]
-    public void SetRowsColumnsPadding_PersistToCurrentSheet ()
+    public void SetRowsColumnsPadding_PersistToCurrentSheet()
     {
-        var vm = CreateVm ();
-        vm.LoadSheets ();
-        var key = vm.SheetKeys[vm.SelectedSheetIndex];
+        AppViewModel vm = CreateVm();
+        vm.LoadSheets();
+        string key = vm.SheetKeys[vm.SelectedSheetIndex];
 
-        vm.SetRows (3);
-        vm.SetColumns (4);
-        vm.SetPadding (250);
+        vm.SetRows(3);
+        vm.SetColumns(4);
+        vm.SetPadding(250);
 
-        Assert.Equal (3, ModelLocator.Current.Settings.Sheets[key].Rows);
-        Assert.Equal (4, ModelLocator.Current.Settings.Sheets[key].Columns);
-        Assert.Equal (250, ModelLocator.Current.Settings.Sheets[key].Padding);
+        Assert.Equal(3, ModelLocator.Current.Settings.Sheets[key].Rows);
+        Assert.Equal(4, ModelLocator.Current.Settings.Sheets[key].Columns);
+        Assert.Equal(250, ModelLocator.Current.Settings.Sheets[key].Padding);
     }
 
     [Fact]
-    public void SetMargins_PersistsAndUpdatesPageSetup ()
+    public void SetMargins_PersistsAndUpdatesPageSetup()
     {
-        var vm = CreateVm ();
-        vm.LoadSheets ();
-        var key = vm.SheetKeys[vm.SelectedSheetIndex];
+        AppViewModel vm = CreateVm();
+        vm.LoadSheets();
+        string key = vm.SheetKeys[vm.SelectedSheetIndex];
 
-        var margins = new PrintMargins (10, 20, 30, 40);
-        vm.SetMargins (margins);
+        var margins = new PrintMargins(10, 20, 30, 40);
+        vm.SetMargins(margins);
 
-        var saved = ModelLocator.Current.Settings.Sheets[key].Margins;
-        Assert.Equal (10, saved.Left);
-        Assert.Equal (20, saved.Right);
-        Assert.Equal (30, saved.Top);
-        Assert.Equal (40, saved.Bottom);
+        PrintMargins saved = ModelLocator.Current.Settings.Sheets[key].Margins;
+        Assert.Equal(10, saved.Left);
+        Assert.Equal(20, saved.Right);
+        Assert.Equal(30, saved.Top);
+        Assert.Equal(40, saved.Bottom);
 
-        Assert.Equal (30, vm.CurrentPageSetup.MarginTop);
-        Assert.Equal (40, vm.CurrentPageSetup.MarginBottom);
-        Assert.Equal (10, vm.CurrentPageSetup.MarginLeft);
-        Assert.Equal (20, vm.CurrentPageSetup.MarginRight);
+        Assert.Equal(30, vm.CurrentPageSetup.MarginTop);
+        Assert.Equal(40, vm.CurrentPageSetup.MarginBottom);
+        Assert.Equal(10, vm.CurrentPageSetup.MarginLeft);
+        Assert.Equal(20, vm.CurrentPageSetup.MarginRight);
     }
 
     [Fact]
-    public void SetHeaderFooter_PersistToCurrentSheet ()
+    public void SetHeaderFooter_PersistToCurrentSheet()
     {
-        var vm = CreateVm ();
-        vm.LoadSheets ();
-        var key = vm.SheetKeys[vm.SelectedSheetIndex];
+        AppViewModel vm = CreateVm();
+        vm.LoadSheets();
+        string key = vm.SheetKeys[vm.SelectedSheetIndex];
 
-        vm.SetHeaderEnabled (false);
-        vm.SetHeaderText ("CUSTOM-H");
-        vm.SetFooterEnabled (true);
-        vm.SetFooterText ("CUSTOM-F");
+        vm.SetHeaderEnabled(false);
+        vm.SetHeaderText("CUSTOM-H");
+        vm.SetFooterEnabled(true);
+        vm.SetFooterText("CUSTOM-F");
 
-        var s = ModelLocator.Current.Settings.Sheets[key];
-        Assert.False (s.Header.Enabled);
-        Assert.Equal ("CUSTOM-H", s.Header.Text);
-        Assert.True (s.Footer.Enabled);
-        Assert.Equal ("CUSTOM-F", s.Footer.Text);
+        SheetSettings s = ModelLocator.Current.Settings.Sheets[key];
+        Assert.False(s.Header.Enabled);
+        Assert.Equal("CUSTOM-H", s.Header.Text);
+        Assert.True(s.Footer.Enabled);
+        Assert.Equal("CUSTOM-F", s.Footer.Text);
     }
 
     [Fact]
-    public void SelectSheetByNameOrId_FindsByFriendlyName ()
+    public void SelectSheetByNameOrId_FindsByFriendlyName()
     {
-        var vm = CreateVm ();
-        vm.LoadSheets ();
-        Assert.True (vm.SheetNames.Count > 1);
+        AppViewModel vm = CreateVm();
+        vm.LoadSheets();
+        Assert.True(vm.SheetNames.Count > 1);
 
         // Switch to a different sheet by friendly name.
         string targetName = vm.SheetNames[vm.SelectedSheetIndex == 0 ? 1 : 0];
-        bool ok = vm.SelectSheetByNameOrId (targetName);
-        Assert.True (ok);
-        Assert.Equal (targetName, vm.SheetNames[vm.SelectedSheetIndex]);
+        bool ok = vm.SelectSheetByNameOrId(targetName);
+        Assert.True(ok);
+        Assert.Equal(targetName, vm.SheetNames[vm.SelectedSheetIndex]);
     }
 
     [Fact]
-    public async Task LoadFileAsync_MissingFile_SetsErrorPrefixedStatus ()
+    public async Task LoadFileAsync_MissingFile_SetsErrorPrefixedStatus()
     {
-        var vm = CreateVm ();
-        vm.LoadSheets ();
+        AppViewModel vm = CreateVm();
+        vm.LoadSheets();
 
-        bool ok = await vm.LoadFileAsync (@"C:\nope\does-not-exist-xyz123.txt");
+        bool ok = await vm.LoadFileAsync(@"C:\nope\does-not-exist-xyz123.txt");
 
-        Assert.False (ok);
-        Assert.StartsWith ("Error:", vm.StatusText);
-        Assert.False (vm.IsFileLoaded);
+        Assert.False(ok);
+        Assert.StartsWith("Error:", vm.StatusText);
+        Assert.False(vm.IsFileLoaded);
     }
 
     [Fact]
-    public async Task LoadFileAsync_EmptyPath_SetsErrorPrefixedStatus ()
+    public async Task LoadFileAsync_EmptyPath_SetsErrorPrefixedStatus()
     {
-        var vm = CreateVm ();
-        vm.LoadSheets ();
+        AppViewModel vm = CreateVm();
+        vm.LoadSheets();
 
-        bool ok = await vm.LoadFileAsync ("");
+        bool ok = await vm.LoadFileAsync("");
 
-        Assert.False (ok);
-        Assert.StartsWith ("Error:", vm.StatusText);
+        Assert.False(ok);
+        Assert.StartsWith("Error:", vm.StatusText);
     }
 
     [Fact]
-    public void ApplyOptions_AppliesLandscapeSheetPrinterAndPaper ()
+    public void ApplyOptions_AppliesLandscapeSheetPrinterAndPaper()
     {
-        var vm = CreateVm ();
-        vm.LoadSheets ();
+        AppViewModel vm = CreateVm();
+        vm.LoadSheets();
 
-        Assert.True (vm.SheetNames.Count > 1);
+        Assert.True(vm.SheetNames.Count > 1);
         string targetSheet = vm.SheetNames[vm.SelectedSheetIndex == 0 ? 1 : 0];
 
         var options = new Options
@@ -209,187 +211,196 @@ public class AppViewModelTests : TestServicesBase
             PaperSize = "Letter"
         };
 
-        string? file = vm.ApplyOptions (
+        string? file = vm.ApplyOptions(
             options,
-            availablePrinters: new[] { "FakePrinter", "OtherPrinter" },
-            availablePaperSizes: new[] { "Letter", "A4" });
+            new[] { "FakePrinter", "OtherPrinter" },
+            new[] { "Letter", "A4" });
 
-        Assert.Null (file);
-        Assert.Equal (targetSheet, vm.SheetNames[vm.SelectedSheetIndex]);
-        Assert.True (vm.CurrentSheet!.Landscape);
-        Assert.Equal ("FakePrinter", vm.SelectedPrinter);
-        Assert.Equal ("Letter", vm.SelectedPaperSize);
+        Assert.Null(file);
+        Assert.Equal(targetSheet, vm.SheetNames[vm.SelectedSheetIndex]);
+        Assert.True(vm.CurrentSheet!.Landscape);
+        Assert.Equal("FakePrinter", vm.SelectedPrinter);
+        Assert.Equal("Letter", vm.SelectedPaperSize);
     }
 
     [Fact]
-    public void ApplyOptions_PortraitFlagForcesPortrait ()
+    public void ApplyOptions_PortraitFlagForcesPortrait()
     {
-        var vm = CreateVm ();
-        vm.LoadSheets ();
-        vm.SetLandscape (true);
+        AppViewModel vm = CreateVm();
+        vm.LoadSheets();
+        vm.SetLandscape(true);
 
-        vm.ApplyOptions (new Options { Portrait = true });
+        vm.ApplyOptions(new Options { Portrait = true });
 
-        Assert.False (vm.CurrentSheet!.Landscape);
+        Assert.False(vm.CurrentSheet!.Landscape);
     }
 
     [Fact]
-    public void ApplyOptions_ReturnsFirstFile ()
+    public void ApplyOptions_ReturnsFirstFile()
     {
-        var vm = CreateVm ();
-        vm.LoadSheets ();
+        AppViewModel vm = CreateVm();
+        vm.LoadSheets();
 
-        string? f = vm.ApplyOptions (new Options
+        string? f = vm.ApplyOptions(new Options
         {
             Files = new[] { "a.txt", "b.txt" }
         });
 
-        Assert.Equal ("a.txt", f);
+        Assert.Equal("a.txt", f);
     }
 
     [Fact]
-    public void ApplyOptions_IgnoresUnknownPrinter ()
+    public void ApplyOptions_IgnoresUnknownPrinter()
     {
-        var vm = CreateVm ();
-        vm.LoadSheets ();
+        AppViewModel vm = CreateVm();
+        vm.LoadSheets();
         vm.SelectedPrinter = "Existing";
 
-        vm.ApplyOptions (
+        vm.ApplyOptions(
             new Options { Printer = "NotInList" },
-            availablePrinters: new[] { "Existing" });
+            new[] { "Existing" });
 
-        Assert.Equal ("Existing", vm.SelectedPrinter);
+        Assert.Equal("Existing", vm.SelectedPrinter);
     }
 
     [Fact]
-    public void RestorePrinterSelection_PrefersSavedThenDefaultThenFirst ()
+    public void RestorePrinterSelection_PrefersSavedThenDefaultThenFirst()
     {
-        var vm = CreateVm ();
-        vm.LoadSheets ();
-        var printers = new[] { "Brother", "Canon", "HP" };
+        AppViewModel vm = CreateVm();
+        vm.LoadSheets();
+        string[] printers = ["Brother", "Canon", "HP"];
 
         // No saved, no default → first.
         ModelLocator.Current.Settings.LastPrinter = null;
-        vm.RestorePrinterSelection (printers, null);
-        Assert.Equal ("Brother", vm.SelectedPrinter);
+        vm.RestorePrinterSelection(printers, null);
+        Assert.Equal("Brother", vm.SelectedPrinter);
 
         // Default available → default.
-        vm.RestorePrinterSelection (printers, "Canon");
-        Assert.Equal ("Canon", vm.SelectedPrinter);
+        vm.RestorePrinterSelection(printers, "Canon");
+        Assert.Equal("Canon", vm.SelectedPrinter);
 
         // Saved available → saved (wins over default).
         ModelLocator.Current.Settings.LastPrinter = "HP";
-        vm.RestorePrinterSelection (printers, "Canon");
-        Assert.Equal ("HP", vm.SelectedPrinter);
+        vm.RestorePrinterSelection(printers, "Canon");
+        Assert.Equal("HP", vm.SelectedPrinter);
 
         // Saved unavailable → default.
         ModelLocator.Current.Settings.LastPrinter = "Epson";
-        vm.RestorePrinterSelection (printers, "Canon");
-        Assert.Equal ("Canon", vm.SelectedPrinter);
+        vm.RestorePrinterSelection(printers, "Canon");
+        Assert.Equal("Canon", vm.SelectedPrinter);
     }
 
     [Fact]
-    public void RestorePaperSize_AppliesOnlyWhenSavedAvailable ()
+    public void RestorePaperSize_AppliesOnlyWhenSavedAvailable()
     {
-        var vm = CreateVm ();
-        vm.LoadSheets ();
+        AppViewModel vm = CreateVm();
+        vm.LoadSheets();
         vm.SelectedPaperSize = "Initial";
 
         ModelLocator.Current.Settings.LastPaperSize = "A4";
-        vm.RestorePaperSize (new[] { "Letter", "A4" });
-        Assert.Equal ("A4", vm.SelectedPaperSize);
+        vm.RestorePaperSize(new[] { "Letter", "A4" });
+        Assert.Equal("A4", vm.SelectedPaperSize);
 
         ModelLocator.Current.Settings.LastPaperSize = "Foolscap";
-        vm.RestorePaperSize (new[] { "Letter", "A4" });
-        Assert.Equal ("A4", vm.SelectedPaperSize); // unchanged
+        vm.RestorePaperSize(new[] { "Letter", "A4" });
+        Assert.Equal("A4", vm.SelectedPaperSize); // unchanged
     }
 
     [Fact]
-    public void SaveWindowState_Normal_StoresBoundsAndState ()
+    public void SaveWindowState_Normal_StoresBoundsAndState()
     {
-        var vm = CreateVm ();
-        vm.LoadSheets ();
+        AppViewModel vm = CreateVm();
+        vm.LoadSheets();
         vm.SelectedPrinter = "MyPrinter";
         vm.SelectedPaperSize = "Letter";
 
-        string fileName = $"WinPrint.{nameof (AppViewModelTests)}.{Guid.NewGuid ():N}.json";
-        var prevName = ServiceLocator.Current.SettingsService.SettingsFileName;
+        string fileName = $"WinPrint.{nameof(AppViewModelTests)}.{Guid.NewGuid():N}.json";
+        string prevName = ServiceLocator.Current.SettingsService.SettingsFileName;
         try
         {
             ServiceLocator.Current.SettingsService.SettingsFileName = fileName;
-            vm.SaveWindowState (100, 200, 1024, 768, isMaximized: false);
+            vm.SaveWindowState(100, 200, 1024, 768, false);
 
-            var s = ModelLocator.Current.Settings;
-            Assert.Equal (FormWindowState.Normal, s.WindowState);
-            Assert.Equal (100, s.Location!.X);
-            Assert.Equal (200, s.Location.Y);
-            Assert.Equal (1024, s.Size!.Width);
-            Assert.Equal (768, s.Size.Height);
-            Assert.Equal ("MyPrinter", s.LastPrinter);
-            Assert.Equal ("Letter", s.LastPaperSize);
+            Settings s = ModelLocator.Current.Settings;
+            Assert.Equal(FormWindowState.Normal, s.WindowState);
+            Assert.Equal(100, s.Location!.X);
+            Assert.Equal(200, s.Location.Y);
+            Assert.Equal(1024, s.Size!.Width);
+            Assert.Equal(768, s.Size.Height);
+            Assert.Equal("MyPrinter", s.LastPrinter);
+            Assert.Equal("Letter", s.LastPaperSize);
         }
         finally
         {
             ServiceLocator.Current.SettingsService.SettingsFileName = prevName;
-            if (File.Exists (fileName)) { File.Delete (fileName); }
+            if (File.Exists(fileName))
+            {
+                File.Delete(fileName);
+            }
         }
     }
 
     [Fact]
-    public void SaveWindowState_Maximized_PreservesPreviousNormalBounds ()
+    public void SaveWindowState_Maximized_PreservesPreviousNormalBounds()
     {
-        var vm = CreateVm ();
-        vm.LoadSheets ();
+        AppViewModel vm = CreateVm();
+        vm.LoadSheets();
 
-        string fileName = $"WinPrint.{nameof (AppViewModelTests)}.{Guid.NewGuid ():N}.json";
-        var prevName = ServiceLocator.Current.SettingsService.SettingsFileName;
+        string fileName = $"WinPrint.{nameof(AppViewModelTests)}.{Guid.NewGuid():N}.json";
+        string prevName = ServiceLocator.Current.SettingsService.SettingsFileName;
         try
         {
             ServiceLocator.Current.SettingsService.SettingsFileName = fileName;
 
             // First record normal bounds, then close while maximized.
-            vm.SaveNormalBounds (50, 60, 1280, 720);
-            vm.SaveWindowState (0, 0, 1920, 1080, isMaximized: true);
+            vm.SaveNormalBounds(50, 60, 1280, 720);
+            vm.SaveWindowState(0, 0, 1920, 1080, true);
 
-            var s = ModelLocator.Current.Settings;
-            Assert.Equal (FormWindowState.Maximized, s.WindowState);
+            Settings s = ModelLocator.Current.Settings;
+            Assert.Equal(FormWindowState.Maximized, s.WindowState);
             // Crucially: maximized save MUST NOT overwrite the normal bounds.
-            Assert.Equal (50, s.Location!.X);
-            Assert.Equal (60, s.Location.Y);
-            Assert.Equal (1280, s.Size!.Width);
-            Assert.Equal (720, s.Size.Height);
+            Assert.Equal(50, s.Location!.X);
+            Assert.Equal(60, s.Location.Y);
+            Assert.Equal(1280, s.Size!.Width);
+            Assert.Equal(720, s.Size.Height);
         }
         finally
         {
             ServiceLocator.Current.SettingsService.SettingsFileName = prevName;
-            if (File.Exists (fileName)) { File.Delete (fileName); }
+            if (File.Exists(fileName))
+            {
+                File.Delete(fileName);
+            }
         }
     }
 
     [Fact]
-    public void SaveWindowState_PersistsDefaultSheetSelection ()
+    public void SaveWindowState_PersistsDefaultSheetSelection()
     {
-        var vm = CreateVm ();
-        vm.LoadSheets ();
-        Assert.True (vm.SheetNames.Count > 1);
+        AppViewModel vm = CreateVm();
+        vm.LoadSheets();
+        Assert.True(vm.SheetNames.Count > 1);
 
         int targetIdx = vm.SelectedSheetIndex == 0 ? 1 : 0;
-        vm.SelectSheetByIndex (targetIdx);
-        var expectedKey = vm.SheetKeys[targetIdx];
+        vm.SelectSheetByIndex(targetIdx);
+        string expectedKey = vm.SheetKeys[targetIdx];
 
-        string fileName = $"WinPrint.{nameof (AppViewModelTests)}.{Guid.NewGuid ():N}.json";
-        var prevName = ServiceLocator.Current.SettingsService.SettingsFileName;
+        string fileName = $"WinPrint.{nameof(AppViewModelTests)}.{Guid.NewGuid():N}.json";
+        string prevName = ServiceLocator.Current.SettingsService.SettingsFileName;
         try
         {
             ServiceLocator.Current.SettingsService.SettingsFileName = fileName;
-            vm.SaveWindowState (0, 0, 800, 600, isMaximized: false);
+            vm.SaveWindowState(0, 0, 800, 600, false);
 
-            Assert.Equal (Guid.Parse (expectedKey), ModelLocator.Current.Settings.DefaultSheet);
+            Assert.Equal(Guid.Parse(expectedKey), ModelLocator.Current.Settings.DefaultSheet);
         }
         finally
         {
             ServiceLocator.Current.SettingsService.SettingsFileName = prevName;
-            if (File.Exists (fileName)) { File.Delete (fileName); }
+            if (File.Exists(fileName))
+            {
+                File.Delete(fileName);
+            }
         }
     }
 }

--- a/tools/WinPrint.Analyzers/WinPrintAnalyzers.cs
+++ b/tools/WinPrint.Analyzers/WinPrintAnalyzers.cs
@@ -16,13 +16,13 @@ namespace WinPrint.Analyzers;
 ///     <c>.g.cs</c>, or <c>.g.i.cs</c>, any file under an <c>obj/</c> or <c>bin/</c>
 ///     directory, or any file containing an <c>&lt;auto-generated&gt;</c> header) are exempt.
 /// </summary>
-[DiagnosticAnalyzer (LanguageNames.CSharp)]
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class WinPrintAnalyzers : DiagnosticAnalyzer
 {
     public const string OneTypePerFileId = "WPA0001";
     public const string NoNestedTypesId = "WPA0002";
 
-    private static readonly DiagnosticDescriptor OneTypePerFileRule = new (
+    private static readonly DiagnosticDescriptor OneTypePerFileRule = new(
         OneTypePerFileId,
         "One type per file",
         "File '{0}' declares more than one top-level type ('{1}'); split each type into its own file",
@@ -31,7 +31,7 @@ public sealed class WinPrintAnalyzers : DiagnosticAnalyzer
         true,
         "Each source file must declare exactly one top-level type.");
 
-    private static readonly DiagnosticDescriptor NoNestedTypesRule = new (
+    private static readonly DiagnosticDescriptor NoNestedTypesRule = new(
         NoNestedTypesId,
         "No nested types",
         "Type '{0}' is nested inside '{1}'; promote it to a top-level type in its own file",
@@ -41,63 +41,65 @@ public sealed class WinPrintAnalyzers : DiagnosticAnalyzer
         "Nested type declarations are not allowed. Promote nested types to top-level types in their own files.");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
-        ImmutableArray.Create (OneTypePerFileRule, NoNestedTypesRule);
+        [OneTypePerFileRule, NoNestedTypesRule];
 
-    public override void Initialize (AnalysisContext context)
+    public override void Initialize(AnalysisContext context)
     {
-        context.ConfigureGeneratedCodeAnalysis (GeneratedCodeAnalysisFlags.None);
-        context.EnableConcurrentExecution ();
-        context.RegisterSyntaxTreeAction (AnalyzeSyntaxTree);
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxTreeAction(AnalyzeSyntaxTree);
     }
 
-    private static void AnalyzeSyntaxTree (SyntaxTreeAnalysisContext context)
+    private static void AnalyzeSyntaxTree(SyntaxTreeAnalysisContext context)
     {
         SyntaxTree tree = context.Tree;
-        if (IsGenerated (tree))
+        if (IsGenerated(tree))
         {
             return;
         }
 
-        SyntaxNode root = tree.GetRoot (context.CancellationToken);
+        SyntaxNode root = tree.GetRoot(context.CancellationToken);
 
         // WPA0001 - collect every top-level type declaration in the file.
-        BaseTypeDeclarationSyntax[] topLevelTypes = root
-            .DescendantNodes (node => node is CompilationUnitSyntax or BaseNamespaceDeclarationSyntax)
-            .OfType<BaseTypeDeclarationSyntax> ()
-            .Where (t => t.Parent is CompilationUnitSyntax or BaseNamespaceDeclarationSyntax)
-            .ToArray ();
+        BaseTypeDeclarationSyntax[] topLevelTypes =
+        [
+            .. root
+                .DescendantNodes(node => node is CompilationUnitSyntax or BaseNamespaceDeclarationSyntax)
+                .OfType<BaseTypeDeclarationSyntax>()
+                .Where(t => t.Parent is CompilationUnitSyntax or BaseNamespaceDeclarationSyntax)
+        ];
 
         if (topLevelTypes.Length > 1)
         {
-            string fileName = Path.GetFileName (tree.FilePath);
-            string names = string.Join (", ", topLevelTypes.Select (t => t.Identifier.ValueText));
+            string fileName = Path.GetFileName(tree.FilePath);
+            string names = string.Join(", ", topLevelTypes.Select(t => t.Identifier.ValueText));
             // Report on the second-and-subsequent declarations so the first type
             // (the conventional primary type) stays clean.
             for (int i = 1; i < topLevelTypes.Length; i++)
             {
-                context.ReportDiagnostic (Diagnostic.Create (
+                context.ReportDiagnostic(Diagnostic.Create(
                     OneTypePerFileRule,
-                    topLevelTypes[i].Identifier.GetLocation (),
+                    topLevelTypes[i].Identifier.GetLocation(),
                     fileName,
                     names));
             }
         }
 
         // WPA0002 - flag every type declared inside another type.
-        foreach (BaseTypeDeclarationSyntax nested in root.DescendantNodes ().OfType<BaseTypeDeclarationSyntax> ())
+        foreach (BaseTypeDeclarationSyntax nested in root.DescendantNodes().OfType<BaseTypeDeclarationSyntax>())
         {
             if (nested.Parent is BaseTypeDeclarationSyntax outer)
             {
-                context.ReportDiagnostic (Diagnostic.Create (
+                context.ReportDiagnostic(Diagnostic.Create(
                     NoNestedTypesRule,
-                    nested.Identifier.GetLocation (),
+                    nested.Identifier.GetLocation(),
                     nested.Identifier.ValueText,
                     outer.Identifier.ValueText));
             }
         }
     }
 
-    private static bool IsGenerated (SyntaxTree tree)
+    private static bool IsGenerated(SyntaxTree tree)
     {
         string path = tree.FilePath ?? string.Empty;
         if (path.Length == 0)
@@ -105,28 +107,28 @@ public sealed class WinPrintAnalyzers : DiagnosticAnalyzer
             return false;
         }
 
-        string fileName = Path.GetFileName (path);
-        if (fileName.EndsWith (".Designer.cs", StringComparison.OrdinalIgnoreCase) ||
-            fileName.EndsWith (".Generated.cs", StringComparison.OrdinalIgnoreCase) ||
-            fileName.EndsWith (".g.cs", StringComparison.OrdinalIgnoreCase) ||
-            fileName.EndsWith (".g.i.cs", StringComparison.OrdinalIgnoreCase))
+        string fileName = Path.GetFileName(path);
+        if (fileName.EndsWith(".Designer.cs", StringComparison.OrdinalIgnoreCase) ||
+            fileName.EndsWith(".Generated.cs", StringComparison.OrdinalIgnoreCase) ||
+            fileName.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase) ||
+            fileName.EndsWith(".g.i.cs", StringComparison.OrdinalIgnoreCase))
         {
             return true;
         }
 
-        string normalized = path.Replace ('\\', '/');
-        if (normalized.Contains ("/obj/") || normalized.Contains ("/bin/"))
+        string normalized = path.Replace('\\', '/');
+        if (normalized.Contains("/obj/") || normalized.Contains("/bin/"))
         {
             return true;
         }
 
         // Check for an <auto-generated> header in the leading trivia.
-        SyntaxNode root = tree.GetRoot ();
-        SyntaxTriviaList leading = root.GetLeadingTrivia ();
+        SyntaxNode root = tree.GetRoot();
+        SyntaxTriviaList leading = root.GetLeadingTrivia();
         foreach (SyntaxTrivia trivia in leading)
         {
-            string text = trivia.ToString ();
-            if (text.IndexOf ("<auto-generated", StringComparison.OrdinalIgnoreCase) >= 0)
+            string text = trivia.ToString();
+            if (text.IndexOf("<auto-generated", StringComparison.OrdinalIgnoreCase) >= 0)
             {
                 return true;
             }


### PR DESCRIPTION
## Summary

Adds a **cross-platform** Content Type Engine for **Markdown** (`text/x-markdown`, `*.md`), and—because verifying it properly required it—reengineers the text rendering path so Content Type Engines can render and be tested on any platform, plus new cross-platform rendering test infrastructure.

`text/x-markdown` already existed in `FileTypeMapping.json` but no CTE claimed it, so `.md` fell through to the syntax highlighter. `MarkdownCte` now claims it, using [Markdig](https://github.com/xoofx/markdig) to flatten Markdown to plain text and rendering it through the shared text pipeline.

> **Note on Markdig:** Markdig is fully cross-platform (pure managed; ships `netstandard2.0`/`net8.0`/`net10.0`). The Markdown→text conversion was never the platform constraint — the *rendering* was, because `TextCte` (MarkdownCte's base) used `System.Drawing` directly. This PR removes that constraint.

## Rendering made cross-platform

`PaintPage` already drew through the `IGraphicsContext` abstraction; only the reflow/measurement path still called `System.Drawing`. This PR routes reflow through the same abstraction:

- **`IGraphicsFont.GetHeight(dpi)`** added; `SystemDrawingFont` implements it via `Font.GetHeight` (identical to the old line-height math).
- **`ContentTypeEngineBase`** gains an injectable `MeasurementContext`. The `System.Drawing` `StringFormat` static is now lazily initialized so the type can load without GDI+ (e.g. the Windows-targeted test assembly running on Linux CI).
- **`TextCte`** reflow (`LineWrapDocument`/`AddLine`/`ExpandFormFeeds`) and `_cachedFont` now use `IGraphicsContext`/`IGraphicsFont`; the `System.Drawing` measurement helpers are gone.
- **Windows production path is preserved**: when no `MeasurementContext` is injected, `RenderAsync` builds a `System.Drawing`-backed context (`WindowsMeasurementContext`, Windows-only) exactly as before — same font (`Pixel`, `size/72*96`), same `Display`-unit graphics, same `MeasureString`.
- `TextCte`/`MarkdownCte` are no longer gated to Windows; only `TextMateCte` (still `System.Drawing`-bound) and `WindowsMeasurementContext` remain Windows-only. `Settings` exposes the Text/Markdown engine settings on all platforms. MAUI `MauiFont`/`CoreGraphicsFont` implement the new `GetHeight`.

## Cross-platform rendering test infrastructure (new)

There was no rendering test infra before. Added:

- **`RecordingGraphicsContext`** — a `System.Drawing`-free `IGraphicsContext` test double that records every draw operation and measures with a deterministic fixed-pitch model (10pt/char, 20pt/line), so page counts and wrap points are exact and assertable on any OS. It needs no GDI+ and no logger.
- **`CteRenderingTests`** — drives the full `SetDocument → RenderAsync → PaintPage` pipeline for `TextCte` and `MarkdownCte`, asserting page counts, long-line wrapping, line-number gutter layout (+ separator line), and the exact text/coordinates painted.

## Verification

Built `WinPrint.Core` (**both** `net10.0` and `net10.0-windows`), `WinPrint.cli`, `WinPrint.WinForms`, and the test project — all green. Ran the suite on **Linux**:
- The 5 `CteRenderingTests` and all 7 `MarkdownCteTests` **pass** — i.e. Markdown rendering is genuinely exercised cross-platform.
- Remaining suite failures on Linux are pre-existing environment limitations unrelated to this change: the *old* `TextCte`/`TextMate` render tests construct real `System.Drawing` objects in test code (no GDI+ on this box), `PrintMarginsRegressionTests` P/Invokes `USER32.dll`, and Pygments/date-macro tests depend on external tooling/filesystem. These pass on the Windows CI and serve as the regression guard for the `System.Drawing` measurement path, which I could not execute here.

## Not covered
- `TextMateCte` was left `System.Drawing`-bound (out of scope); only the text/markdown engines were made cross-platform.
- The MAUI `GetHeight` implementations are point-space approximations (the MAUI render surface is still a stub) pending real MAUI text-metrics integration; they keep the MAUI project compiling.

https://claude.ai/code/session_01NrcwMcieTftQCjVg9D28Cz