### PR TITLE
Add VS Code dev environment configs and contributor guide (#64)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,14 @@ bld/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/
-.vscode/
+
+# VS Code: ignore per-user state, but commit the shared workspace configs
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/*.code-snippets
 
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    // Extensions recommended for developing winprint in VS Code on Windows, macOS, or Linux.
+    // VS Code prompts to install these the first time the folder is opened.
+    "recommendations": [
+        "ms-dotnettools.csdevkit",
+        "ms-dotnettools.csharp",
+        "ms-dotnettools.dotnet-maui",
+        "editorconfig.editorconfig"
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,48 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // winprint CLI. net10.0-windows today, so this runs on Windows.
+            // Put CLI arguments (e.g. a file to print, "--what-if") in "args".
+            "name": "WinPrint.cli",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build-cli",
+            "program": "${workspaceFolder}/src/WinPrint.cli/bin/Debug/net10.0-windows/winprint.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/src/WinPrint.cli",
+            "console": "integratedTerminal",
+            "stopAtEntry": false
+        },
+        {
+            // winprint WinForms GUI (winprintgui). Windows only.
+            "name": "WinPrint.WinForms (Windows)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build-solution",
+            "program": "${workspaceFolder}/src/WinPrint.WinForms/bin/Debug/net10.0-windows/winprintgui.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/src/WinPrint.WinForms",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            // MAUI app on Windows. Requires `dotnet workload install maui`.
+            "name": "WinPrint.Maui (Windows)",
+            "type": "maui",
+            "request": "launch",
+            "preLaunchTask": "",
+            "project": "${workspaceFolder}/src/WinPrint.Maui/WinPrint.Maui.csproj",
+            "targetFramework": "net10.0-windows10.0.19041.0"
+        },
+        {
+            // MAUI app on Mac Catalyst. Requires `dotnet workload install maui`.
+            "name": "WinPrint.Maui (Mac Catalyst)",
+            "type": "maui",
+            "request": "launch",
+            "preLaunchTask": "",
+            "project": "${workspaceFolder}/src/WinPrint.Maui/WinPrint.Maui.csproj",
+            "targetFramework": "net10.0-maccatalyst"
+        }
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,28 +19,31 @@
             "name": "WinPrint.WinForms (Windows)",
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "build-solution",
-            "program": "${workspaceFolder}/src/WinPrint.WinForms/bin/Debug/net10.0-windows/winprintgui.dll",
+            "preLaunchTask": "build-winforms",
+            "program": "${workspaceFolder}/src/WinPrint.WinForms/bin/x64/Debug/net10.0-windows/winprintgui.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/WinPrint.WinForms",
             "console": "internalConsole",
             "stopAtEntry": false
         },
         {
-            // MAUI app on Windows. Requires `dotnet workload install maui`.
+            // MAUI app on Windows. This project is unpackaged, so launch the built EXE
+            // directly instead of relying on the MAUI debug adapter to deploy it.
             "name": "WinPrint.Maui (Windows)",
-            "type": "maui",
+            "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "",
-            "project": "${workspaceFolder}/src/WinPrint.Maui/WinPrint.Maui.csproj",
-            "targetFramework": "net10.0-windows10.0.19041.0"
+            "preLaunchTask": "build-maui-windows",
+            "program": "${workspaceFolder}/src/WinPrint.Maui/bin/x64/Debug/net10.0-windows10.0.19041.0/win-x64/WinPrint.Maui.exe",
+            "args": [],
+            "cwd": "${workspaceFolder}/src/WinPrint.Maui",
+            "console": "internalConsole",
+            "stopAtEntry": false
         },
         {
             // MAUI app on Mac Catalyst. Requires `dotnet workload install maui`.
             "name": "WinPrint.Maui (Mac Catalyst)",
             "type": "maui",
             "request": "launch",
-            "preLaunchTask": "",
             "project": "${workspaceFolder}/src/WinPrint.Maui/WinPrint.Maui.csproj",
             "targetFramework": "net10.0-maccatalyst"
         }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,35 @@
+{
+    // Load the solution explicitly so the C# Dev Kit doesn't have to guess.
+    "dotnet.defaultSolution": "src/WinPrint.slnx",
+
+    // Use the C# Dev Kit / Roslyn language service (not OmniSharp).
+    // NOTE: the legacy "omnisharp.useGlobalMono" setting is obsolete and intentionally
+    // omitted — the C# Dev Kit does not use OmniSharp or Mono.
+    "dotnet.preferCSharpExtension": false,
+
+    // Format on save, driven by .editorconfig. Organize-imports is left OFF on purpose:
+    // it hoists `using`s out of the `#if WINDOWS` blocks this repo relies on for its
+    // multi-TFM build, which the CI style gate then rejects.
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+        "source.organizeImports": "never"
+    },
+    "[csharp]": {
+        "editor.defaultFormatter": "ms-dotnettools.csharp",
+        "editor.formatOnSave": true
+    },
+
+    // Keep build output out of the explorer, search, and the file watcher.
+    "files.exclude": {
+        "**/bin": true,
+        "**/obj": true
+    },
+    "search.exclude": {
+        "**/bin": true,
+        "**/obj": true
+    },
+    "files.watcherExclude": {
+        "**/bin/**": true,
+        "**/obj/**": true
+    }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,83 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            // Default build (Ctrl/Cmd+Shift+B).
+            // Windows: build the whole solution (the everyday Windows experience).
+            // macOS/Linux: build Core only — the WinForms/MAUI-Windows TFMs can't build there,
+            // and the base args below keep the default safe and fast cross-platform.
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/src/WinPrint.Core/WinPrint.Core.csproj"
+            ],
+            "windows": {
+                "args": [
+                    "build",
+                    "${workspaceFolder}/src/WinPrint.slnx",
+                    "/p:Platform=x64"
+                ]
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": "$msCompile"
+        },
+        {
+            // CLI app. net10.0-windows today (see CONTRIBUTING.md) — builds on Windows.
+            "label": "build-cli",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/src/WinPrint.cli/WinPrint.cli.csproj"
+            ],
+            "group": "build",
+            "problemMatcher": "$msCompile"
+        },
+        {
+            // Full solution. Needs the MAUI workload installed (`dotnet workload install maui`);
+            // the WinForms/MAUI-Windows targets only build on Windows.
+            "label": "build-solution",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/src/WinPrint.slnx",
+                "/p:Platform=x64"
+            ],
+            "group": "build",
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "test",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "test",
+                "${workspaceFolder}/tests/WinPrint.Core.UnitTests/WinPrint.Core.UnitTests.csproj"
+            ],
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish-cli",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/src/WinPrint.cli/WinPrint.cli.csproj",
+                "-c",
+                "Release"
+            ],
+            "group": "build",
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -53,6 +53,70 @@
             "problemMatcher": "$msCompile"
         },
         {
+            // WinForms GUI. Build this directly for debugging so F5 does not require MAUI workloads.
+            "label": "build-winforms",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/src/WinPrint.WinForms/WinPrint.WinForms.csproj",
+                "/p:Platform=x64"
+            ],
+            "windows": {
+                "command": "${env:ProgramFiles}\\dotnet\\dotnet.exe",
+                "options": {
+                    "env": {
+                        "DOTNET_ROOT": "${env:ProgramFiles}\\dotnet"
+                    }
+                }
+            },
+            "group": "build",
+            "problemMatcher": "$msCompile"
+        },
+        {
+            // MAUI Windows app. Requires the MAUI workload installed (`dotnet workload install maui`).
+            "label": "build-maui-windows",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/src/WinPrint.Maui/WinPrint.Maui.csproj",
+                "-f",
+                "net10.0-windows10.0.19041.0",
+                "/p:Platform=x64"
+            ],
+            "windows": {
+                "command": "${env:ProgramFiles}\\dotnet\\dotnet.exe",
+                "options": {
+                    "env": {
+                        "DOTNET_ROOT": "${env:ProgramFiles}\\dotnet"
+                    }
+                }
+            },
+            "group": "build",
+            "problemMatcher": "$msCompile"
+        },
+        {
+            // First-time MAUI setup. Run this if builds fail with NETSDK1147.
+            "label": "restore-maui-workloads",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "workload",
+                "restore",
+                "${workspaceFolder}/src/WinPrint.Maui/WinPrint.Maui.csproj"
+            ],
+            "windows": {
+                "command": "${env:ProgramFiles}\\dotnet\\dotnet.exe",
+                "options": {
+                    "env": {
+                        "DOTNET_ROOT": "${env:ProgramFiles}\\dotnet"
+                    }
+                }
+            },
+            "problemMatcher": []
+        },
+        {
             "label": "test",
             "command": "dotnet",
             "type": "process",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,9 +17,14 @@ debugging winprint in **VS Code** on Windows, macOS, or Linux.
    dotnet workload install maui
    ```
    On **macOS** the Mac Catalyst build additionally needs full **Xcode** (not just the
-   Command Line Tools): install Xcode, then
-   `sudo xcode-select -s /Applications/Xcode.app` and accept the license. Without it the
-   `net10.0-maccatalyst` target fails with "A valid Xcode installation was not found".
+   Command Line Tools), and the version must match what the workload pins — currently
+   **Xcode 26.5** (the `26.5` Apple SDK). Install it, then:
+   ```bash
+   sudo xcode-select -s /Applications/Xcode.app
+   sudo xcodebuild -license accept
+   ```
+   A mismatched Xcode fails with "requires the MacCatalyst 26.5 SDK"; Command Line Tools
+   alone fail with "A valid Xcode installation was not found".
 3. **libgdiplus** (macOS/Linux only) — the Windows `System.Drawing` measurement and the
    full test suite P/Invoke GDI+, which ships natively on Windows. On other platforms:
    ```bash
@@ -82,7 +87,7 @@ dotnet test  tests/WinPrint.Core.UnitTests/WinPrint.Core.UnitTests.csproj
 | `WinPrint.Core.UnitTests` | ✅ | ✅ cross-platform suite; some Windows/GDI+ tests are skipped or env-dependent (see [CLAUDE.md](CLAUDE.md)) |
 | `WinPrint.cli`       |   ✅    | 🟡 compiles (`net10.0-windows` via `EnableWindowsTargeting`) but won't run — printing is `System.Drawing.Printing`/Windows-only. Tracked in #64 |
 | `WinPrint.WinForms`  |   ✅    | 🟡 compiles via `EnableWindowsTargeting`; Windows-only at runtime by design |
-| `WinPrint.Maui`      |   ✅    | 🟡 `net10.0-maccatalyst` builds with the MAUI workload **+ Xcode**; the Windows head only builds on Windows. Runtime not yet verified (#64) |
+| `WinPrint.Maui`      |   ✅    | ✅ `net10.0-maccatalyst` builds with the MAUI workload + Xcode 26.5; the Windows head only builds on Windows. Runtime not yet verified (#64) |
 
 ## Before you push
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,10 @@ debugging winprint in **VS Code** on Windows, macOS, or Linux.
    ```bash
    dotnet workload install maui
    ```
+   On **macOS** the Mac Catalyst build additionally needs full **Xcode** (not just the
+   Command Line Tools): install Xcode, then
+   `sudo xcode-select -s /Applications/Xcode.app` and accept the license. Without it the
+   `net10.0-maccatalyst` target fails with "A valid Xcode installation was not found".
 3. **libgdiplus** (macOS/Linux only) — the Windows `System.Drawing` measurement and the
    full test suite P/Invoke GDI+, which ships natively on Windows. On other platforms:
    ```bash
@@ -76,9 +80,9 @@ dotnet test  tests/WinPrint.Core.UnitTests/WinPrint.Core.UnitTests.csproj
 | -------------------- | :-----: | ------------------------------------------------ |
 | `WinPrint.Core`      |   ✅    | ✅ (`net10.0`)                                   |
 | `WinPrint.Core.UnitTests` | ✅ | ✅ cross-platform suite; some Windows/GDI+ tests are skipped or env-dependent (see [CLAUDE.md](CLAUDE.md)) |
-| `WinPrint.cli`       |   ✅    | ⛔ Windows-only today (real printing via `System.Drawing.Printing`) — tracked in #64 |
-| `WinPrint.WinForms`  |   ✅    | ⛔ Windows-only by design                        |
-| `WinPrint.Maui`      |   ✅    | 🟡 Mac Catalyst target builds with the MAUI workload; runtime not yet verified (#64) |
+| `WinPrint.cli`       |   ✅    | 🟡 compiles (`net10.0-windows` via `EnableWindowsTargeting`) but won't run — printing is `System.Drawing.Printing`/Windows-only. Tracked in #64 |
+| `WinPrint.WinForms`  |   ✅    | 🟡 compiles via `EnableWindowsTargeting`; Windows-only at runtime by design |
+| `WinPrint.Maui`      |   ✅    | 🟡 `net10.0-maccatalyst` builds with the MAUI workload **+ Xcode**; the Windows head only builds on Windows. Runtime not yet verified (#64) |
 
 ## Before you push
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,9 +12,10 @@ debugging winprint in **VS Code** on Windows, macOS, or Linux.
 
 1. **.NET 10 SDK** — the version is pinned by [`global.json`](global.json). Get it from
    <https://dotnet.microsoft.com/download/dotnet/10.0>. Verify with `dotnet --version`.
-2. **MAUI workload** (only needed to build/run the `WinPrint.Maui` app):
+2. **MAUI workload** (only needed to build/run the `WinPrint.Maui` app). From the
+   repo root, restore the workloads required by the MAUI project:
    ```bash
-   dotnet workload install maui
+   dotnet workload restore src/WinPrint.Maui/WinPrint.Maui.csproj
    ```
    On **macOS** the Mac Catalyst build additionally needs full **Xcode** (not just the
    Command Line Tools), and the version must match what the workload pins — currently
@@ -25,6 +26,11 @@ debugging winprint in **VS Code** on Windows, macOS, or Linux.
    ```
    A mismatched Xcode fails with "requires the MacCatalyst 26.5 SDK"; Command Line Tools
    alone fail with "A valid Xcode installation was not found".
+   You can also run the VS Code task **restore-maui-workloads**. A fresh .NET 10 SDK
+   may report `NETSDK1147` for a specific MAUI workload such as `maui-tizen`; that means
+   the MAUI workload set has not been restored yet.
+   On Windows, restart VS Code after installing the SDK or workload so the integrated
+   terminal and extensions pick up the updated `PATH`.
 3. **libgdiplus** (macOS/Linux only) — the Windows `System.Drawing` measurement and the
    full test suite P/Invoke GDI+, which ships natively on Windows. On other platforms:
    ```bash
@@ -51,6 +57,14 @@ VS Code will prompt to install the recommended extensions
 The solution is loaded automatically from `src/WinPrint.slnx`
 (`dotnet.defaultSolution` in [`.vscode/settings.json`](.vscode/settings.json)).
 
+If starting **WinPrint.Maui (Windows)** shows
+`Couldn't find a debug adapter descriptor for debug type 'maui'`, the .NET MAUI extension
+did not activate. In VS Code or VS Code Insiders, verify that **C# Dev Kit**, **C#**, and
+**.NET MAUI** are installed and enabled, then run **Developer: Reload Window**. If it still
+fails, check **Output → C# Dev Kit** and **Output → .NET MAUI**; the usual causes are
+`dotnet` not being on VS Code's `PATH`, a missing `maui` workload, or C# Dev Kit not being
+signed in/activated.
+
 ## Build, test, debug
 
 ### Tasks (Command Palette → **Tasks: Run Task**, or Ctrl/Cmd+Shift+B for the default)
@@ -60,6 +74,9 @@ The solution is loaded automatically from `src/WinPrint.slnx`
 | `build` *(default)* | **Windows:** full solution. **macOS/Linux:** `WinPrint.Core` only.     |
 | `build-cli`      | Builds `WinPrint.cli` (`winprint`).                                        |
 | `build-solution` | Builds the whole `src/WinPrint.slnx` (needs the MAUI workload).           |
+| `build-winforms` | Builds the WinForms GUI directly for debugging; does not require MAUI.    |
+| `build-maui-windows` | Builds `WinPrint.Maui` for Windows (needs the MAUI workload).        |
+| `restore-maui-workloads` | Restores the MAUI workloads required by `WinPrint.Maui`.        |
 | `test`           | Runs the `WinPrint.Core.UnitTests` suite.                                 |
 | `publish-cli`    | `dotnet publish -c Release` of the CLI.                                   |
 
@@ -76,7 +93,7 @@ dotnet test  tests/WinPrint.Core.UnitTests/WinPrint.Core.UnitTests.csproj
 | ------------------------------- | -------------------------------------------------- |
 | **WinPrint.cli**                | Put CLI args (a file, `--what-if`) in `"args"`.    |
 | **WinPrint.WinForms (Windows)** | The GUI (`winprintgui`). Windows only.             |
-| **WinPrint.Maui (Windows)**     | MAUI app on Windows. Needs the MAUI workload.      |
+| **WinPrint.Maui (Windows)**     | Directly launches the unpackaged Windows MAUI EXE. Needs the MAUI workload. |
 | **WinPrint.Maui (Mac Catalyst)**| MAUI app on macOS. Needs the MAUI workload.        |
 
 ### What builds/runs where today

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,96 @@
-Contributing...
+# Contributing to winprint
+
+Pull requests are welcome. This guide gets you from `git clone` to building, testing, and
+debugging winprint in **VS Code** on Windows, macOS, or Linux.
+
+> winprint started life as a Windows app. **On Windows everything builds, runs, and
+> debugs today.** The cross-platform story (macOS/Linux) is in progress — see
+> [issue #64](https://github.com/tig/winprint/issues/64) and the matrix below for what
+> works where right now.
+
+## Prerequisites
+
+1. **.NET 10 SDK** — the version is pinned by [`global.json`](global.json). Get it from
+   <https://dotnet.microsoft.com/download/dotnet/10.0>. Verify with `dotnet --version`.
+2. **MAUI workload** (only needed to build/run the `WinPrint.Maui` app):
+   ```bash
+   dotnet workload install maui
+   ```
+3. **libgdiplus** (macOS/Linux only) — the Windows `System.Drawing` measurement and the
+   full test suite P/Invoke GDI+, which ships natively on Windows. On other platforms:
+   ```bash
+   brew install mono-libgdiplus          # macOS
+   sudo apt-get install -y libgdiplus    # Debian/Ubuntu
+   ```
+
+## Open in VS Code
+
+```bash
+git clone https://github.com/tig/winprint.git
+cd winprint
+code .
+```
+
+VS Code will prompt to install the recommended extensions
+([`.vscode/extensions.json`](.vscode/extensions.json)) — accept them:
+
+- **C# Dev Kit** (`ms-dotnettools.csdevkit`) + **C#** (`ms-dotnettools.csharp`) — Roslyn
+  language service, build, and debug.
+- **.NET MAUI** (`ms-dotnettools.dotnet-maui`) — MAUI build/debug targets.
+- **EditorConfig** (`editorconfig.editorconfig`) — applies [`.editorconfig`](.editorconfig).
+
+The solution is loaded automatically from `src/WinPrint.slnx`
+(`dotnet.defaultSolution` in [`.vscode/settings.json`](.vscode/settings.json)).
+
+## Build, test, debug
+
+### Tasks (Command Palette → **Tasks: Run Task**, or Ctrl/Cmd+Shift+B for the default)
+
+| Task             | What it does                                                              |
+| ---------------- | ------------------------------------------------------------------------- |
+| `build` *(default)* | **Windows:** full solution. **macOS/Linux:** `WinPrint.Core` only.     |
+| `build-cli`      | Builds `WinPrint.cli` (`winprint`).                                        |
+| `build-solution` | Builds the whole `src/WinPrint.slnx` (needs the MAUI workload).           |
+| `test`           | Runs the `WinPrint.Core.UnitTests` suite.                                 |
+| `publish-cli`    | `dotnet publish -c Release` of the CLI.                                   |
+
+Or from a terminal:
+
+```bash
+dotnet build src/WinPrint.Core/WinPrint.Core.csproj                       # both TFMs
+dotnet test  tests/WinPrint.Core.UnitTests/WinPrint.Core.UnitTests.csproj
+```
+
+### Debug (Run and Debug panel — [`.vscode/launch.json`](.vscode/launch.json))
+
+| Profile                         | Notes                                              |
+| ------------------------------- | -------------------------------------------------- |
+| **WinPrint.cli**                | Put CLI args (a file, `--what-if`) in `"args"`.    |
+| **WinPrint.WinForms (Windows)** | The GUI (`winprintgui`). Windows only.             |
+| **WinPrint.Maui (Windows)**     | MAUI app on Windows. Needs the MAUI workload.      |
+| **WinPrint.Maui (Mac Catalyst)**| MAUI app on macOS. Needs the MAUI workload.        |
+
+### What builds/runs where today
+
+| Project              | Windows | macOS / Linux                                    |
+| -------------------- | :-----: | ------------------------------------------------ |
+| `WinPrint.Core`      |   ✅    | ✅ (`net10.0`)                                   |
+| `WinPrint.Core.UnitTests` | ✅ | ✅ cross-platform suite; some Windows/GDI+ tests are skipped or env-dependent (see [CLAUDE.md](CLAUDE.md)) |
+| `WinPrint.cli`       |   ✅    | ⛔ Windows-only today (real printing via `System.Drawing.Printing`) — tracked in #64 |
+| `WinPrint.WinForms`  |   ✅    | ⛔ Windows-only by design                        |
+| `WinPrint.Maui`      |   ✅    | 🟡 Mac Catalyst target builds with the MAUI workload; runtime not yet verified (#64) |
+
+## Before you push
+
+CI ([`.github/workflows/ci.yml`](.github/workflows/ci.yml)) runs a **style gate** that
+fails the build on any diff. Match it locally:
+
+```bash
+dotnet tool restore
+dotnet jb cleanupcode src/WinPrint.slnx --profile="WinPrintCleanup" --exclude="**/MainPage.xaml.cs"
+dotnet format src/WinPrint.slnx
+git diff --exit-code
+```
+
+The repo also enforces **one top-level type per file** (WPA0001) and **no nested types**
+(WPA0002) via analyzers. There's a `Build.ps1` helper at the repo root for scripted builds.

--- a/src/WinPrint.Core/WinPrint.Core.csproj
+++ b/src/WinPrint.Core/WinPrint.Core.csproj
@@ -72,6 +72,10 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
         <PackageReference Include="MvvmLightLibsStd10" Version="5.4.1.1" />
+        <!-- TextMateSharp pulls in Onigwrap transitively; pin 1.0.11 (over 1.0.10) so the
+             prebuilt maccatalyst libonigwrap.dylib has enough Mach-O header padding for the
+             MAUI bundler's install_name_tool rewrite. 1.0.10 overflows and fails the build. -->
+        <PackageReference Include="Onigwrap" Version="1.0.11" />
         <PackageReference Include="Octokit" Version="13.0.1" />
         <PackageReference Include="Serilog" Version="4.1.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />

--- a/src/WinPrint.Maui/WinPrint.Maui.csproj
+++ b/src/WinPrint.Maui/WinPrint.Maui.csproj
@@ -1,7 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net10.0-windows10.0.19041.0;net10.0-maccatalyst</TargetFrameworks>
+		<!-- MacCatalyst always; the Windows TFM only on Windows so a Mac/Linux build
+		     doesn't try (and fail NETSDK1100) to build the Windows head. -->
+		<TargetFrameworks>net10.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">net10.0-windows10.0.19041.0;net10.0-maccatalyst</TargetFrameworks>
 
 		<!-- Note for MacCatalyst:
 		The default runtime is maccatalyst-x64, except in Release config, in which case the default is maccatalyst-x64;maccatalyst-arm64.

--- a/tools/WinPrint.Analyzers/WinPrint.Analyzers.csproj
+++ b/tools/WinPrint.Analyzers/WinPrint.Analyzers.csproj
@@ -5,6 +5,11 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
 
+    <!-- A Roslyn analyzer is loaded by the compiler host, not run as an app, so it needs
+         no .deps.json. Skipping it also removes the GenerateDepsFile write that multiple
+         consuming projects/TFMs otherwise race on during a parallel solution build. -->
+    <GenerateDependencyFile>false</GenerateDependencyFile>
+
     <!-- Analyzer assemblies run inside Roslyn / OmniSharp hosts that may load older
          versions of these packages. Suppress the build warning. -->
     <NoWarn>$(NoWarn);RS1036;RS2008</NoWarn>


### PR DESCRIPTION
## Summary

First slice of #64: make `git clone && code .` give a working **build / test / debug** experience in VS Code on Windows, Mac, and Linux. **It "just works" on Windows today**, and on Mac/Linux the whole solution now builds except the MAUI Mac Catalyst head (which needs Xcode).

## VS Code configs & docs

- **`.vscode/extensions.json`** — recommends C# Dev Kit, C#, .NET MAUI, EditorConfig.
- **`.vscode/settings.json`** — loads `src/WinPrint.slnx`, format-on-save via `.editorconfig`, organize-imports **off** (it hoists `using`s out of the `#if WINDOWS` blocks the CI style gate enforces), `bin/obj` excluded.
- **`.vscode/tasks.json`** — `build` (OS-aware: full solution on Windows, Core on Mac/Linux), `build-cli`, `build-solution`, `test`, `publish-cli`.
- **`.vscode/launch.json`** — debug profiles for CLI, WinForms, MAUI (Windows), MAUI (Mac Catalyst).
- **`.gitignore`** — was ignoring all of `.vscode/`; switched to "ignore per-user state, commit the shared configs".
- **`CONTRIBUTING.md`** — real contributor guide: prereqs (.NET 10 SDK, MAUI workload, libgdiplus, **Xcode** for Mac Catalyst), open-in-VS-Code flow, task/debug tables, per-OS support matrix, CI style-gate commands.

## Cross-platform build fixes (so `dotnet build` works on Mac/Linux)

- **MAUI Windows TFM is now Windows-only** — the `net10.0-windows10.0.19041.0` head is guarded behind `IsOSPlatform('windows')`, fixing `error NETSDK1100` on Mac. Windows still builds both heads (CI unchanged).
- **Analyzer `deps.json` race removed at the root** — `WinPrint.Analyzers` now sets `GenerateDependencyFile=false` (a Roslyn analyzer needs no deps.json). This is the same race CI dodges by pre-building the analyzer; now a cold parallel solution build is clean.

## Verified on this Mac

- `WinPrint.Core` (both TFMs), `WinPrint.cli`, `WinPrint.WinForms`, and `WinPrint.Core.UnitTests` all build.
- The **only** remaining solution build error is the MAUI `net10.0-maccatalyst` target, which requires the MAUI workload + full Xcode (documented).
- All four `.vscode/*.json` parse; none are gitignored.

## Deferred (tracked in #64)

CLI runtime on Mac/Linux (printing is `System.Drawing.Printing`/Windows-only), MAUI Mac Catalyst runtime verification, the CI matrix, and the libgdiplus test-suite crash on Mac.

Relates to #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)