### PR TITLE
Add run-maui-app project skill for launching and driving the MAUI app

### DIFF
--- a/.claude/skills/run-maui-app/SKILL.md
+++ b/.claude/skills/run-maui-app/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: run-maui-app
+description: Build, launch, screenshot, and drive the WinPrint.Maui Windows app (winprint.exe) — including UIA automation of the File button and native Open dialog, and pixel capture that works for WinUI3 content. Use when asked to run, verify, or screenshot the MAUI app.
+---
+
+# Run & drive the WinPrint MAUI app (Windows)
+
+## Build and launch
+
+```powershell
+dotnet build src/WinPrint.Maui/WinPrint.Maui.csproj -f net10.0-windows10.0.19041.0
+```
+
+The app is **unpackaged** (`WindowsPackageType=None`), assembly name `winprint`:
+
+```powershell
+$exe = "src\WinPrint.Maui\bin\Debug\net10.0-windows10.0.19041.0\win-x64\winprint.exe"
+# No args — empty preview; or pass a file to load it on startup:
+$proc = Start-Process -FilePath $exe -ArgumentList '"C:\full\path\to\file.cs"' -PassThru
+```
+
+Give it ~6-8 seconds to start. Command-line options mirror the CLI (`--landscape`,
+`--sheet`, `--printer`, `--paper-size`; files are positional). Relative file paths are
+resolved against the launch CWD (`MauiProgram.cs` captures it before switching CWD to
+the exe dir).
+
+## Verify state (works even on a locked session)
+
+Screenshots lie or fail when the session is locked — **UI Automation doesn't**. Use:
+
+```powershell
+& .claude\skills\run-maui-app\scripts\Get-UIState.ps1 -ProcessId $proc.Id
+```
+
+Signals:
+- **File loaded?** The `🖨 Print...` button is enabled only when `IsFileLoaded && !IsBusy`
+  (load failure clears `ActiveFile`, disabling it). This is the reliable check.
+- **Title**: `(Get-Process -Id $proc.Id).MainWindowTitle` becomes `WinPrint - <name>`
+  when the title sync fires. (Historically this did NOT fire for command-line-loaded
+  files because the load starts before the page is attached to its Window — don't
+  treat a stale title alone as "load failed"; check the Print button.)
+- The page indicator ("Page x of y") and status text are drawn **inside the preview
+  drawable** — invisible to UIA. Pixel capture is the only way to see them.
+
+## Screenshot (WinUI3 needs PrintWindow + PW_RENDERFULLCONTENT)
+
+```powershell
+& .claude\skills\run-maui-app\scripts\Capture-Window.ps1 -ProcessId $proc.Id -OutFile out.png
+```
+
+- `Graphics.CopyFromScreen` returns wallpaper/black if the session is locked
+  (`Get-Process LogonUI` running ⇒ locked) — don't trust it.
+- `PrintWindow` flag must be `2` (`PW_RENDERFULLCONTENT`) or WinUI3 composition content
+  comes back black. The first capture right after launch can still be black; retry a few
+  seconds after the file loads.
+- **Look at the screenshot**: a loaded file shows the rendered page with header
+  (date | filename | language), line numbers, and footer ("Page x of y").
+
+## Drive the File button + Open dialog
+
+```powershell
+& .claude\skills\run-maui-app\scripts\Drive-FileOpen.ps1 -ProcessId $proc.Id -FilePath "C:\full\path\to\README.md"
+```
+
+This UIA-invokes the `📂 File...` button, waits for the native **Open** dialog (a child
+window of the app window), sets the filename edit (automation id `1148`), and clicks
+Open (automation id `1`). Works on a locked session — no real mouse/keyboard input.
+
+## Cleanup
+
+```powershell
+$proc.CloseMainWindow()   # polite close; prompts only if sheet settings were edited
+# fall back to Stop-Process -Force if it lingers
+```
+
+Closing instances matters: the app persists window state and settings next to the exe
+on exit, and a leftover instance holds the bin directory, breaking the next build.

