### PR TITLE
MacCatalyst: disable File ▸ Print… when no document is loaded

### DIFF
--- a/src/WinPrint.Maui/MainPage.xaml.cs
+++ b/src/WinPrint.Maui/MainPage.xaml.cs
@@ -43,6 +43,12 @@ public partial class MainPage : ContentPage
         // native UIMenuBuilder already adds (and merges correctly into the system File
         // menu). Drop the MAUI copy here so the Mac shows a single File menu.
         MenuBarItems.Clear();
+
+        // The native File ▸ Print… item is greyed out when PrintCommand can't execute (see the
+        // AppDelegate's BuildMenu). Rebuild the menu whenever that changes — e.g. a file loads —
+        // so the item enables/disables in step with CanPrint.
+        _viewModel.PrintCommand.CanExecuteChanged += (_, _) =>
+            MainThread.BeginInvokeOnMainThread(() => UIKit.UIMenuSystem.MainSystem.SetNeedsRebuild());
 #endif
 
         BindingContext = _viewModel;

--- a/src/WinPrint.Maui/Platforms/MacCatalyst/AppDelegate.cs
+++ b/src/WinPrint.Maui/Platforms/MacCatalyst/AppDelegate.cs
@@ -41,6 +41,14 @@ public class AppDelegate : MauiUIApplicationDelegate
         var print = UIKeyCommand.Create(
             "Print…", null, new Selector(PrintSelector), "p", UIKeyModifierFlags.Command, null);
 
+        // Grey out Print when there's nothing to print (no document loaded). MainPage asks the
+        // menu system to rebuild whenever PrintCommand's executability changes, so this stays in
+        // sync — see the CanExecuteChanged hook in MainPage's ctor.
+        if (MainPage.Current?.CanPrint != true)
+        {
+            print.Attributes = UIMenuElementAttributes.Disabled;
+        }
+
         // DisplayInline so the two items merge into the existing File menu as a group
         // rather than appearing as a nested submenu.
         var group = UIMenu.Create(


### PR DESCRIPTION
Addresses the Copilot review comment on #101: the native **File ▸ Print…** menu item was always enabled even when `PrintCommand` can't execute — so it looked clickable but `InvokePrint()` was a no-op, and the `MainPage.CanPrint` property I'd added was unused.

## Fix
- `AppDelegate.BuildMenu` sets the Print command's `Attributes` to **Disabled** when `MainPage.Current?.CanPrint` is false (no document loaded). This finally uses `CanPrint`.
- `MainPage` (MacCatalyst) calls `UIMenuSystem.MainSystem.SetNeedsRebuild()` whenever `PrintCommand.CanExecuteChanged` fires, so the item greys/ungreys as files load and unload.

`InvokePrint()` is already guarded, so this is purely the visual/UX correctness the reviewer asked for. Built `net10.0-maccatalyst` (0/0); menu-enablement is runtime UIKit behavior best confirmed visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)