### PR TITLE
feat: Add WinPrint.TUI Terminal.Gui front end (issue #68, phase 1)

### DIFF
--- a/src/WinPrint.TUI/Program.cs
+++ b/src/WinPrint.TUI/Program.cs
@@ -1,0 +1,18 @@
+using System.Diagnostics;
+using System.Reflection;
+using Terminal.Gui.Cli;
+using WinPrint.TUI;
+
+var assembly = Assembly.GetExecutingAssembly();
+var versionInfo = FileVersionInfo.GetVersionInfo(assembly.Location);
+
+CliHost host = new(options =>
+{
+    options.ApplicationName = "print";
+    options.Version = versionInfo.ProductVersion ?? "0.0.0";
+    options.DefaultCommand = "print";
+});
+
+host.Registry.Register(new TuiCommand());
+
+return await host.RunAsync(args).ConfigureAwait(false);

--- a/src/WinPrint.TUI/README.md
+++ b/src/WinPrint.TUI/README.md
@@ -65,7 +65,8 @@ This is the initial implementation (issue #68, phase 1):
   in phase 1.
 - **Printer/paper enumeration**: Uses text fields rather than dynamic enumeration
   (platform-specific printer discovery is a follow-up).
-- **Font selection**: Uses "Family, Sizept" text entry rather than a font picker dialog.
+- **Font selection**: Uses DropDownList controls for font family and size from a curated
+  list of common monospace and print fonts.
 
 ## Future work
 

--- a/src/WinPrint.TUI/README.md
+++ b/src/WinPrint.TUI/README.md
@@ -1,0 +1,93 @@
+# WinPrint.TUI
+
+A full character-mode Terminal.Gui front end for WinPrint, mirroring the MAUI/WinForms layout.
+
+## Overview
+
+`WinPrint.TUI` produces an executable named `print` that provides a full-screen print preview
+interface in the terminal. It uses [gui-cs/Cli](https://github.com/gui-cs/Cli) as the hosting
+framework with `AppModel.FullScreen`.
+
+## Running
+
+```bash
+dotnet run --project src/WinPrint.TUI -- <file>
+```
+
+Or after building:
+
+```bash
+print <file>
+```
+
+### Command-line options
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--printer` | `-P` | Printer name (defaults to system default) |
+| `--paper-size` | | Paper size supported by the selected printer |
+| `--sheet` | `-s` | Sheet definition name or ID |
+| `--content-type` | `-c` | Content type engine override |
+| `--language` | `-l` | Language override for syntax highlighting |
+
+## Layout
+
+The TUI mirrors the desktop front ends:
+
+- **Left panel**: Settings rail with collapsible groups (Sheet Definition, Margins, Pages Up,
+  Fonts, Printer) matching the MAUI/WinForms ordering and grouping.
+- **Right panel**: Header bar (above), print preview (center), footer bar (below).
+- **Status bar**: Keyboard shortcuts for common operations.
+
+## Terminal requirements
+
+### Sixel support (optional)
+
+For image-based page preview, the terminal must support sixel graphics. Known compatible
+terminals: WezTerm, iTerm2, mlterm, Contour, foot.
+
+Terminals without sixel support show a text-based preview fallback with line numbers and
+page navigation.
+
+### Minimum terminal size
+
+The TUI is usable at 80×24 but works best at 120×40 or larger. The left settings panel
+is fixed at 36 columns; the remaining width is allocated to the preview area.
+
+## Phase 1 limitations
+
+This is the initial implementation (issue #68, phase 1):
+
+- **Preview rendering**: Currently shows a text-mode line-numbered preview. Full PNG
+  rendering through the CTE pipeline with sixel display is wired but pending complete
+  cross-platform graphics integration.
+- **Printing**: Displays an informational message. Use `winprint` CLI for actual printing
+  in phase 1.
+- **Printer/paper enumeration**: Uses text fields rather than dynamic enumeration
+  (platform-specific printer discovery is a follow-up).
+- **Font selection**: Uses "Family, Sizept" text entry rather than a font picker dialog.
+
+## Future work
+
+- **#66 — Native AOT**: The project is designed with AOT compatibility in mind but does
+  not yet publish with `<PublishAot>true</PublishAot>`.
+- **#64 — Cross-platform CI**: The TUI will be included in cross-platform build/test
+  validation once that infrastructure is in place.
+- **#63 — Installer/distribution**: The `print` executable will be included in
+  distribution packages.
+
+## Architecture
+
+- **Hosting**: `gui-cs/Cli` (`Terminal.Gui.Cli`) provides the command registration,
+  lifecycle management, and `AppModel.FullScreen` integration.
+- **Views**: `MainView` (top-level Window), `SettingsPanel` (left rail), `PreviewPanel`
+  (center), `HeaderFooterBar` (above/below preview).
+- **Services**: `PreviewRenderer` (page count and PNG rendering, testable without a
+  terminal), `SixelDetector` (terminal capability detection).
+- **Models**: Shares `WinPrint.Core` models (`Settings`, `SheetSettings`, etc.) with the
+  other front ends.
+
+## Relationship to WinPrint.cli
+
+Both `WinPrint.cli` and `WinPrint.TUI` coexist in the repository. `WinPrint.TUI` will
+eventually replace `WinPrint.cli`, but migration is a separate future effort.

--- a/src/WinPrint.TUI/Services/PreviewRenderer.cs
+++ b/src/WinPrint.TUI/Services/PreviewRenderer.cs
@@ -1,0 +1,54 @@
+using WinPrint.Core.Models;
+
+namespace WinPrint.TUI.Services;
+
+/// <summary>
+///     Renders page previews as PNG images. Separated from Terminal.Gui widgets
+///     so it can be tested without an interactive terminal.
+/// </summary>
+public sealed class PreviewRenderer
+{
+    /// <summary>
+    ///     Counts the total number of pages for the given file and sheet settings.
+    ///     Phase 1 provides a simplified count; full CTE pipeline integration follows.
+    /// </summary>
+    public Task<int> CountPagesAsync(string filePath, SheetSettings sheet)
+    {
+        if (!File.Exists(filePath))
+        {
+            return Task.FromResult(0);
+        }
+
+        // Simplified page count based on line count and sheet configuration
+        int lineCount = File.ReadLines(filePath).Count();
+        int linesPerPage = EstimateLinesPerPage(sheet);
+        int pagesPerSheet = sheet.Rows * sheet.Columns;
+        int totalPages = Math.Max(1, (int)Math.Ceiling((double)lineCount / linesPerPage));
+        int totalSheets = (int)Math.Ceiling((double)totalPages / pagesPerSheet);
+
+        return Task.FromResult(totalSheets);
+    }
+
+    /// <summary>
+    ///     Renders a specific page to PNG bytes.
+    ///     Phase 1 placeholder — returns null until the CTE pipeline is wired for cross-platform rendering.
+    /// </summary>
+    public Task<byte[]?> RenderPageAsync(string filePath, SheetSettings sheet, int pageIndex)
+    {
+        // Phase 1: PNG rendering will be completed when the cross-platform
+        // graphics abstractions from #65 are fully integrated.
+        return Task.FromResult<byte[]?>(null);
+    }
+
+    private static int EstimateLinesPerPage(SheetSettings sheet)
+    {
+        // Rough estimate: assume ~60 lines per page at 8pt font on letter paper
+        float fontSize = sheet.ContentSettings?.Font.Size ?? 8f;
+        double lineHeight = fontSize * 1.2;
+        double pageHeightPoints = sheet.Landscape ? 612 : 792; // Letter paper in points
+        double marginPoints = (sheet.Margins.Top + sheet.Margins.Bottom) * 0.72;
+        double usableHeight = pageHeightPoints - marginPoints;
+
+        return Math.Max(10, (int)(usableHeight / lineHeight));
+    }
+}

--- a/src/WinPrint.TUI/Services/SixelDetector.cs
+++ b/src/WinPrint.TUI/Services/SixelDetector.cs
@@ -24,7 +24,10 @@ public static class SixelDetector
     }
 
     /// <summary>Resets the cached detection result (for testing).</summary>
-    public static void Reset() => s_cached = null;
+    public static void Reset()
+    {
+        s_cached = null;
+    }
 
     private static bool Detect()
     {

--- a/src/WinPrint.TUI/Services/SixelDetector.cs
+++ b/src/WinPrint.TUI/Services/SixelDetector.cs
@@ -1,0 +1,68 @@
+namespace WinPrint.TUI.Services;
+
+/// <summary>
+///     Detects whether the current terminal supports sixel graphics.
+///     Checks the TERM, TERM_PROGRAM environment variables and attempts
+///     a Device Attributes query where practical.
+/// </summary>
+public static class SixelDetector
+{
+    private static bool? s_cached;
+
+    /// <summary>
+    ///     Returns true if the terminal likely supports sixel image rendering.
+    /// </summary>
+    public static bool IsSupported()
+    {
+        if (s_cached.HasValue)
+        {
+            return s_cached.Value;
+        }
+
+        s_cached = Detect();
+        return s_cached.Value;
+    }
+
+    /// <summary>Resets the cached detection result (for testing).</summary>
+    public static void Reset() => s_cached = null;
+
+    private static bool Detect()
+    {
+        // Check known sixel-capable terminals via environment
+        string? termProgram = Environment.GetEnvironmentVariable("TERM_PROGRAM");
+        if (!string.IsNullOrEmpty(termProgram))
+        {
+            string lower = termProgram.ToLowerInvariant();
+            if (lower.Contains("wezterm") ||
+                lower.Contains("iterm") ||
+                lower.Contains("mlterm") ||
+                lower.Contains("contour") ||
+                lower.Contains("foot"))
+            {
+                return true;
+            }
+        }
+
+        string? term = Environment.GetEnvironmentVariable("TERM");
+        if (!string.IsNullOrEmpty(term))
+        {
+            if (term.Contains("sixel", StringComparison.OrdinalIgnoreCase) ||
+                term.Contains("mlterm", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        // Check for SIXEL environment hint (some terminals set this)
+        string? sixelEnv = Environment.GetEnvironmentVariable("SIXEL_SUPPORT");
+        if (!string.IsNullOrEmpty(sixelEnv) &&
+            sixelEnv.Equals("1", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        // Default: not supported. A full implementation would use DA1/DA2 escape sequences
+        // to query the terminal, but that requires async terminal I/O coordination.
+        return false;
+    }
+}

--- a/src/WinPrint.TUI/TuiCommand.cs
+++ b/src/WinPrint.TUI/TuiCommand.cs
@@ -1,0 +1,67 @@
+using Terminal.Gui.App;
+using Terminal.Gui.Cli;
+using WinPrint.Core.Models;
+using WinPrint.Core.Services;
+using WinPrint.TUI.Views;
+
+namespace WinPrint.TUI;
+
+/// <summary>
+///     The main TUI command — opens the full-screen print-preview interface.
+///     Uses CommandKind.Viewer so the host always runs it as AppModel.FullScreen.
+/// </summary>
+public sealed class TuiCommand : IViewerCommand
+{
+    public string PrimaryAlias => "print";
+
+    public IReadOnlyList<string> Aliases { get; } = ["print"];
+
+    public string Description => "Open the WinPrint TUI full-screen print preview.";
+
+    public CommandKind Kind => CommandKind.Viewer;
+
+    public Type ResultType => typeof(void);
+
+    public bool AcceptsPositionalArgs => true;
+
+    public IReadOnlyList<CommandOptionDescriptor> Options { get; } =
+    [
+        new("printer", "P", typeof(string), "Printer name. Defaults to the system default printer.", false, null),
+        new("paper-size", null, typeof(string), "Paper size supported by the selected printer.", false, null),
+        new("sheet", "s", typeof(string), "WinPrint sheet definition name or ID.", false, null),
+        new("content-type", "c", typeof(string), "Content type engine override.", false, null),
+        new("language", "l", typeof(string), "Language override for syntax highlighting.", false, null)
+    ];
+
+    public async Task<CommandResult> RunAsync(
+        IApplication app,
+        string? initial,
+        CommandRunOptions options,
+        CancellationToken cancellationToken)
+    {
+        ServiceLocator.Current.TelemetryService.Start("print");
+        ServiceLocator.Current.LogService.Start("print", null, false, false);
+
+        Settings? settings = SettingsService.Create();
+        if (settings is null)
+        {
+            return new CommandResult(CommandStatus.Error, null, "ConfigError", "Failed to load settings.");
+        }
+
+        string? fileName = options.Arguments.Count > 0 ? options.Arguments[0] : null;
+
+        var mainView = new MainView(app, settings, fileName, options);
+        app.Run(mainView);
+
+        await Task.CompletedTask;
+        return new CommandResult(CommandStatus.Ok, null, null, null);
+    }
+
+    public Task<CommandResult?> RenderCatAsync(
+        CommandRunOptions options,
+        TextWriter stdout,
+        CancellationToken cancellationToken)
+    {
+        return Task.FromResult<CommandResult?>(null);
+    }
+}

--- a/src/WinPrint.TUI/TuiCommand.cs
+++ b/src/WinPrint.TUI/TuiCommand.cs
@@ -40,7 +40,7 @@ public sealed class TuiCommand : IViewerCommand
         CancellationToken cancellationToken)
     {
         ServiceLocator.Current.TelemetryService.Start("print");
-        ServiceLocator.Current.LogService.Start("print", null, false, false);
+        ServiceLocator.Current.LogService.Start("print");
 
         Settings? settings = SettingsService.Create();
         if (settings is null)

--- a/src/WinPrint.TUI/Views/HeaderFooterBar.cs
+++ b/src/WinPrint.TUI/Views/HeaderFooterBar.cs
@@ -5,11 +5,22 @@ using WinPrint.Core.Models;
 namespace WinPrint.TUI.Views;
 
 /// <summary>
-///     Thin bar (1 row) with a checkbox to enable/disable + editable text field
-///     for header or footer macros. Positioned above/below the preview panel.
+///     Thin bar (1 row) with a checkbox to enable/disable + editable TextField
+///     with autocomplete for header/footer macros.
+///     Positioned above/below the preview panel.
 /// </summary>
 public sealed class HeaderFooterBar : View
 {
+    /// <summary>Known macro names for autocomplete suggestions.</summary>
+    public static readonly string[] MacroNames =
+    [
+        "{FileName}", "{Title}", "{FileNameWithoutExtension}", "{FileExtension}",
+        "{FileDirectoryName}", "{FullPath}",
+        "{DatePrinted}", "{DateRevised}", "{DateCreated}",
+        "{Page}", "{NumPages}",
+        "{Language}", "{ContentType}", "{CteName}", "{Style}"
+    ];
+
     private HeaderFooter _model;
     private readonly CheckBox _enabledBox;
     private readonly TextField _textField;
@@ -28,6 +39,12 @@ public sealed class HeaderFooterBar : View
             Text = model.Text ?? string.Empty,
             Enabled = model.Enabled
         };
+
+        // Configure autocomplete for macros
+        if (_textField.Autocomplete is { } autocomplete)
+        {
+            autocomplete.SuggestionGenerator = new MacroSuggestionGenerator();
+        }
 
         _enabledBox = new CheckBox
         {

--- a/src/WinPrint.TUI/Views/HeaderFooterBar.cs
+++ b/src/WinPrint.TUI/Views/HeaderFooterBar.cs
@@ -5,11 +5,14 @@ using WinPrint.Core.Models;
 namespace WinPrint.TUI.Views;
 
 /// <summary>
-///     Inline bar for enabling/configuring a header or footer.
+///     Thin bar (1 row) with a checkbox to enable/disable + editable text field
+///     for header or footer macros. Positioned above/below the preview panel.
 /// </summary>
 public sealed class HeaderFooterBar : View
 {
-    private readonly HeaderFooter _model;
+    private HeaderFooter _model;
+    private readonly CheckBox _enabledBox;
+    private readonly TextField _textField;
 
     public event EventHandler? Changed;
 
@@ -17,32 +20,46 @@ public sealed class HeaderFooterBar : View
     {
         _model = model;
 
-        var enabledBox = new CheckBox
+        _textField = new TextField
+        {
+            X = title.Length + 5,
+            Y = 0,
+            Width = Dim.Fill(),
+            Text = model.Text ?? string.Empty,
+            Enabled = model.Enabled
+        };
+
+        _enabledBox = new CheckBox
         {
             X = 0,
             Y = 0,
             Text = title,
             Value = model.Enabled ? CheckState.Checked : CheckState.None
         };
-        enabledBox.ValueChanged += (_, _) =>
+        _enabledBox.ValueChanged += (_, _) =>
         {
-            _model.Enabled = enabledBox.Value == CheckState.Checked;
+            _model.Enabled = _enabledBox.Value == CheckState.Checked;
+            _textField.Enabled = _model.Enabled;
             Changed?.Invoke(this, EventArgs.Empty);
         };
 
-        var textField = new TextField
+        _textField.TextChanged += (_, _) =>
         {
-            X = title.Length + 5,
-            Y = 0,
-            Width = Dim.Fill(),
-            Text = model.Text ?? string.Empty
-        };
-        textField.TextChanged += (_, _) =>
-        {
-            _model.Text = textField.Text;
+            _model.Text = _textField.Text;
             Changed?.Invoke(this, EventArgs.Empty);
         };
 
-        Add(enabledBox, textField);
+        Add(_enabledBox, _textField);
+    }
+
+    /// <summary>
+    ///     Updates the backing model (e.g. when the active sheet changes).
+    /// </summary>
+    public void UpdateModel(HeaderFooter newModel)
+    {
+        _model = newModel;
+        _enabledBox.Value = newModel.Enabled ? CheckState.Checked : CheckState.None;
+        _textField.Text = newModel.Text ?? string.Empty;
+        _textField.Enabled = newModel.Enabled;
     }
 }

--- a/src/WinPrint.TUI/Views/HeaderFooterBar.cs
+++ b/src/WinPrint.TUI/Views/HeaderFooterBar.cs
@@ -1,0 +1,48 @@
+using Terminal.Gui.ViewBase;
+using Terminal.Gui.Views;
+using WinPrint.Core.Models;
+
+namespace WinPrint.TUI.Views;
+
+/// <summary>
+///     Inline bar for enabling/configuring a header or footer.
+/// </summary>
+public sealed class HeaderFooterBar : View
+{
+    private readonly HeaderFooter _model;
+
+    public event EventHandler? Changed;
+
+    public HeaderFooterBar(string title, HeaderFooter model)
+    {
+        _model = model;
+
+        var enabledBox = new CheckBox
+        {
+            X = 0,
+            Y = 0,
+            Text = title,
+            Value = model.Enabled ? CheckState.Checked : CheckState.None
+        };
+        enabledBox.ValueChanged += (_, _) =>
+        {
+            _model.Enabled = enabledBox.Value == CheckState.Checked;
+            Changed?.Invoke(this, EventArgs.Empty);
+        };
+
+        var textField = new TextField
+        {
+            X = title.Length + 5,
+            Y = 0,
+            Width = Dim.Fill(),
+            Text = model.Text ?? string.Empty
+        };
+        textField.TextChanged += (_, _) =>
+        {
+            _model.Text = textField.Text;
+            Changed?.Invoke(this, EventArgs.Empty);
+        };
+
+        Add(enabledBox, textField);
+    }
+}

--- a/src/WinPrint.TUI/Views/MacroSuggestionGenerator.cs
+++ b/src/WinPrint.TUI/Views/MacroSuggestionGenerator.cs
@@ -1,0 +1,60 @@
+using Terminal.Gui.Drawing;
+using Terminal.Gui.Views;
+
+namespace WinPrint.TUI.Views;
+
+/// <summary>
+///     Autocomplete suggestion generator for header/footer macro tokens.
+///     Triggers on '{' and suggests matching macros as the user types.
+/// </summary>
+public sealed class MacroSuggestionGenerator : ISuggestionGenerator
+{
+    public IEnumerable<Suggestion> GenerateSuggestions(AutocompleteContext context)
+    {
+        string line = CellsToString(context.CurrentLine);
+        int cursor = context.CursorPosition;
+
+        if (cursor > line.Length)
+        {
+            cursor = line.Length;
+        }
+
+        // Find the start of the current macro token (look back for '{')
+        int braceStart = -1;
+        for (int i = cursor - 1; i >= 0; i--)
+        {
+            if (line[i] == '{')
+            {
+                braceStart = i;
+                break;
+            }
+
+            if (line[i] == '}' || line[i] == ' ')
+            {
+                break;
+            }
+        }
+
+        if (braceStart < 0)
+        {
+            return [];
+        }
+
+        string partial = line[braceStart..cursor];
+        int removeCount = partial.Length;
+
+        return HeaderFooterBar.MacroNames
+            .Where(m => m.StartsWith(partial, StringComparison.OrdinalIgnoreCase))
+            .Select(m => new Suggestion(removeCount, m, m));
+    }
+
+    public bool IsWordChar(string rune)
+    {
+        return rune.Length > 0 && (char.IsLetterOrDigit(rune[0]) || rune[0] == '{' || rune[0] == '}');
+    }
+
+    private static string CellsToString(List<Cell> cells)
+    {
+        return string.Concat(cells.Select(c => c.Grapheme ?? string.Empty));
+    }
+}

--- a/src/WinPrint.TUI/Views/MainView.cs
+++ b/src/WinPrint.TUI/Views/MainView.cs
@@ -131,7 +131,10 @@ public sealed class MainView : Window
         RefreshPreview();
     }
 
-    private void OnFileOpenRequested(object? sender, EventArgs e) => OnFileOpenRequested();
+    private void OnFileOpenRequested(object? sender, EventArgs e)
+    {
+        OnFileOpenRequested();
+    }
 
     private void OnFileOpenRequested()
     {
@@ -149,12 +152,16 @@ public sealed class MainView : Window
         }
     }
 
-    private void OnPrintRequested(object? sender, EventArgs e) => OnPrintRequested();
+    private void OnPrintRequested(object? sender, EventArgs e)
+    {
+        OnPrintRequested();
+    }
 
     private void OnPrintRequested()
     {
         // Phase 1: show info message; actual print integration follows
-        MessageBox.Query(_app, "Print", "Printing is not yet implemented in the TUI.\nUse winprint CLI for printing.", "OK");
+        MessageBox.Query(_app, "Print", "Printing is not yet implemented in the TUI.\nUse winprint CLI for printing.",
+            "OK");
     }
 
     private async Task LoadFileAsync(string path)

--- a/src/WinPrint.TUI/Views/MainView.cs
+++ b/src/WinPrint.TUI/Views/MainView.cs
@@ -1,6 +1,7 @@
 using Terminal.Gui.App;
 using Terminal.Gui.Cli;
 using Terminal.Gui.Drawing;
+using Terminal.Gui.Input;
 using Terminal.Gui.ViewBase;
 using Terminal.Gui.Views;
 using WinPrint.Core.Models;
@@ -10,46 +11,159 @@ namespace WinPrint.TUI.Views;
 
 /// <summary>
 ///     Top-level full-screen Window providing two-column layout:
-///     left settings panel and right preview panel.
+///     left settings rail (scrollable) and right preview area with header/footer bars.
 /// </summary>
 public sealed class MainView : Window
 {
     private readonly IApplication _app;
+    private readonly Settings _settings;
     private readonly SettingsPanel _settingsPanel;
     private readonly PreviewPanel _previewPanel;
-    private readonly Settings _settings;
+    private readonly HeaderFooterBar _headerBar;
+    private readonly HeaderFooterBar _footerBar;
+    private string? _filePath;
+    private SheetSettings _currentSheet;
 
     public MainView(IApplication app, Settings settings, string? filePath, CommandRunOptions options)
     {
         _app = app;
         _settings = settings;
+        _filePath = filePath;
+
+        _currentSheet = ResolveCurrentSheet(settings);
 
         Title = "WinPrint — Print Preview";
         BorderStyle = LineStyle.Single;
 
-        _settingsPanel = new SettingsPanel(settings)
+        // Left settings rail
+        _settingsPanel = new SettingsPanel(settings, _currentSheet)
         {
             X = 0,
             Y = 0,
-            Width = 35,
-            Height = Dim.Fill()
+            Width = 36,
+            Height = Dim.Fill(1)
         };
 
-        _previewPanel = new PreviewPanel(filePath)
+        // Right side: header bar (row 0), preview (row 1, fills), footer bar (row 2)
+        var rightPanel = new View
         {
-            X = 36,
+            X = 37,
             Y = 0,
             Width = Dim.Fill(),
-            Height = Dim.Fill()
+            Height = Dim.Fill(1)
         };
 
-        Add(_settingsPanel, _previewPanel);
+        _headerBar = new HeaderFooterBar("Header", _currentSheet.Header)
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = 1
+        };
 
+        _previewPanel = new PreviewPanel(filePath, _currentSheet)
+        {
+            X = 0,
+            Y = 1,
+            Width = Dim.Fill(),
+            Height = Dim.Fill(1),
+            BorderStyle = LineStyle.Single
+        };
+
+        _footerBar = new HeaderFooterBar("Footer", _currentSheet.Footer)
+        {
+            X = 0,
+            Y = Pos.Bottom(_previewPanel),
+            Width = Dim.Fill(),
+            Height = 1
+        };
+
+        rightPanel.Add(_headerBar, _previewPanel, _footerBar);
+        Add(_settingsPanel, rightPanel);
+
+        // Wire up settings changes
         _settingsPanel.SettingsChanged += OnSettingsChanged;
+        _settingsPanel.SheetChanged += OnSheetChanged;
+        _settingsPanel.FileOpenRequested += OnFileOpenRequested;
+        _settingsPanel.PrintRequested += OnPrintRequested;
+        _headerBar.Changed += (_, _) => RefreshPreview();
+        _footerBar.Changed += (_, _) => RefreshPreview();
+
+        // Status bar with keyboard shortcuts
+        var statusBar = new StatusBar([
+            new Shortcut(Key.F1, "Help", () => { }, ""),
+            new Shortcut(Key.O.WithCtrl, "Open", OnFileOpenRequested, ""),
+            new Shortcut(Key.P.WithCtrl, "Print", OnPrintRequested, ""),
+            new Shortcut(Key.PageUp, "PgUp", () => _previewPanel.PreviousPage(), ""),
+            new Shortcut(Key.PageDown, "PgDn", () => _previewPanel.NextPage(), ""),
+            new Shortcut(Key.Q.WithCtrl, "Quit", () => _app.RequestStop(), "")
+        ]);
+        statusBar.Y = Pos.Bottom(rightPanel);
+        Add(statusBar);
+
+        // Load file if specified
+        if (filePath is not null)
+        {
+            _ = Task.Run(() => LoadFileAsync(filePath));
+        }
+    }
+
+    private static SheetSettings ResolveCurrentSheet(Settings settings)
+    {
+        if (settings.Sheets.TryGetValue(settings.DefaultSheet.ToString(), out SheetSettings? sheet))
+        {
+            return sheet;
+        }
+
+        return settings.Sheets.Values.FirstOrDefault() ?? new SheetSettings { Name = "Default" };
     }
 
     private void OnSettingsChanged(object? sender, EventArgs e)
     {
-        _previewPanel.RefreshPreview(_settings);
+        RefreshPreview();
+    }
+
+    private void OnSheetChanged(object? sender, SheetSettings newSheet)
+    {
+        _currentSheet = newSheet;
+        _headerBar.UpdateModel(newSheet.Header);
+        _footerBar.UpdateModel(newSheet.Footer);
+        RefreshPreview();
+    }
+
+    private void OnFileOpenRequested(object? sender, EventArgs e) => OnFileOpenRequested();
+
+    private void OnFileOpenRequested()
+    {
+        var dialog = new OpenDialog
+        {
+            AllowsMultipleSelection = false
+        };
+        dialog.Title = "Open File";
+        _app.Run(dialog);
+
+        if (!dialog.Canceled && dialog.FilePaths.Count > 0)
+        {
+            _filePath = dialog.FilePaths[0];
+            _ = Task.Run(() => LoadFileAsync(_filePath));
+        }
+    }
+
+    private void OnPrintRequested(object? sender, EventArgs e) => OnPrintRequested();
+
+    private void OnPrintRequested()
+    {
+        // Phase 1: show info message; actual print integration follows
+        MessageBox.Query(_app, "Print", "Printing is not yet implemented in the TUI.\nUse winprint CLI for printing.", "OK");
+    }
+
+    private async Task LoadFileAsync(string path)
+    {
+        await _previewPanel.LoadFileAsync(path, _currentSheet);
+    }
+
+    private void RefreshPreview()
+    {
+        _previewPanel.RefreshPreview(_currentSheet);
     }
 }

--- a/src/WinPrint.TUI/Views/MainView.cs
+++ b/src/WinPrint.TUI/Views/MainView.cs
@@ -1,0 +1,55 @@
+using Terminal.Gui.App;
+using Terminal.Gui.Cli;
+using Terminal.Gui.Drawing;
+using Terminal.Gui.ViewBase;
+using Terminal.Gui.Views;
+using WinPrint.Core.Models;
+using WinPrint.TUI.Services;
+
+namespace WinPrint.TUI.Views;
+
+/// <summary>
+///     Top-level full-screen Window providing two-column layout:
+///     left settings panel and right preview panel.
+/// </summary>
+public sealed class MainView : Window
+{
+    private readonly IApplication _app;
+    private readonly SettingsPanel _settingsPanel;
+    private readonly PreviewPanel _previewPanel;
+    private readonly Settings _settings;
+
+    public MainView(IApplication app, Settings settings, string? filePath, CommandRunOptions options)
+    {
+        _app = app;
+        _settings = settings;
+
+        Title = "WinPrint — Print Preview";
+        BorderStyle = LineStyle.Single;
+
+        _settingsPanel = new SettingsPanel(settings)
+        {
+            X = 0,
+            Y = 0,
+            Width = 35,
+            Height = Dim.Fill()
+        };
+
+        _previewPanel = new PreviewPanel(filePath)
+        {
+            X = 36,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = Dim.Fill()
+        };
+
+        Add(_settingsPanel, _previewPanel);
+
+        _settingsPanel.SettingsChanged += OnSettingsChanged;
+    }
+
+    private void OnSettingsChanged(object? sender, EventArgs e)
+    {
+        _previewPanel.RefreshPreview(_settings);
+    }
+}

--- a/src/WinPrint.TUI/Views/PreviewPanel.cs
+++ b/src/WinPrint.TUI/Views/PreviewPanel.cs
@@ -7,43 +7,144 @@ using WinPrint.TUI.Services;
 namespace WinPrint.TUI.Views;
 
 /// <summary>
-///     Central preview panel that renders page content.
-///     In terminals that support sixel, renders images; otherwise shows text-mode preview.
+///     Central preview panel displaying page content.
+///     Supports sixel rendering in capable terminals; shows text-mode fallback otherwise.
 /// </summary>
 public sealed class PreviewPanel : View
 {
-    private readonly string? _filePath;
     private readonly PreviewRenderer _renderer = new();
+    private readonly Label _pageInfoLabel;
+    private readonly Label _contentLabel;
+    private string? _filePath;
+    private int _currentPage;
+    private int _totalPages;
+    private bool _sixelSupported;
 
-    public PreviewPanel(string? filePath)
+    public PreviewPanel(string? filePath, SheetSettings sheet)
     {
         _filePath = filePath;
+        _sixelSupported = SixelDetector.IsSupported();
 
-        BorderStyle = LineStyle.Single;
         Title = "Preview";
 
-        var pageInfo = new Label
+        _pageInfoLabel = new Label
         {
-            X = 0,
+            X = Pos.Center(),
             Y = 0,
-            Width = Dim.Fill(),
-            Text = "Page: 1 / 1"
+            Text = "Page: - / -"
         };
 
-        var contentArea = new Label
+        _contentLabel = new Label
         {
-            X = 0,
+            X = 1,
             Y = 2,
-            Width = Dim.Fill(),
-            Height = Dim.Fill(),
-            Text = filePath is null ? "(No file loaded)" : $"Loading: {filePath}"
+            Width = Dim.Fill(1),
+            Height = Dim.Fill(1),
+            Text = filePath is null
+                ? "No file loaded.\n\nPress Ctrl+O to open a file,\nor pass a file path as argument."
+                : $"Loading: {Path.GetFileName(filePath)}..."
         };
 
-        Add(pageInfo, contentArea);
+        Add(_pageInfoLabel, _contentLabel);
     }
 
-    public void RefreshPreview(Settings settings)
+    public void NextPage()
     {
+        if (_currentPage < _totalPages - 1)
+        {
+            _currentPage++;
+            UpdatePageDisplay();
+        }
+    }
+
+    public void PreviousPage()
+    {
+        if (_currentPage > 0)
+        {
+            _currentPage--;
+            UpdatePageDisplay();
+        }
+    }
+
+    public async Task LoadFileAsync(string filePath, SheetSettings sheet)
+    {
+        _filePath = filePath;
+        _currentPage = 0;
+        _totalPages = await _renderer.CountPagesAsync(filePath, sheet);
+
+        UpdatePageDisplay();
+    }
+
+    public void RefreshPreview(SheetSettings sheet)
+    {
+        if (_filePath is not null)
+        {
+            _ = Task.Run(async () =>
+            {
+                _totalPages = await _renderer.CountPagesAsync(_filePath, sheet);
+                if (_currentPage >= _totalPages)
+                {
+                    _currentPage = Math.Max(0, _totalPages - 1);
+                }
+
+                UpdatePageDisplay();
+            });
+        }
+    }
+
+    private void UpdatePageDisplay()
+    {
+        _pageInfoLabel.Text = _totalPages > 0
+            ? $"Page: {_currentPage + 1} / {_totalPages}"
+            : "Page: - / -";
+
+        if (_filePath is null || _totalPages == 0)
+        {
+            _contentLabel.Text = "No file loaded.\n\nPress Ctrl+O to open a file.";
+            SetNeedsDraw();
+            return;
+        }
+
+        // Phase 1: Show text content as a preview fallback
+        // Full PNG/sixel rendering will be implemented when the cross-platform
+        // graphics pipeline is fully integrated.
+        string previewText = GenerateTextPreview(_filePath, _currentPage);
+        string renderMode = _sixelSupported ? "[Sixel capable — PNG preview pending]" : "[Text fallback]";
+
+        _contentLabel.Text = $"{renderMode}\n\n{previewText}";
         SetNeedsDraw();
+    }
+
+    private static string GenerateTextPreview(string filePath, int pageIndex)
+    {
+        const int linesPerPage = 50;
+
+        try
+        {
+            string[] lines = File.ReadAllLines(filePath);
+            int startLine = pageIndex * linesPerPage;
+            int endLine = Math.Min(startLine + linesPerPage, lines.Length);
+
+            if (startLine >= lines.Length)
+            {
+                return "(End of file)";
+            }
+
+            var preview = new System.Text.StringBuilder();
+            int lineNumWidth = endLine.ToString().Length;
+
+            for (int i = startLine; i < endLine; i++)
+            {
+                string lineNum = (i + 1).ToString().PadLeft(lineNumWidth);
+                string line = lines[i].Length > 72 ? lines[i][..72] + "…" : lines[i];
+                preview.AppendLine($" {lineNum} │ {line}");
+            }
+
+            return preview.ToString();
+        }
+        catch (Exception ex)
+        {
+            return $"Error reading file: {ex.Message}";
+        }
     }
 }

--- a/src/WinPrint.TUI/Views/PreviewPanel.cs
+++ b/src/WinPrint.TUI/Views/PreviewPanel.cs
@@ -1,0 +1,49 @@
+using Terminal.Gui.Drawing;
+using Terminal.Gui.ViewBase;
+using Terminal.Gui.Views;
+using WinPrint.Core.Models;
+using WinPrint.TUI.Services;
+
+namespace WinPrint.TUI.Views;
+
+/// <summary>
+///     Central preview panel that renders page content.
+///     In terminals that support sixel, renders images; otherwise shows text-mode preview.
+/// </summary>
+public sealed class PreviewPanel : View
+{
+    private readonly string? _filePath;
+    private readonly PreviewRenderer _renderer = new();
+
+    public PreviewPanel(string? filePath)
+    {
+        _filePath = filePath;
+
+        BorderStyle = LineStyle.Single;
+        Title = "Preview";
+
+        var pageInfo = new Label
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            Text = "Page: 1 / 1"
+        };
+
+        var contentArea = new Label
+        {
+            X = 0,
+            Y = 2,
+            Width = Dim.Fill(),
+            Height = Dim.Fill(),
+            Text = filePath is null ? "(No file loaded)" : $"Loading: {filePath}"
+        };
+
+        Add(pageInfo, contentArea);
+    }
+
+    public void RefreshPreview(Settings settings)
+    {
+        SetNeedsDraw();
+    }
+}

--- a/src/WinPrint.TUI/Views/SettingsPanel.cs
+++ b/src/WinPrint.TUI/Views/SettingsPanel.cs
@@ -12,6 +12,19 @@ namespace WinPrint.TUI.Views;
 /// </summary>
 public sealed class SettingsPanel : FrameView
 {
+    /// <summary>Common monospace/print font families for the dropdown.</summary>
+    internal static readonly string[] FontFamilies =
+    [
+        "Consolas", "Courier New", "Cascadia Code", "Cascadia Mono",
+        "DejaVu Sans Mono", "Fira Code", "Inconsolata", "JetBrains Mono",
+        "Liberation Mono", "Lucida Console", "Menlo", "Monaco",
+        "SF Mono", "Source Code Pro", "Ubuntu Mono",
+        "Arial", "Calibri", "Cambria", "Segoe UI", "Times New Roman", "Verdana"
+    ];
+
+    /// <summary>Common font sizes for the dropdown.</summary>
+    internal static readonly float[] FontSizes = [6, 7, 8, 9, 10, 11, 12, 14, 16, 18, 20, 24];
+
     private readonly Settings _settings;
     private SheetSettings _currentSheet;
 
@@ -226,48 +239,103 @@ public sealed class SettingsPanel : FrameView
         string hfFontFamily = _currentSheet.Header.Font?.Family ?? "Calibri";
         float hfFontSize = _currentSheet.Header.Font?.Size ?? 10f;
 
+        // Content font: family dropdown + size dropdown
         var cfLabel = new Label { X = 2, Y = bodyRow, Text = "Content:" };
         sectionBody.Add(cfLabel);
         bodyRow++;
 
-        var cfField = new TextField
+        var cfFamilyDrop = new DropDownList
         {
             X = 2,
             Y = bodyRow,
             Width = Dim.Fill(1),
-            Text = $"{contentFontFamily}, {contentFontSize}pt"
+            ReadOnly = true,
+            Source = new ListWrapper<string>(new ObservableCollection<string>(FontFamilies)),
+            Text = contentFontFamily
         };
-        cfField.TextChanged += (_, _) =>
+        cfFamilyDrop.Accepted += (_, _) =>
         {
-            if (_currentSheet.ContentSettings is not null)
+            if (_currentSheet.ContentSettings is not null && !string.IsNullOrEmpty(cfFamilyDrop.Text))
             {
-                ParseFontString(cfField.Text, _currentSheet.ContentSettings.Font);
+                _currentSheet.ContentSettings.Font.Family = cfFamilyDrop.Text;
                 RaiseChanged();
             }
         };
-        sectionBody.Add(cfField);
+        sectionBody.Add(cfFamilyDrop);
         bodyRow++;
 
+        string[] fontSizeLabels = [.. FontSizes.Select(s => $"{s}pt")];
+        var cfSizeDrop = new DropDownList
+        {
+            X = 2,
+            Y = bodyRow,
+            Width = 12,
+            ReadOnly = true,
+            Source = new ListWrapper<string>(new ObservableCollection<string>(fontSizeLabels)),
+            Text = $"{contentFontSize}pt"
+        };
+        cfSizeDrop.Accepted += (_, _) =>
+        {
+            int idx = Array.IndexOf(fontSizeLabels, cfSizeDrop.Text);
+            if (idx >= 0 && idx < FontSizes.Length && _currentSheet.ContentSettings is not null)
+            {
+                _currentSheet.ContentSettings.Font.Size = FontSizes[idx];
+                RaiseChanged();
+            }
+        };
+        sectionBody.Add(cfSizeDrop);
+        bodyRow += 2;
+
+        // Header/Footer font: family dropdown + size dropdown
         var hfLabel = new Label { X = 2, Y = bodyRow, Text = "H/F:" };
         sectionBody.Add(hfLabel);
         bodyRow++;
 
-        var hfField = new TextField
+        var hfFamilyDrop = new DropDownList
         {
             X = 2,
             Y = bodyRow,
             Width = Dim.Fill(1),
-            Text = $"{hfFontFamily}, {hfFontSize}pt"
+            ReadOnly = true,
+            Source = new ListWrapper<string>(new ObservableCollection<string>(FontFamilies)),
+            Text = hfFontFamily
         };
-        hfField.TextChanged += (_, _) =>
+        hfFamilyDrop.Accepted += (_, _) =>
         {
-            Font font = _currentSheet.Header.Font ?? new Font();
-            ParseFontString(hfField.Text, font);
-            _currentSheet.Header.Font = font;
-            _currentSheet.Footer.Font = (Font)font.Clone();
-            RaiseChanged();
+            if (!string.IsNullOrEmpty(hfFamilyDrop.Text))
+            {
+                Font font = _currentSheet.Header.Font ?? new Font();
+                font.Family = hfFamilyDrop.Text;
+                _currentSheet.Header.Font = font;
+                _currentSheet.Footer.Font = (Font)font.Clone();
+                RaiseChanged();
+            }
         };
-        sectionBody.Add(hfField);
+        sectionBody.Add(hfFamilyDrop);
+        bodyRow++;
+
+        var hfSizeDrop = new DropDownList
+        {
+            X = 2,
+            Y = bodyRow,
+            Width = 12,
+            ReadOnly = true,
+            Source = new ListWrapper<string>(new ObservableCollection<string>(fontSizeLabels)),
+            Text = $"{hfFontSize}pt"
+        };
+        hfSizeDrop.Accepted += (_, _) =>
+        {
+            int idx = Array.IndexOf(fontSizeLabels, hfSizeDrop.Text);
+            if (idx >= 0 && idx < FontSizes.Length)
+            {
+                Font font = _currentSheet.Header.Font ?? new Font();
+                font.Size = FontSizes[idx];
+                _currentSheet.Header.Font = font;
+                _currentSheet.Footer.Font = (Font)font.Clone();
+                RaiseChanged();
+            }
+        };
+        sectionBody.Add(hfSizeDrop);
         bodyRow += 2;
 
         // ─── Line Numbers ───
@@ -384,25 +452,6 @@ public sealed class SettingsPanel : FrameView
         field.ValueChanged += (_, args) => setter(args.NewValue);
         parent.Add(lbl, field);
         return row + 1;
-    }
-
-    private static void ParseFontString(string text, Font font)
-    {
-        // Expected format: "Family, Sizept" e.g. "Consolas, 8pt"
-        string[] parts = text.Split(',', StringSplitOptions.TrimEntries);
-        if (parts.Length >= 1 && !string.IsNullOrWhiteSpace(parts[0]))
-        {
-            font.Family = parts[0];
-        }
-
-        if (parts.Length >= 2)
-        {
-            string sizePart = parts[1].Replace("pt", "", StringComparison.OrdinalIgnoreCase).Trim();
-            if (float.TryParse(sizePart, out float size) && size > 0)
-            {
-                font.Size = size;
-            }
-        }
     }
 
     private void RaiseChanged()

--- a/src/WinPrint.TUI/Views/SettingsPanel.cs
+++ b/src/WinPrint.TUI/Views/SettingsPanel.cs
@@ -152,13 +152,29 @@ public sealed class SettingsPanel : FrameView
         bodyRow++;
 
         bodyRow = AddNumericRow(sectionBody, "  Top:", _currentSheet.Margins.Top, bodyRow,
-            v => { _currentSheet.Margins.Top = v; RaiseChanged(); });
+            v =>
+            {
+                _currentSheet.Margins.Top = v;
+                RaiseChanged();
+            });
         bodyRow = AddNumericRow(sectionBody, "  Left:", _currentSheet.Margins.Left, bodyRow,
-            v => { _currentSheet.Margins.Left = v; RaiseChanged(); });
+            v =>
+            {
+                _currentSheet.Margins.Left = v;
+                RaiseChanged();
+            });
         bodyRow = AddNumericRow(sectionBody, "  Right:", _currentSheet.Margins.Right, bodyRow,
-            v => { _currentSheet.Margins.Right = v; RaiseChanged(); });
+            v =>
+            {
+                _currentSheet.Margins.Right = v;
+                RaiseChanged();
+            });
         bodyRow = AddNumericRow(sectionBody, "  Bot:", _currentSheet.Margins.Bottom, bodyRow,
-            v => { _currentSheet.Margins.Bottom = v; RaiseChanged(); });
+            v =>
+            {
+                _currentSheet.Margins.Bottom = v;
+                RaiseChanged();
+            });
         bodyRow++;
 
         // ─── Pages Up ───
@@ -167,11 +183,23 @@ public sealed class SettingsPanel : FrameView
         bodyRow++;
 
         bodyRow = AddNumericRow(sectionBody, "  Rows:", _currentSheet.Rows, bodyRow,
-            v => { _currentSheet.Rows = v; RaiseChanged(); });
+            v =>
+            {
+                _currentSheet.Rows = v;
+                RaiseChanged();
+            });
         bodyRow = AddNumericRow(sectionBody, "  Cols:", _currentSheet.Columns, bodyRow,
-            v => { _currentSheet.Columns = v; RaiseChanged(); });
+            v =>
+            {
+                _currentSheet.Columns = v;
+                RaiseChanged();
+            });
         bodyRow = AddNumericRow(sectionBody, "  Pad:", _currentSheet.Padding, bodyRow,
-            v => { _currentSheet.Padding = v; RaiseChanged(); });
+            v =>
+            {
+                _currentSheet.Padding = v;
+                RaiseChanged();
+            });
 
         var pageSepCheck = new CheckBox
         {
@@ -233,7 +261,7 @@ public sealed class SettingsPanel : FrameView
         };
         hfField.TextChanged += (_, _) =>
         {
-            var font = _currentSheet.Header.Font ?? new Font();
+            Font font = _currentSheet.Header.Font ?? new Font();
             ParseFontString(hfField.Text, font);
             _currentSheet.Header.Font = font;
             _currentSheet.Footer.Font = (Font)font.Clone();

--- a/src/WinPrint.TUI/Views/SettingsPanel.cs
+++ b/src/WinPrint.TUI/Views/SettingsPanel.cs
@@ -1,5 +1,4 @@
 using System.Collections.ObjectModel;
-using Terminal.Gui.App;
 using Terminal.Gui.Drawing;
 using Terminal.Gui.ViewBase;
 using Terminal.Gui.Views;
@@ -8,154 +7,375 @@ using WinPrint.Core.Models;
 namespace WinPrint.TUI.Views;
 
 /// <summary>
-///     Left panel with collapsible settings groups for sheet, margins,
-///     header/footer, and content-type options.
+///     Left panel with collapsible settings groups matching the MAUI/WinForms layout:
+///     File/Print, Sheet Definition (Margins, Pages Up, Fonts, Line Numbers), Printer, Help.
 /// </summary>
-public sealed class SettingsPanel : View
+public sealed class SettingsPanel : FrameView
 {
     private readonly Settings _settings;
     private SheetSettings _currentSheet;
 
     public event EventHandler? SettingsChanged;
+    public event EventHandler<SheetSettings>? SheetChanged;
+    public event EventHandler? FileOpenRequested;
+    public event EventHandler? PrintRequested;
 
-    public SettingsPanel(Settings settings)
+    public SettingsPanel(Settings settings, SheetSettings currentSheet)
     {
         _settings = settings;
-        _currentSheet = settings.Sheets.TryGetValue(settings.DefaultSheet.ToString(), out SheetSettings? sheet)
-            ? sheet
-            : settings.Sheets.Values.First();
+        _currentSheet = currentSheet;
 
-        BorderStyle = LineStyle.Single;
         Title = "Settings";
+        BorderStyle = LineStyle.Single;
+        CanFocus = true;
 
-        BuildUi();
-    }
+        var content = new View
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = Dim.Auto(DimAutoStyle.Content)
+        };
 
-    private void BuildUi()
-    {
         int row = 0;
 
-        // Sheet selector
-        var sheetLabel = new Label { X = 1, Y = row, Text = "Sheet:" };
-        Add(sheetLabel);
+        // ─── File / Print buttons ───
+        var fileBtn = new Button
+        {
+            X = 0,
+            Y = row,
+            Text = "_Open..."
+        };
+        fileBtn.Accepting += (_, _) => FileOpenRequested?.Invoke(this, EventArgs.Empty);
+
+        var printBtn = new Button
+        {
+            X = 14,
+            Y = row,
+            Text = "_Print..."
+        };
+        printBtn.Accepting += (_, _) => PrintRequested?.Invoke(this, EventArgs.Empty);
+        content.Add(fileBtn, printBtn);
+        row += 2;
+
+        // ─── Sheet Definition (collapsible) ───
+        row = BuildSheetDefinitionSection(content, row);
+
+        // ─── Printer (collapsible) ───
+        row = BuildPrinterSection(content, row);
+
+        // ─── Help & Version ───
+        var helpLabel = new Label { X = 0, Y = row, Text = "[Help & About (F1)]" };
+        content.Add(helpLabel);
+        row++;
+        var versionLabel = new Label
+        {
+            X = 0,
+            Y = row,
+            Text = $"v{typeof(SettingsPanel).Assembly.GetName().Version?.ToString(3) ?? "2.5.0"}"
+        };
+        content.Add(versionLabel);
+
+        Add(content);
+    }
+
+    private int BuildSheetDefinitionSection(View parent, int row)
+    {
+        var sectionHeader = new Label { X = 0, Y = row, Text = "▼ Sheet Definition" };
+        parent.Add(sectionHeader);
         row++;
 
+        var sectionBody = new View
+        {
+            X = 0,
+            Y = row,
+            Width = Dim.Fill(),
+            Height = Dim.Auto(DimAutoStyle.Content),
+            Visible = true
+        };
+        int bodyRow = 0;
+
+        // Sheet selector
+        var sheetLabel = new Label { X = 1, Y = bodyRow, Text = "Sheet:" };
+        sectionBody.Add(sheetLabel);
+        bodyRow++;
+
         var sheetNames = new ObservableCollection<string>(
-            settings_Sheets().Select(s => s.Name));
+            _settings.Sheets.Values.Select(s => s.Name));
         var sheetList = new ListView
         {
             X = 1,
-            Y = row,
+            Y = bodyRow,
             Width = Dim.Fill(1),
-            Height = Math.Min(sheetNames.Count, 4)
+            Height = Math.Min(sheetNames.Count, 3)
         };
         sheetList.SetSource(sheetNames);
-        sheetList.ValueChanged += OnSheetSelectionChanged;
-        Add(sheetList);
-        row += Math.Min(sheetNames.Count, 4) + 1;
 
-        // Margins
-        var marginsLabel = new Label { X = 1, Y = row, Text = "── Margins ──" };
-        Add(marginsLabel);
-        row++;
-
-        AddMarginField("Left:", _currentSheet.Margins.Left, row, v => { _currentSheet.Margins.Left = v; RaiseChanged(); });
-        row++;
-        AddMarginField("Right:", _currentSheet.Margins.Right, row, v => { _currentSheet.Margins.Right = v; RaiseChanged(); });
-        row++;
-        AddMarginField("Top:", _currentSheet.Margins.Top, row, v => { _currentSheet.Margins.Top = v; RaiseChanged(); });
-        row++;
-        AddMarginField("Bottom:", _currentSheet.Margins.Bottom, row, v => { _currentSheet.Margins.Bottom = v; RaiseChanged(); });
-        row += 2;
-
-        // Layout
-        var layoutLabel = new Label { X = 1, Y = row, Text = "── Layout ──" };
-        Add(layoutLabel);
-        row++;
-
-        AddIntField("Rows:", _currentSheet.Rows, row, v => { _currentSheet.Rows = v; RaiseChanged(); });
-        row++;
-        AddIntField("Cols:", _currentSheet.Columns, row, v => { _currentSheet.Columns = v; RaiseChanged(); });
-        row++;
-        AddIntField("Padding:", _currentSheet.Padding, row, v => { _currentSheet.Padding = v; RaiseChanged(); });
-        row += 2;
-
-        // Header
-        var headerBar = new HeaderFooterBar("Header", _currentSheet.Header)
+        int selectedIdx = sheetNames.IndexOf(_currentSheet.Name);
+        if (selectedIdx >= 0)
         {
-            X = 1,
-            Y = row,
-            Width = Dim.Fill(1),
-            Height = 2
-        };
-        headerBar.Changed += (_, _) => RaiseChanged();
-        Add(headerBar);
-        row += 3;
+            sheetList.SelectedItem = selectedIdx;
+        }
 
-        // Footer
-        var footerBar = new HeaderFooterBar("Footer", _currentSheet.Footer)
+        sheetList.ValueChanged += (_, args) =>
         {
-            X = 1,
-            Y = row,
-            Width = Dim.Fill(1),
-            Height = 2
-        };
-        footerBar.Changed += (_, _) => RaiseChanged();
-        Add(footerBar);
-    }
-
-    private void AddMarginField(string label, int initialValue, int row, Action<int> setter)
-    {
-        var lbl = new Label { X = 1, Y = row, Text = label };
-        var field = new TextField
-        {
-            X = 10,
-            Y = row,
-            Width = 8,
-            Text = initialValue.ToString()
-        };
-        field.TextChanged += (_, _) =>
-        {
-            if (int.TryParse(field.Text, out int val))
+            SheetSettings[] sheets = [.. _settings.Sheets.Values];
+            int index = args.NewValue ?? -1;
+            if (index >= 0 && index < sheets.Length)
             {
-                setter(val);
+                _currentSheet = sheets[index];
+                SheetChanged?.Invoke(this, _currentSheet);
             }
         };
-        Add(lbl, field);
-    }
+        sectionBody.Add(sheetList);
+        bodyRow += Math.Min(sheetNames.Count, 3) + 1;
 
-    private void AddIntField(string label, int initialValue, int row, Action<int> setter)
-    {
-        var lbl = new Label { X = 1, Y = row, Text = label };
-        var field = new TextField
+        // Landscape
+        var landscapeCheck = new CheckBox
         {
-            X = 10,
-            Y = row,
-            Width = 8,
-            Text = initialValue.ToString()
+            X = 1,
+            Y = bodyRow,
+            Text = "Landscape",
+            Value = _currentSheet.Landscape ? CheckState.Checked : CheckState.None
         };
-        field.TextChanged += (_, _) =>
+        landscapeCheck.ValueChanged += (_, _) =>
         {
-            if (int.TryParse(field.Text, out int val))
-            {
-                setter(val);
-            }
-        };
-        Add(lbl, field);
-    }
-
-    private void OnSheetSelectionChanged(object? sender, ValueChangedEventArgs<int?> e)
-    {
-        SheetSettings[] sheets = [.. _settings.Sheets.Values];
-        int index = e.NewValue ?? -1;
-        if (index >= 0 && index < sheets.Length)
-        {
-            _currentSheet = sheets[index];
+            _currentSheet.Landscape = landscapeCheck.Value == CheckState.Checked;
             RaiseChanged();
+        };
+        sectionBody.Add(landscapeCheck);
+        bodyRow += 2;
+
+        // ─── Margins ───
+        var marginsHeader = new Label { X = 1, Y = bodyRow, Text = "▼ Margins (1/100\")" };
+        sectionBody.Add(marginsHeader);
+        bodyRow++;
+
+        bodyRow = AddNumericRow(sectionBody, "  Top:", _currentSheet.Margins.Top, bodyRow,
+            v => { _currentSheet.Margins.Top = v; RaiseChanged(); });
+        bodyRow = AddNumericRow(sectionBody, "  Left:", _currentSheet.Margins.Left, bodyRow,
+            v => { _currentSheet.Margins.Left = v; RaiseChanged(); });
+        bodyRow = AddNumericRow(sectionBody, "  Right:", _currentSheet.Margins.Right, bodyRow,
+            v => { _currentSheet.Margins.Right = v; RaiseChanged(); });
+        bodyRow = AddNumericRow(sectionBody, "  Bot:", _currentSheet.Margins.Bottom, bodyRow,
+            v => { _currentSheet.Margins.Bottom = v; RaiseChanged(); });
+        bodyRow++;
+
+        // ─── Pages Up ───
+        var pagesHeader = new Label { X = 1, Y = bodyRow, Text = "▼ Pages Up" };
+        sectionBody.Add(pagesHeader);
+        bodyRow++;
+
+        bodyRow = AddNumericRow(sectionBody, "  Rows:", _currentSheet.Rows, bodyRow,
+            v => { _currentSheet.Rows = v; RaiseChanged(); });
+        bodyRow = AddNumericRow(sectionBody, "  Cols:", _currentSheet.Columns, bodyRow,
+            v => { _currentSheet.Columns = v; RaiseChanged(); });
+        bodyRow = AddNumericRow(sectionBody, "  Pad:", _currentSheet.Padding, bodyRow,
+            v => { _currentSheet.Padding = v; RaiseChanged(); });
+
+        var pageSepCheck = new CheckBox
+        {
+            X = 2,
+            Y = bodyRow,
+            Text = "Page Separator",
+            Value = _currentSheet.PageSeparator ? CheckState.Checked : CheckState.None
+        };
+        pageSepCheck.ValueChanged += (_, _) =>
+        {
+            _currentSheet.PageSeparator = pageSepCheck.Value == CheckState.Checked;
+            RaiseChanged();
+        };
+        sectionBody.Add(pageSepCheck);
+        bodyRow += 2;
+
+        // ─── Fonts ───
+        var fontsHeader = new Label { X = 1, Y = bodyRow, Text = "▼ Fonts" };
+        sectionBody.Add(fontsHeader);
+        bodyRow++;
+
+        string contentFontFamily = _currentSheet.ContentSettings?.Font.Family ?? "Consolas";
+        float contentFontSize = _currentSheet.ContentSettings?.Font.Size ?? 8f;
+        string hfFontFamily = _currentSheet.Header.Font?.Family ?? "Calibri";
+        float hfFontSize = _currentSheet.Header.Font?.Size ?? 10f;
+
+        var cfLabel = new Label { X = 2, Y = bodyRow, Text = "Content:" };
+        sectionBody.Add(cfLabel);
+        bodyRow++;
+
+        var cfField = new TextField
+        {
+            X = 2,
+            Y = bodyRow,
+            Width = Dim.Fill(1),
+            Text = $"{contentFontFamily}, {contentFontSize}pt"
+        };
+        cfField.TextChanged += (_, _) =>
+        {
+            if (_currentSheet.ContentSettings is not null)
+            {
+                ParseFontString(cfField.Text, _currentSheet.ContentSettings.Font);
+                RaiseChanged();
+            }
+        };
+        sectionBody.Add(cfField);
+        bodyRow++;
+
+        var hfLabel = new Label { X = 2, Y = bodyRow, Text = "H/F:" };
+        sectionBody.Add(hfLabel);
+        bodyRow++;
+
+        var hfField = new TextField
+        {
+            X = 2,
+            Y = bodyRow,
+            Width = Dim.Fill(1),
+            Text = $"{hfFontFamily}, {hfFontSize}pt"
+        };
+        hfField.TextChanged += (_, _) =>
+        {
+            var font = _currentSheet.Header.Font ?? new Font();
+            ParseFontString(hfField.Text, font);
+            _currentSheet.Header.Font = font;
+            _currentSheet.Footer.Font = (Font)font.Clone();
+            RaiseChanged();
+        };
+        sectionBody.Add(hfField);
+        bodyRow += 2;
+
+        // ─── Line Numbers ───
+        bool hasLineNumbers = _currentSheet.ContentSettings?.LineNumbers ?? false;
+        var lineNumCheck = new CheckBox
+        {
+            X = 1,
+            Y = bodyRow,
+            Text = "Line Numbers",
+            Value = hasLineNumbers ? CheckState.Checked : CheckState.None
+        };
+        lineNumCheck.ValueChanged += (_, _) =>
+        {
+            if (_currentSheet.ContentSettings is not null)
+            {
+                _currentSheet.ContentSettings.LineNumbers = lineNumCheck.Value == CheckState.Checked;
+                RaiseChanged();
+            }
+        };
+        sectionBody.Add(lineNumCheck);
+        bodyRow++;
+
+        // Wire collapsible toggle
+        sectionHeader.Accepting += (_, _) =>
+        {
+            sectionBody.Visible = !sectionBody.Visible;
+            sectionHeader.Text = (sectionBody.Visible ? "▼ " : "▶ ") + "Sheet Definition";
+        };
+
+        parent.Add(sectionBody);
+        row += bodyRow + 1;
+        return row;
+    }
+
+    private int BuildPrinterSection(View parent, int row)
+    {
+        var sectionHeader = new Label { X = 0, Y = row, Text = "▼ Printer" };
+        parent.Add(sectionHeader);
+        row++;
+
+        var sectionBody = new View
+        {
+            X = 0,
+            Y = row,
+            Width = Dim.Fill(),
+            Height = Dim.Auto(DimAutoStyle.Content),
+            Visible = true
+        };
+        int bodyRow = 0;
+
+        // Printer name
+        var printerLabel = new Label { X = 2, Y = bodyRow, Text = "Printer:" };
+        sectionBody.Add(printerLabel);
+        bodyRow++;
+
+        string printerName = _settings.LastPrinter ?? "(Default)";
+        var printerField = new TextField
+        {
+            X = 2,
+            Y = bodyRow,
+            Width = Dim.Fill(1),
+            Text = printerName
+        };
+        printerField.TextChanged += (_, _) => _settings.LastPrinter = printerField.Text;
+        sectionBody.Add(printerField);
+        bodyRow += 2;
+
+        // Paper size
+        var paperLabel = new Label { X = 2, Y = bodyRow, Text = "Paper:" };
+        sectionBody.Add(paperLabel);
+        bodyRow++;
+
+        var paperField = new TextField
+        {
+            X = 2,
+            Y = bodyRow,
+            Width = Dim.Fill(1),
+            Text = _settings.LastPaperSize ?? "Letter"
+        };
+        paperField.TextChanged += (_, _) => _settings.LastPaperSize = paperField.Text;
+        sectionBody.Add(paperField);
+        bodyRow += 2;
+
+        // Page range
+        var pagesLabel = new Label { X = 2, Y = bodyRow, Text = "Pages:" };
+        var fromField = new NumericUpDown<int> { X = 10, Y = bodyRow, Width = 8, Value = 1 };
+        var toLabel = new Label { X = 19, Y = bodyRow, Text = "to" };
+        var toField = new NumericUpDown<int> { X = 22, Y = bodyRow, Width = 8, Value = 999 };
+        sectionBody.Add(pagesLabel, fromField, toLabel, toField);
+        bodyRow++;
+
+        // Wire collapsible toggle
+        sectionHeader.Accepting += (_, _) =>
+        {
+            sectionBody.Visible = !sectionBody.Visible;
+            sectionHeader.Text = (sectionBody.Visible ? "▼ " : "▶ ") + "Printer";
+        };
+
+        parent.Add(sectionBody);
+        row += bodyRow + 1;
+        return row;
+    }
+
+    private int AddNumericRow(View parent, string label, int initialValue, int row, Action<int> setter)
+    {
+        var lbl = new Label { X = 1, Y = row, Text = label };
+        var field = new NumericUpDown<int>
+        {
+            X = 11,
+            Y = row,
+            Width = Dim.Fill(1),
+            Value = initialValue
+        };
+        field.ValueChanged += (_, args) => setter(args.NewValue);
+        parent.Add(lbl, field);
+        return row + 1;
+    }
+
+    private static void ParseFontString(string text, Font font)
+    {
+        // Expected format: "Family, Sizept" e.g. "Consolas, 8pt"
+        string[] parts = text.Split(',', StringSplitOptions.TrimEntries);
+        if (parts.Length >= 1 && !string.IsNullOrWhiteSpace(parts[0]))
+        {
+            font.Family = parts[0];
+        }
+
+        if (parts.Length >= 2)
+        {
+            string sizePart = parts[1].Replace("pt", "", StringComparison.OrdinalIgnoreCase).Trim();
+            if (float.TryParse(sizePart, out float size) && size > 0)
+            {
+                font.Size = size;
+            }
         }
     }
-
-    private SheetSettings[] settings_Sheets() => [.. _settings.Sheets.Values];
 
     private void RaiseChanged()
     {

--- a/src/WinPrint.TUI/Views/SettingsPanel.cs
+++ b/src/WinPrint.TUI/Views/SettingsPanel.cs
@@ -1,0 +1,164 @@
+using System.Collections.ObjectModel;
+using Terminal.Gui.App;
+using Terminal.Gui.Drawing;
+using Terminal.Gui.ViewBase;
+using Terminal.Gui.Views;
+using WinPrint.Core.Models;
+
+namespace WinPrint.TUI.Views;
+
+/// <summary>
+///     Left panel with collapsible settings groups for sheet, margins,
+///     header/footer, and content-type options.
+/// </summary>
+public sealed class SettingsPanel : View
+{
+    private readonly Settings _settings;
+    private SheetSettings _currentSheet;
+
+    public event EventHandler? SettingsChanged;
+
+    public SettingsPanel(Settings settings)
+    {
+        _settings = settings;
+        _currentSheet = settings.Sheets.TryGetValue(settings.DefaultSheet.ToString(), out SheetSettings? sheet)
+            ? sheet
+            : settings.Sheets.Values.First();
+
+        BorderStyle = LineStyle.Single;
+        Title = "Settings";
+
+        BuildUi();
+    }
+
+    private void BuildUi()
+    {
+        int row = 0;
+
+        // Sheet selector
+        var sheetLabel = new Label { X = 1, Y = row, Text = "Sheet:" };
+        Add(sheetLabel);
+        row++;
+
+        var sheetNames = new ObservableCollection<string>(
+            settings_Sheets().Select(s => s.Name));
+        var sheetList = new ListView
+        {
+            X = 1,
+            Y = row,
+            Width = Dim.Fill(1),
+            Height = Math.Min(sheetNames.Count, 4)
+        };
+        sheetList.SetSource(sheetNames);
+        sheetList.ValueChanged += OnSheetSelectionChanged;
+        Add(sheetList);
+        row += Math.Min(sheetNames.Count, 4) + 1;
+
+        // Margins
+        var marginsLabel = new Label { X = 1, Y = row, Text = "── Margins ──" };
+        Add(marginsLabel);
+        row++;
+
+        AddMarginField("Left:", _currentSheet.Margins.Left, row, v => { _currentSheet.Margins.Left = v; RaiseChanged(); });
+        row++;
+        AddMarginField("Right:", _currentSheet.Margins.Right, row, v => { _currentSheet.Margins.Right = v; RaiseChanged(); });
+        row++;
+        AddMarginField("Top:", _currentSheet.Margins.Top, row, v => { _currentSheet.Margins.Top = v; RaiseChanged(); });
+        row++;
+        AddMarginField("Bottom:", _currentSheet.Margins.Bottom, row, v => { _currentSheet.Margins.Bottom = v; RaiseChanged(); });
+        row += 2;
+
+        // Layout
+        var layoutLabel = new Label { X = 1, Y = row, Text = "── Layout ──" };
+        Add(layoutLabel);
+        row++;
+
+        AddIntField("Rows:", _currentSheet.Rows, row, v => { _currentSheet.Rows = v; RaiseChanged(); });
+        row++;
+        AddIntField("Cols:", _currentSheet.Columns, row, v => { _currentSheet.Columns = v; RaiseChanged(); });
+        row++;
+        AddIntField("Padding:", _currentSheet.Padding, row, v => { _currentSheet.Padding = v; RaiseChanged(); });
+        row += 2;
+
+        // Header
+        var headerBar = new HeaderFooterBar("Header", _currentSheet.Header)
+        {
+            X = 1,
+            Y = row,
+            Width = Dim.Fill(1),
+            Height = 2
+        };
+        headerBar.Changed += (_, _) => RaiseChanged();
+        Add(headerBar);
+        row += 3;
+
+        // Footer
+        var footerBar = new HeaderFooterBar("Footer", _currentSheet.Footer)
+        {
+            X = 1,
+            Y = row,
+            Width = Dim.Fill(1),
+            Height = 2
+        };
+        footerBar.Changed += (_, _) => RaiseChanged();
+        Add(footerBar);
+    }
+
+    private void AddMarginField(string label, int initialValue, int row, Action<int> setter)
+    {
+        var lbl = new Label { X = 1, Y = row, Text = label };
+        var field = new TextField
+        {
+            X = 10,
+            Y = row,
+            Width = 8,
+            Text = initialValue.ToString()
+        };
+        field.TextChanged += (_, _) =>
+        {
+            if (int.TryParse(field.Text, out int val))
+            {
+                setter(val);
+            }
+        };
+        Add(lbl, field);
+    }
+
+    private void AddIntField(string label, int initialValue, int row, Action<int> setter)
+    {
+        var lbl = new Label { X = 1, Y = row, Text = label };
+        var field = new TextField
+        {
+            X = 10,
+            Y = row,
+            Width = 8,
+            Text = initialValue.ToString()
+        };
+        field.TextChanged += (_, _) =>
+        {
+            if (int.TryParse(field.Text, out int val))
+            {
+                setter(val);
+            }
+        };
+        Add(lbl, field);
+    }
+
+    private void OnSheetSelectionChanged(object? sender, ValueChangedEventArgs<int?> e)
+    {
+        SheetSettings[] sheets = [.. _settings.Sheets.Values];
+        int index = e.NewValue ?? -1;
+        if (index >= 0 && index < sheets.Length)
+        {
+            _currentSheet = sheets[index];
+            RaiseChanged();
+        }
+    }
+
+    private SheetSettings[] settings_Sheets() => [.. _settings.Sheets.Values];
+
+    private void RaiseChanged()
+    {
+        SettingsChanged?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/WinPrint.TUI/WinPrint.TUI.csproj
+++ b/src/WinPrint.TUI/WinPrint.TUI.csproj
@@ -16,6 +16,7 @@
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Platforms>AnyCPU;x64</Platforms>
+    <InternalsVisibleTo>WinPrint.TUI.UnitTests</InternalsVisibleTo>
     <!-- <ApplicationIcon>print.ico</ApplicationIcon> -->
   </PropertyGroup>
 

--- a/src/WinPrint.TUI/WinPrint.TUI.csproj
+++ b/src/WinPrint.TUI/WinPrint.TUI.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>WinPrint.TUI</RootNamespace>
+    <AssemblyTitle>winprint TUI</AssemblyTitle>
+    <AssemblyName>print</AssemblyName>
+    <Version>2.5.0.0</Version>
+    <Company>Kindel</Company>
+    <Product>winprint</Product>
+    <Authors>Tig Kindel</Authors>
+    <Description>winprint Terminal.Gui full-screen TUI front end</Description>
+    <Copyright>Copyright Kindel, LLC</Copyright>
+    <PackageProjectUrl>https://github.com/tig/winprint</PackageProjectUrl>
+    <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
+    <NeutralLanguage>en-US</NeutralLanguage>
+    <Platforms>AnyCPU;x64</Platforms>
+    <!-- <ApplicationIcon>print.ico</ApplicationIcon> -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="print.ico" Condition="Exists('print.ico')" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Terminal.Gui.Cli" Version="0.1.0-develop.5" />
+    <ProjectReference Include="..\WinPrint.Core\WinPrint.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\agent-guide.md" LogicalName="WinPrint.TUI.agent-guide.md" Condition="Exists('Resources\agent-guide.md')" />
+  </ItemGroup>
+
+</Project>

--- a/src/WinPrint.slnx
+++ b/src/WinPrint.slnx
@@ -31,4 +31,7 @@
     <Platform Solution="*|x64" Project="x64" />
   </Project>
   <Project Path="WinPrint.Maui/WinPrint.Maui.csproj" />
+  <Project Path="WinPrint.TUI/WinPrint.TUI.csproj">
+    <Platform Solution="*|x64" Project="x64" />
+  </Project>
 </Solution>

--- a/src/WinPrint.slnx
+++ b/src/WinPrint.slnx
@@ -20,6 +20,9 @@
   <Project Path="../tests/WinPrint.Core.UnitTests/WinPrint.Core.UnitTests.csproj">
     <Platform Solution="*|x64" Project="x64" />
   </Project>
+  <Project Path="../tests/WinPrint.TUI.UnitTests/WinPrint.TUI.UnitTests.csproj">
+    <Platform Solution="*|x64" Project="x64" />
+  </Project>
   <Project Path="WinPrint.cli/WinPrint.cli.csproj">
     <Platform Solution="*|x64" Project="x64" />
   </Project>

--- a/tests/WinPrint.TUI.UnitTests/MacroSuggestionGeneratorTests.cs
+++ b/tests/WinPrint.TUI.UnitTests/MacroSuggestionGeneratorTests.cs
@@ -12,7 +12,7 @@ public sealed class MacroSuggestionGeneratorTests
     private static AutocompleteContext CreateContext(string text, int cursorPos)
     {
         List<Cell> cells = [.. text.Select(c => new Cell { Grapheme = c.ToString() })];
-        return new AutocompleteContext(cells, cursorPos, false);
+        return new AutocompleteContext(cells, cursorPos);
     }
 
     [Fact]

--- a/tests/WinPrint.TUI.UnitTests/MacroSuggestionGeneratorTests.cs
+++ b/tests/WinPrint.TUI.UnitTests/MacroSuggestionGeneratorTests.cs
@@ -1,0 +1,82 @@
+using Terminal.Gui.Drawing;
+using Terminal.Gui.Views;
+using WinPrint.TUI.Views;
+using Xunit;
+
+namespace WinPrint.TUI.UnitTests;
+
+public sealed class MacroSuggestionGeneratorTests
+{
+    private readonly MacroSuggestionGenerator _generator = new();
+
+    private static AutocompleteContext CreateContext(string text, int cursorPos)
+    {
+        List<Cell> cells = [.. text.Select(c => new Cell { Grapheme = c.ToString() })];
+        return new AutocompleteContext(cells, cursorPos, false);
+    }
+
+    [Fact]
+    public void GenerateSuggestions_NoBrace_ReturnsEmpty()
+    {
+        AutocompleteContext ctx = CreateContext("Hello World", 5);
+        IEnumerable<Suggestion> result = _generator.GenerateSuggestions(ctx);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void GenerateSuggestions_OpenBrace_ReturnsAllMacros()
+    {
+        AutocompleteContext ctx = CreateContext("{", 1);
+        Suggestion[] result = [.. _generator.GenerateSuggestions(ctx)];
+        Assert.Equal(HeaderFooterBar.MacroNames.Length, result.Length);
+    }
+
+    [Fact]
+    public void GenerateSuggestions_PartialMacro_FiltersResults()
+    {
+        AutocompleteContext ctx = CreateContext("{File", 5);
+        Suggestion[] result = [.. _generator.GenerateSuggestions(ctx)];
+
+        Assert.All(result, s => Assert.StartsWith("{File", s.Replacement));
+        Assert.Contains(result, s => s.Replacement == "{FileName}");
+        Assert.Contains(result, s => s.Replacement == "{FileExtension}");
+    }
+
+    [Fact]
+    public void GenerateSuggestions_AfterClosedBrace_ReturnsEmpty()
+    {
+        AutocompleteContext ctx = CreateContext("{FileName} text", 15);
+        IEnumerable<Suggestion> result = _generator.GenerateSuggestions(ctx);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void GenerateSuggestions_RemoveCount_MatchesPartialLength()
+    {
+        AutocompleteContext ctx = CreateContext("{Dat", 4);
+        Suggestion[] result = [.. _generator.GenerateSuggestions(ctx)];
+
+        Assert.NotEmpty(result);
+        Assert.All(result, s => Assert.Equal(4, s.Remove));
+    }
+
+    [Fact]
+    public void IsWordChar_BraceChars_ReturnsTrue()
+    {
+        Assert.True(_generator.IsWordChar("{"));
+        Assert.True(_generator.IsWordChar("}"));
+    }
+
+    [Fact]
+    public void IsWordChar_Letters_ReturnsTrue()
+    {
+        Assert.True(_generator.IsWordChar("A"));
+        Assert.True(_generator.IsWordChar("z"));
+    }
+
+    [Fact]
+    public void IsWordChar_Space_ReturnsFalse()
+    {
+        Assert.False(_generator.IsWordChar(" "));
+    }
+}

--- a/tests/WinPrint.TUI.UnitTests/PreviewRendererTests.cs
+++ b/tests/WinPrint.TUI.UnitTests/PreviewRendererTests.cs
@@ -1,0 +1,111 @@
+using WinPrint.Core.Abstractions;
+using WinPrint.Core.Models;
+using WinPrint.TUI.Services;
+using Xunit;
+
+namespace WinPrint.TUI.UnitTests;
+
+public sealed class PreviewRendererTests
+{
+    private readonly PreviewRenderer _renderer = new();
+
+    private static SheetSettings CreateDefaultSheet()
+    {
+        return new SheetSettings
+        {
+            Name = "Test",
+            Rows = 1,
+            Columns = 1,
+            Padding = 0,
+            Margins = new PrintMargins { Top = 100, Bottom = 100, Left = 75, Right = 75 },
+            ContentSettings = new ContentSettings { Font = new Font { Family = "Consolas", Size = 8 } }
+        };
+    }
+
+    [Fact]
+    public async Task CountPagesAsync_NonExistentFile_ReturnsZero()
+    {
+        int count = await _renderer.CountPagesAsync("/nonexistent/file.txt", CreateDefaultSheet());
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public async Task CountPagesAsync_EmptyFile_ReturnsAtLeastOne()
+    {
+        string tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, "");
+            int count = await _renderer.CountPagesAsync(tempFile, CreateDefaultSheet());
+            Assert.True(count >= 1);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task CountPagesAsync_LargeFile_ReturnsMultiplePages()
+    {
+        string tempFile = Path.GetTempFileName();
+        try
+        {
+            // Write 200 lines — should require multiple pages at ~60 lines/page
+            string content = string.Join("\n", Enumerable.Range(1, 200).Select(i => $"Line {i}"));
+            File.WriteAllText(tempFile, content);
+
+            int count = await _renderer.CountPagesAsync(tempFile, CreateDefaultSheet());
+            Assert.True(count > 1, $"Expected multiple pages, got {count}");
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task CountPagesAsync_MultiPageUp_ReducesSheetCount()
+    {
+        string tempFile = Path.GetTempFileName();
+        try
+        {
+            string content = string.Join("\n", Enumerable.Range(1, 200).Select(i => $"Line {i}"));
+            File.WriteAllText(tempFile, content);
+
+            SheetSettings singleUp = CreateDefaultSheet();
+            singleUp.Rows = 1;
+            singleUp.Columns = 1;
+
+            SheetSettings twoUp = CreateDefaultSheet();
+            twoUp.Rows = 1;
+            twoUp.Columns = 2;
+
+            int singleCount = await _renderer.CountPagesAsync(tempFile, singleUp);
+            int twoUpCount = await _renderer.CountPagesAsync(tempFile, twoUp);
+
+            Assert.True(twoUpCount <= singleCount,
+                $"2-up ({twoUpCount}) should have <= sheets than 1-up ({singleCount})");
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task RenderPageAsync_ReturnsNull_InPhase1()
+    {
+        string tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, "Hello World");
+            byte[]? result = await _renderer.RenderPageAsync(tempFile, CreateDefaultSheet(), 0);
+            Assert.Null(result);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+}

--- a/tests/WinPrint.TUI.UnitTests/SixelDetectorTests.cs
+++ b/tests/WinPrint.TUI.UnitTests/SixelDetectorTests.cs
@@ -1,0 +1,44 @@
+using WinPrint.TUI.Services;
+using Xunit;
+
+namespace WinPrint.TUI.UnitTests;
+
+public sealed class SixelDetectorTests
+{
+    public SixelDetectorTests()
+    {
+        // Reset cached state between tests
+        SixelDetector.Reset();
+    }
+
+    [Fact]
+    public void IsSupported_DefaultEnvironment_ReturnsFalse()
+    {
+        // In a typical CI/test environment, sixel is not supported
+        SixelDetector.Reset();
+        bool result = SixelDetector.IsSupported();
+
+        // We can't guarantee it's false (depends on env), but it shouldn't throw
+        Assert.IsType<bool>(result);
+    }
+
+    [Fact]
+    public void IsSupported_CachesResult()
+    {
+        SixelDetector.Reset();
+        bool first = SixelDetector.IsSupported();
+        bool second = SixelDetector.IsSupported();
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void Reset_ClearsCache()
+    {
+        // Should not throw
+        SixelDetector.Reset();
+        SixelDetector.IsSupported();
+        SixelDetector.Reset();
+        SixelDetector.IsSupported();
+    }
+}

--- a/tests/WinPrint.TUI.UnitTests/WinPrint.TUI.UnitTests.csproj
+++ b/tests/WinPrint.TUI.UnitTests/WinPrint.TUI.UnitTests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Platforms>AnyCPU;x64</Platforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\WinPrint.TUI\WinPrint.TUI.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
Implements the first version of `WinPrint.TUI` - a full character-mode Terminal.Gui front end for WinPrint that mirrors the MAUI/WinForms layout. Resolves the phase 1 scope of #68.

## What's included

### Project & hosting
- New `src/WinPrint.TUI` project producing executable named `print`
- Uses `gui-cs/Cli` (`Terminal.Gui.Cli`) as the hosting framework
- Runs with `AppModel.FullScreen` via `CommandKind.Viewer`
- CLI options: `--printer`, `--paper-size`, `--sheet`, `--content-type`, `--language`

### Layout parity with MAUI/WinForms
- **Left settings rail** (36 cols, scrollable) with collapsible groups:
  - File Open / Print buttons
  - Sheet Definition (selector, landscape, margins, pages up, fonts, line numbers)
  - Printer (name, paper size, page range with NumericUpDown)
  - Help & version
- **Right panel**: header bar -> preview -> footer bar
- **Status bar**: F1 Help, Ctrl+O Open, Ctrl+P Print, PgUp/PgDn, Ctrl+Q Quit

### Preview architecture
- `PreviewRenderer` service - page counting and PNG rendering (separated from UI, testable)
- `SixelDetector` - terminal capability detection for sixel-capable terminals
- Text-mode fallback with line numbers for non-sixel terminals
- PNG/sixel rendering wired but pending full CTE pipeline integration (documented)

### Header/Footer
- Enable/disable checkbox + editable TextField
- `MacroSuggestionGenerator` autocomplete for macros

### Fonts
- `DropDownList` for font family and size selection
- Curated list of common monospace and print fonts

### Tests (16 passing)
- `PreviewRendererTests` - page counting logic
- `SixelDetectorTests` - environment-based detection
- `MacroSuggestionGeneratorTests` - autocomplete behavior

### Documentation
- `src/WinPrint.TUI/README.md` with usage, layout, terminal requirements, phase 1 limitations

## What's preserved
- `WinPrint.cli` remains intact and buildable
- No changes to existing projects

## Phase 1 limitations (documented)
- Preview: text-mode fallback; full PNG/sixel rendering pending cross-platform graphics integration
- Printing: informational message only (use `winprint` CLI)
- Does NOT require #66 (AOT), #64 (cross-platform CI), or #63 (installer)

## Verification
- `dotnet build src/WinPrint.TUI/WinPrint.TUI.csproj` - passes
- `dotnet build src/WinPrint.cli/WinPrint.cli.csproj` - passes
- `dotnet test tests/WinPrint.TUI.UnitTests/` - 16 tests passing

Closes #68 (phase 1 scope)