--- a/.claude/skills/run-maui-app/scripts/Capture-Window.ps1
+++ b/.claude/skills/run-maui-app/scripts/Capture-Window.ps1
@@ -1,0 +1,44 @@
+# Captures a screenshot of a window by process ID.
+# Uses PrintWindow with PW_RENDERFULLCONTENT (2), which is REQUIRED for WinUI3/MAUI
+# (DirectComposition) content and works even when the session is locked or the window
+# is occluded. Plain CopyFromScreen returns wallpaper/black on a locked session.
+# Note: the first PrintWindow attempt right after launch can come back black; retry
+# after the app has painted (a few seconds after the file loads).
+param(
+    [Parameter(Mandatory)] [int] $ProcessId,
+    [Parameter(Mandatory)] [string] $OutFile
+)
+Add-Type -AssemblyName System.Drawing
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public class Win32Cap {
+    [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr hWnd);
+    [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr hWnd, out RECT rect);
+    [DllImport("user32.dll")] public static extern bool PrintWindow(IntPtr hWnd, IntPtr hdcBlt, uint nFlags);
+    [DllImport("user32.dll")] public static extern bool IsIconic(IntPtr hWnd);
+    [DllImport("user32.dll")] public static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+    [StructLayout(LayoutKind.Sequential)] public struct RECT { public int Left, Top, Right, Bottom; }
+}
+"@
+$proc = Get-Process -Id $ProcessId -ErrorAction Stop
+$hwnd = $proc.MainWindowHandle
+if ($hwnd -eq [IntPtr]::Zero) { throw "Process $ProcessId has no main window" }
+if ([Win32Cap]::IsIconic($hwnd)) { [Win32Cap]::ShowWindow($hwnd, 9) | Out-Null; Start-Sleep -Milliseconds 500 }
+[Win32Cap]::SetForegroundWindow($hwnd) | Out-Null
+Start-Sleep -Milliseconds 500
+$rect = New-Object Win32Cap+RECT
+[Win32Cap]::GetWindowRect($hwnd, [ref]$rect) | Out-Null
+$w = $rect.Right - $rect.Left
+$h = $rect.Bottom - $rect.Top
+if ($w -le 0 -or $h -le 0) { throw "Bad window rect" }
+$bmp = New-Object System.Drawing.Bitmap($w, $h)
+$gfx = [System.Drawing.Graphics]::FromImage($bmp)
+$hdc = $gfx.GetHdc()
+$ok = [Win32Cap]::PrintWindow($hwnd, $hdc, 2)  # 2 = PW_RENDERFULLCONTENT
+$gfx.ReleaseHdc($hdc)
+$gfx.Dispose()
+if (-not $ok) { Write-Warning "PrintWindow returned false" }
+$bmp.Save($OutFile, [System.Drawing.Imaging.ImageFormat]::Png)
+$bmp.Dispose()
+Write-Output "Saved ${w}x${h} screenshot to $OutFile (title: '$($proc.MainWindowTitle)')"

--- a/.claude/skills/run-maui-app/scripts/Drive-FileOpen.ps1
+++ b/.claude/skills/run-maui-app/scripts/Drive-FileOpen.ps1
@@ -1,0 +1,50 @@
+# Drives the running WinPrint MAUI app's "📂 File..." button via UI Automation:
+# clicks the button, waits for the native Open dialog, types the file path, clicks Open.
+# Works even when the session is locked (UIA is in-session, no real input needed).
+param(
+    [Parameter(Mandatory)] [int] $ProcessId,
+    [Parameter(Mandatory)] [string] $FilePath
+)
+Add-Type -AssemblyName UIAutomationClient
+Add-Type -AssemblyName UIAutomationTypes
+
+$root = [System.Windows.Automation.AutomationElement]::RootElement
+$cond = New-Object System.Windows.Automation.PropertyCondition(
+    [System.Windows.Automation.AutomationElement]::ProcessIdProperty, $ProcessId)
+$win = $root.FindFirst([System.Windows.Automation.TreeScope]::Children, $cond)
+if ($win -eq $null) { throw "No top-level window for process $ProcessId" }
+
+$btnCond = New-Object System.Windows.Automation.PropertyCondition(
+    [System.Windows.Automation.AutomationElement]::NameProperty, "📂 File...")
+$fileBtn = $win.FindFirst([System.Windows.Automation.TreeScope]::Descendants, $btnCond)
+if ($fileBtn -eq $null) { throw "File button not found" }
+$fileBtn.GetCurrentPattern([System.Windows.Automation.InvokePattern]::Pattern).Invoke()
+
+# Wait for the Open dialog (a child Window of the app window)
+$dlg = $null
+$dlgCond = New-Object System.Windows.Automation.PropertyCondition(
+    [System.Windows.Automation.AutomationElement]::ControlTypeProperty,
+    [System.Windows.Automation.ControlType]::Window)
+for ($i = 0; $i -lt 20 -and $dlg -eq $null; $i++) {
+    Start-Sleep -Milliseconds 500
+    $dlg = $win.FindFirst([System.Windows.Automation.TreeScope]::Children, $dlgCond)
+}
+if ($dlg -eq $null) { throw "Open dialog did not appear" }
+
+# Classic common-dialog automation IDs: 1148 = filename edit, 1 = Open button
+$editCond = New-Object System.Windows.Automation.PropertyCondition(
+    [System.Windows.Automation.AutomationElement]::AutomationIdProperty, "1148")
+$edit = $dlg.FindFirst([System.Windows.Automation.TreeScope]::Descendants, $editCond)
+if ($edit -eq $null) { throw "Filename edit (autoid 1148) not found" }
+$edit.GetCurrentPattern([System.Windows.Automation.ValuePattern]::Pattern).SetValue($FilePath)
+Start-Sleep -Milliseconds 500
+
+$openCond = New-Object System.Windows.Automation.PropertyCondition(
+    [System.Windows.Automation.AutomationElement]::AutomationIdProperty, "1")
+$openBtn = $dlg.FindFirst([System.Windows.Automation.TreeScope]::Descendants, $openCond)
+if ($openBtn -eq $null) { throw "Open button (autoid 1) not found" }
+$openBtn.GetCurrentPattern([System.Windows.Automation.InvokePattern]::Pattern).Invoke()
+
+Start-Sleep -Seconds 3
+$proc = Get-Process -Id $ProcessId
+Write-Output "Opened '$FilePath'. Window title now: '$($proc.MainWindowTitle)'"

