### PR TITLE
run-maui-app skill: self-healing capture and locked-session key injection

### DIFF
--- a/.claude/skills/run-maui-app/SKILL.md
+++ b/.claude/skills/run-maui-app/SKILL.md
@@ -51,10 +51,32 @@ Signals:
 - `Graphics.CopyFromScreen` returns wallpaper/black if the session is locked
   (`Get-Process LogonUI` running ⇒ locked) — don't trust it.
 - `PrintWindow` flag must be `2` (`PW_RENDERFULLCONTENT`) or WinUI3 composition content
-  comes back black. The first capture right after launch can still be black; retry a few
-  seconds after the file loads.
+  comes back black. Even then, captures stay black until the composition surface is
+  poked — a **UIA `SetFocus` on any element in the window** reliably unsticks it
+  (waiting and resizing do NOT). The script detects an all-black result, pokes focus,
+  and recaptures automatically.
 - **Look at the screenshot**: a loaded file shows the rendered page with header
   (date | filename | language), line numbers, and footer ("Page x of y").
+
+## Inject keyboard input (works on a locked session)
+
+`SendInput`/`SendKeys` can't reach a locked desktop, but posting `WM_KEYDOWN`/`WM_KEYUP`
+to the app's **`InputSiteWindowClass`** child hwnd does enter the WinUI3 keyboard
+pipeline (posting to the top-level hwnd or `DesktopChildSiteBridge` does NOT). Keys
+route only if some XAML element has focus — use UIA `SetFocus` first if needed.
+
+```powershell
+# Find the input-site child hwnd via EnumChildWindows (class "InputSiteWindowClass"),
+# then e.g. PageDown (VK_NEXT=0x22, scan 0x51, extended):
+$lpDown = [IntPtr](0x1 -bor (0x51 -shl 16) -bor 0x01000000)
+$lpUp   = [IntPtr]([long]0x1 -bor (0x51 -shl 16) -bor 0x01000000 -bor 0xC0000000)
+[Win32]::PostMessage($inputSite, 0x0100, [IntPtr]0x22, $lpDown)  # WM_KEYDOWN
+[Win32]::PostMessage($inputSite, 0x0101, [IntPtr]0x22, $lpUp)    # WM_KEYUP
+```
+
+Verify paging took effect by capturing and reading the drawn footer ("Page x of y").
+Note: `GetKeyStateForCurrentThread`-based modifier checks (Ctrl/Shift) won't see
+modifiers this way — posted messages don't update the thread keyboard state.
 
 ## Drive the File button + Open dialog
 

--- a/.claude/skills/run-maui-app/scripts/Capture-Window.ps1
+++ b/.claude/skills/run-maui-app/scripts/Capture-Window.ps1
@@ -2,13 +2,16 @@
 # Uses PrintWindow with PW_RENDERFULLCONTENT (2), which is REQUIRED for WinUI3/MAUI
 # (DirectComposition) content and works even when the session is locked or the window
 # is occluded. Plain CopyFromScreen returns wallpaper/black on a locked session.
-# Note: the first PrintWindow attempt right after launch can come back black; retry
-# after the app has painted (a few seconds after the file loads).
+# Note: PrintWindow can come back black until the composition surface is poked — a UIA
+# SetFocus on any element in the window reliably unsticks it. This script detects an
+# (almost) all-black capture, pokes focus via UIA, and recaptures automatically.
 param(
     [Parameter(Mandatory)] [int] $ProcessId,
     [Parameter(Mandatory)] [string] $OutFile
 )
 Add-Type -AssemblyName System.Drawing
+Add-Type -AssemblyName UIAutomationClient
+Add-Type -AssemblyName UIAutomationTypes
 Add-Type @"
 using System;
 using System.Runtime.InteropServices;
@@ -21,24 +24,63 @@ public class Win32Cap {
     [StructLayout(LayoutKind.Sequential)] public struct RECT { public int Left, Top, Right, Bottom; }
 }
 "@
