### PR TITLE
Fix MAUI window title not updating for command-line file loads

### DIFF
--- a/src/WinPrint.Maui/MainPage.xaml.cs
+++ b/src/WinPrint.Maui/MainPage.xaml.cs
@@ -44,9 +44,9 @@ public partial class MainPage : ContentPage
         // Sync window title with ViewModel title
         _viewModel.PropertyChanged += (s, e) =>
         {
-            if (e.PropertyName == nameof(_viewModel.Title) && Window != null)
+            if (e.PropertyName == nameof(_viewModel.Title))
             {
-                MainThread.BeginInvokeOnMainThread(() => Window.Title = _viewModel.Title);
+                MainThread.BeginInvokeOnMainThread(SyncWindowTitle);
             }
         };
 
@@ -60,9 +60,25 @@ public partial class MainPage : ContentPage
         Unloaded += OnPageUnloaded;
     }
 
+    /// <summary>
+    ///     Pushes the view-model title to the native window. The title can change before
+    ///     the page is attached to its Window — command-line file loads are queued from
+    ///     the constructor — so <see cref="OnHandlerChanged" /> calls this again once the
+    ///     window exists.
+    /// </summary>
+    private void SyncWindowTitle()
+    {
+        if (Window != null)
+        {
+            Window.Title = _viewModel.Title;
+        }
+    }
+
     protected override void OnHandlerChanged()
     {
         base.OnHandlerChanged();
+
+        SyncWindowTitle();
 
         // Restore saved window size and state (mirrors WinForms pattern)
         Settings settings = ModelLocator.Current.Settings;


### PR DESCRIPTION
Fixes #89

Command-line file loads are queued from the `MainPage` constructor, so the view-model `Title` changes while the page is not yet attached to its `Window`. The old title-sync handler checked `Window != null` at event time and silently skipped the update — the window stayed "WinPrint" even though the file loaded and the preview rendered.

## Changes
- Check `Window` inside the dispatched callback (`SyncWindowTitle`) instead of at `PropertyChanged` time.
- Re-sync the title in `OnHandlerChanged` once the window exists, covering any title change that happened before attach.

## Verification
Ran the app on Windows with `winprint.exe CLAUDE.md`: window title now reads "WinPrint - CLAUDE.md" (was "WinPrint"). File-button path still updates the title as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)