--- a/.claude/skills/run-maui-app/scripts/Get-UIState.ps1
+++ b/.claude/skills/run-maui-app/scripts/Get-UIState.ps1
@@ -1,0 +1,35 @@
+# Dumps the UI Automation element tree (control type, name, value, enabled) of the
+# running WinPrint MAUI app. Use this to verify app state without pixels — works on a
+# locked session where screenshots fail.
+# Key signals:
+#   - "🖨 Print..." button enabled  => a file is loaded (PrintCommand CanExecute is
+#     IsFileLoaded && !IsBusy). On load failure ActiveFile is cleared, disabling it.
+#   - Window title "WinPrint - <name>" => title sync fired (file-button path).
+# The page indicator / status text are drawn inside the preview GraphicsView drawable
+# and are NOT visible to UIA.
+param(
+    [Parameter(Mandatory)] [int] $ProcessId
+)
+Add-Type -AssemblyName UIAutomationClient
+Add-Type -AssemblyName UIAutomationTypes
+
+$root = [System.Windows.Automation.AutomationElement]::RootElement
+$cond = New-Object System.Windows.Automation.PropertyCondition(
+    [System.Windows.Automation.AutomationElement]::ProcessIdProperty, $ProcessId)
+$win = $root.FindFirst([System.Windows.Automation.TreeScope]::Children, $cond)
+if ($win -eq $null) { throw "No top-level window for process $ProcessId" }
+"Window: '$($win.Current.Name)'"
+$all = $win.FindAll([System.Windows.Automation.TreeScope]::Descendants,
+    [System.Windows.Automation.Condition]::TrueCondition)
+$i = 0
+foreach ($el in $all) {
+    $c = $el.Current
+    $type = $c.ControlType.ProgrammaticName -replace 'ControlType.', ''
+    $val = ''
+    try {
+        $vp = $el.GetCurrentPattern([System.Windows.Automation.ValuePattern]::Pattern)
+        $val = $vp.Current.Value
+    } catch {}
+    "{0,2}: {1} name='{2}' value='{3}' enabled={4}" -f $i, $type, $c.Name, $val, $c.IsEnabled
+    $i++
+}


### PR DESCRIPTION
Fixes #91

Adds `.claude/skills/run-maui-app/` so agents can run and verify the MAUI Windows head without rediscovering the non-obvious parts. Everything in it was validated against the real app while verifying the file-open paths (see #89/#90, found during that session).

## Contents
- **SKILL.md** — build/launch the unpackaged `winprint.exe`, command-line file args, verification signals, cleanup.
- **scripts/Capture-Window.ps1** — window screenshot via `PrintWindow` + `PW_RENDERFULLCONTENT` (required for WinUI3 composition content; `CopyFromScreen` silently returns wallpaper/black on a locked session).
- **scripts/Get-UIState.ps1** — UIA element/state dump; documents that the Print button''s enabled state is the reliable "file loaded" signal, and that the page indicator is drawn in the preview drawable and invisible to UIA.
- **scripts/Drive-FileOpen.ps1** — UIA driver for the 📂 File... button and the native Open dialog (filename edit automation id `1148`, Open button id `1`); works on a locked session with no real input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)