+
+function Invoke-Capture([IntPtr] $hwnd) {
+    $rect = New-Object Win32Cap+RECT
+    [Win32Cap]::GetWindowRect($hwnd, [ref]$rect) | Out-Null
+    $w = $rect.Right - $rect.Left
+    $h = $rect.Bottom - $rect.Top
+    if ($w -le 0 -or $h -le 0) { throw "Bad window rect" }
+    $bmp = New-Object System.Drawing.Bitmap($w, $h)
+    $gfx = [System.Drawing.Graphics]::FromImage($bmp)
+    $hdc = $gfx.GetHdc()
+    $ok = [Win32Cap]::PrintWindow($hwnd, $hdc, 2)  # 2 = PW_RENDERFULLCONTENT
+    $gfx.ReleaseHdc($hdc)
+    $gfx.Dispose()
+    if (-not $ok) { Write-Warning "PrintWindow returned false" }
+    return $bmp
+}
+
+function Test-MostlyBlack([System.Drawing.Bitmap] $bmp) {
+    # Sample a sparse grid; treat as black when nearly every sample is black.
+    $samples = 0; $black = 0
+    for ($y = 10; $y -lt $bmp.Height; $y += [Math]::Max(1, [int]($bmp.Height / 12))) {
+        for ($x = 10; $x -lt $bmp.Width; $x += [Math]::Max(1, [int]($bmp.Width / 12))) {
+            $px = $bmp.GetPixel($x, $y)
+            $samples++
+            if ($px.R -lt 8 -and $px.G -lt 8 -and $px.B -lt 8) { $black++ }
+        }
+    }
+    return ($samples -gt 0 -and $black / $samples -gt 0.98)
+}
+
 $proc = Get-Process -Id $ProcessId -ErrorAction Stop
 $hwnd = $proc.MainWindowHandle
 if ($hwnd -eq [IntPtr]::Zero) { throw "Process $ProcessId has no main window" }
 if ([Win32Cap]::IsIconic($hwnd)) { [Win32Cap]::ShowWindow($hwnd, 9) | Out-Null; Start-Sleep -Milliseconds 500 }
 [Win32Cap]::SetForegroundWindow($hwnd) | Out-Null
 Start-Sleep -Milliseconds 500
-$rect = New-Object Win32Cap+RECT
-[Win32Cap]::GetWindowRect($hwnd, [ref]$rect) | Out-Null
-$w = $rect.Right - $rect.Left
-$h = $rect.Bottom - $rect.Top
-if ($w -le 0 -or $h -le 0) { throw "Bad window rect" }
-$bmp = New-Object System.Drawing.Bitmap($w, $h)
-$gfx = [System.Drawing.Graphics]::FromImage($bmp)
-$hdc = $gfx.GetHdc()
-$ok = [Win32Cap]::PrintWindow($hwnd, $hdc, 2)  # 2 = PW_RENDERFULLCONTENT
-$gfx.ReleaseHdc($hdc)
-$gfx.Dispose()
-if (-not $ok) { Write-Warning "PrintWindow returned false" }
+
+$bmp = Invoke-Capture $hwnd
+if (Test-MostlyBlack $bmp) {
+    $bmp.Dispose()
+    # Poke the window via UIA focus to force the composition surface to materialize.
+    $root = [System.Windows.Automation.AutomationElement]::RootElement
+    $cond = New-Object System.Windows.Automation.PropertyCondition(
+        [System.Windows.Automation.AutomationElement]::ProcessIdProperty, $ProcessId)
+    $win = $root.FindFirst([System.Windows.Automation.TreeScope]::Children, $cond)
+    if ($win -ne $null) {
+        $focusable = New-Object System.Windows.Automation.PropertyCondition(
+            [System.Windows.Automation.AutomationElement]::IsKeyboardFocusableProperty, $true)
+        $el = $win.FindFirst([System.Windows.Automation.TreeScope]::Descendants, $focusable)
+        if ($el -ne $null) { try { $el.SetFocus() } catch {} }
+    }
+    Start-Sleep -Seconds 3
+    $bmp = Invoke-Capture $hwnd
+    if (Test-MostlyBlack $bmp) { Write-Warning "Capture still looks black after UIA focus poke" }
+}
+
 $bmp.Save($OutFile, [System.Drawing.Imaging.ImageFormat]::Png)
+$size = "$($bmp.Width)x$($bmp.Height)"
 $bmp.Dispose()
-Write-Output "Saved ${w}x${h} screenshot to $OutFile (title: '$($proc.MainWindowTitle)')"
+Write-Output "Saved $size screenshot to $OutFile (title: '$($proc.MainWindowTitle)')"


### PR DESCRIPTION
Two hard-won lessons from verifying #94/#95 folded back into the skill:

- **Self-healing screenshots**: `PrintWindow` of WinUI3 content stays black until the composition surface is poked; waiting and resizing do nothing, but a UIA `SetFocus` on any element unsticks it instantly. `Capture-Window.ps1` now samples the capture, detects all-black, pokes focus via UIA, and recaptures — verified working in a single invocation against a fresh app instance.
- **Keyboard injection on a locked session**: `SendInput` can''t reach a locked desktop, but posting `WM_KEYDOWN`/`WM_KEYUP` to the app''s `InputSiteWindowClass` child hwnd enters the WinUI3 keyboard pipeline (the top-level hwnd and `DesktopChildSiteBridge` do not work). Documented with the VK/scan-code recipe and the caveat that some XAML element must have focus for keys to route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)