### PR TITLE
Add pinch-to-zoom to the MAUI print preview

### DIFF
--- a/src/WinPrint.Maui/MainPage.xaml
+++ b/src/WinPrint.Maui/MainPage.xaml
@@ -207,6 +207,7 @@
                           BackgroundColor="{AppThemeBinding Light=DarkGray, Dark=#555}">
                 <GraphicsView.GestureRecognizers>
                     <TapGestureRecognizer Tapped="OnPreviewTapped" />
+                    <PinchGestureRecognizer PinchUpdated="OnPreviewPinchUpdated" />
                 </GraphicsView.GestureRecognizers>
             </GraphicsView>
 

--- a/src/WinPrint.Maui/MainPage.xaml.cs
+++ b/src/WinPrint.Maui/MainPage.xaml.cs
@@ -293,6 +293,19 @@ public partial class MainPage : ContentPage
     }
 
     /// <summary>
+    ///     Pinch-to-zoom on the preview. <see cref="PinchGestureUpdatedEventArgs.Scale" />
+    ///     is the relative change since the previous update, so accumulate it
+    ///     multiplicatively, clamped to the same range as the zoom commands.
+    /// </summary>
+    private void OnPreviewPinchUpdated(object? sender, PinchGestureUpdatedEventArgs e)
+    {
+        if (e.Status == GestureStatus.Running)
+        {
+            _viewModel.ZoomFactor = Math.Clamp(_viewModel.ZoomFactor * (float)e.Scale, 0.25f, 4.0f);
+        }
+    }
+
+    /// <summary>
     ///     When preview is tapped and no file is loaded, open file dialog (per spec).
     /// </summary>
     private async void OnPreviewTapped(object? sender, TappedEventArgs e)


### PR DESCRIPTION
Fixes #94

The preview `GraphicsView` only had a `TapGestureRecognizer`, so pinch gestures did nothing — there was no `PinchGestureRecognizer` anywhere in the MAUI head. The zoom machinery itself (ZoomFactor → drawable, Ctrl+wheel, Ctrl+±) already worked.

## Changes
- Add a `PinchGestureRecognizer` to `PreviewGraphicsView`.
- `OnPreviewPinchUpdated` multiplies `ZoomFactor` by the per-update pinch `Scale` delta, clamped to the existing 0.25–4.0 command range.

## Verification
- Builds clean for `net10.0-windows10.0.19041.0`; smoke-ran the app with a file argument — loads and previews normally with the new recognizer attached.
- Actual pinch input needs touch hardware: not verifiable from this remote (locked) session — please give it a quick two-finger test on a touch screen. Note that touchpad pinch on Windows is typically delivered as Ctrl+wheel, which already worked; this adds true touch-screen pinch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)