### PR TITLE
MarkdownCte: render Markdown richly (not flattened to plain text)

### DIFF
--- a/src/WinPrint.Core/ContentTypeEngines/MarkdownCte.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/MarkdownCte.cs
@@ -299,10 +299,11 @@ public class MarkdownCte : ContentTypeEngineBase
         float charWidth = Math.Max(1f, Measure(g, "M", font).Width);
         int maxChars = Math.Max(8, (int)Math.Floor((PageSize.Width - indent) / charWidth));
 
+        string tab = new(' ', Math.Max(0, ContentSettings!.TabSpaces));
         bool first = true;
         for (int n = 0; n < code.Lines.Count; n++)
         {
-            string raw = code.Lines.Lines[n].Slice.ToString().Replace("\t", "    ");
+            string raw = code.Lines.Lines[n].Slice.ToString().Replace("\t", tab);
             // char-wrap long code lines so they don't clip
             for (int start = 0; start == 0 || start < raw.Length; start += maxChars)
             {
@@ -665,6 +666,43 @@ public class MarkdownCte : ContentTypeEngineBase
                 Flush();
             }
 
+            // A single token wider than a full empty line (e.g. a long URL) can't be placed whole
+            // without clipping; hard-split it character-by-character to fit, mirroring TextCte. The 1px
+            // tolerance avoids splitting at exact-fit column boundaries (sub-pixel measurement drift).
+            if (w > maxWidth - line.Indent + 1f && tok.Text.Length > 1)
+            {
+                string remaining = tok.Text;
+                while (remaining.Length > 0)
+                {
+                    float curAvail = maxWidth - line.Indent - x;
+                    int fit = FitChars(g, remaining, font, curAvail);
+                    if (fit <= 0)
+                    {
+                        if (any)
+                        {
+                            Flush();
+                            continue; // retry on a fresh line
+                        }
+
+                        fit = 1; // guarantee progress on an empty line
+                    }
+
+                    string piece = remaining[..fit];
+                    line.Runs.Add(new MarkdownRun
+                    { Text = piece, Scale = tok.Scale, Style = tok.Style, Color = tok.Color });
+                    x += Measure(g, piece, font).Width;
+                    maxHeight = Math.Max(maxHeight, h);
+                    any = true;
+                    remaining = remaining[fit..];
+                    if (remaining.Length > 0)
+                    {
+                        Flush();
+                    }
+                }
+
+                continue;
+            }
+
             line.Runs.Add(tok);
             x += w;
             maxHeight = Math.Max(maxHeight, h);
@@ -730,6 +768,19 @@ public class MarkdownCte : ContentTypeEngineBase
     {
         var proposed = new GraphicsSizeF(PageSize.Width, _baseLineHeight * 4f);
         return g.MeasureString(text, font, proposed, GraphicsStringFormat, out _, out _);
+    }
+
+    /// <summary>Longest prefix of <paramref name="text" /> (in characters) that fits <paramref name="width" />.</summary>
+    private int FitChars(IGraphicsContext g, string text, IGraphicsFont font, float width)
+    {
+        if (width <= 0)
+        {
+            return 0;
+        }
+
+        var proposed = new GraphicsSizeF(width, _baseLineHeight * 4f);
+        g.MeasureString(text, font, proposed, GraphicsStringFormat, out int charsFitted, out _);
+        return Math.Min(charsFitted, text.Length);
     }
 
     private static float HeadingScale(int level)

--- a/src/WinPrint.Core/ContentTypeEngines/MarkdownCte.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/MarkdownCte.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using System.Runtime.InteropServices;
 using Markdig;
+using Markdig.Extensions.Tables;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
 using Serilog;
@@ -36,6 +37,7 @@ public class MarkdownCte : ContentTypeEngineBase
     private static readonly GraphicsColor CodeBgColor = GraphicsColor.FromRgb(0xf3, 0xf3, 0xf5);
     private static readonly GraphicsColor QuoteBarColor = GraphicsColor.FromRgb(0xcf, 0xd3, 0xda);
     private static readonly GraphicsColor RuleColor = GraphicsColor.FromRgb(0xc7, 0xcc, 0xd6);
+    private static readonly GraphicsColor TableHeaderColor = GraphicsColor.FromRgb(0xee, 0xf1, 0xf6);
 
     private readonly List<MarkdownLine> _lines = [];
     private float _baseLineHeight;
@@ -126,7 +128,9 @@ public class MarkdownCte : ContentTypeEngineBase
 
         using IGraphicsBrush codeBg = g.CreateSolidBrush(CodeBgColor);
         using IGraphicsBrush quoteBar = g.CreateSolidBrush(QuoteBarColor);
+        using IGraphicsBrush headerBg = g.CreateSolidBrush(TableHeaderColor);
         using IGraphicsPen rulePen = g.CreatePen(RuleColor, 2f);
+        using IGraphicsPen gridPen = g.CreatePen(RuleColor);
 
         foreach (MarkdownLine line in _lines)
         {
@@ -153,6 +157,29 @@ public class MarkdownCte : ContentTypeEngineBase
                 continue;
             }
 
+            if (line.ColumnEdges is { Count: > 1 } edges)
+            {
+                if (line.HeaderShade)
+                {
+                    g.FillRectangle(headerBg, edges[0], line.Y, edges[^1] - edges[0], line.Height);
+                }
+
+                foreach (float ex in edges)
+                {
+                    g.DrawLine(gridPen, ex, line.Y, ex, line.Y + line.Height);
+                }
+
+                if (line.TableRowTop)
+                {
+                    g.DrawLine(gridPen, edges[0], line.Y, edges[^1], line.Y);
+                }
+
+                if (line.TableRowBottom)
+                {
+                    g.DrawLine(gridPen, edges[0], line.Y + line.Height, edges[^1], line.Y + line.Height);
+                }
+            }
+
             float x = line.Indent;
             foreach (MarkdownRun run in line.Runs)
             {
@@ -164,8 +191,9 @@ public class MarkdownCte : ContentTypeEngineBase
                 using IGraphicsFont font = g.CreateFont(ContentSettings.Font.Family, basePt * run.Scale, run.Style,
                     unit);
                 using IGraphicsBrush brush = g.CreateSolidBrush(run.Color);
-                g.DrawString(run.Text, font, brush, x, line.Y, GraphicsStringFormat);
-                x += Measure(g, run.Text, font).Width;
+                float rx = run.X ?? x;
+                g.DrawString(run.Text, font, brush, rx, line.Y, GraphicsStringFormat);
+                x = rx + Measure(g, run.Text, font).Width;
             }
         }
     }
@@ -199,6 +227,9 @@ public class MarkdownCte : ContentTypeEngineBase
                     break;
                 case ThematicBreakBlock:
                     EmitRule(indentLevel, quoteDepth);
+                    break;
+                case Table table:
+                    EmitTable(table, g, fonts, indentLevel, quoteDepth);
                     break;
                 case ContainerBlock container:
                     WalkBlocks(container, g, fonts, indentLevel, quoteDepth);
@@ -247,7 +278,8 @@ public class MarkdownCte : ContentTypeEngineBase
 
         float quoteGutter = quoteDepth * _indentStep;
         float markerIndent = quoteGutter + indentLevel * _indentStep + _indentStep * 0.4f;
-        List<MarkdownLine> lines = WrapTokens(tokens, g, fonts, markerIndent, markerIndent + markerWidth);
+        List<MarkdownLine> lines = WrapTokens(tokens, g, fonts, markerIndent, markerIndent + markerWidth,
+            PageSize.Width);
         Decorate(lines, _baseLineHeight * 0.18f, quoteDepth > 0);
         _lines.AddRange(lines);
 
@@ -313,6 +345,150 @@ public class MarkdownCte : ContentTypeEngineBase
         });
     }
 
+    private void EmitTable(Table table, IGraphicsContext g, Dictionary<string, IGraphicsFont> fonts,
+        int indentLevel, int quoteDepth)
+    {
+        // Flatten every cell's inline content into tokens; track header rows and the column count.
+        var rows = new List<(bool Header, List<List<MarkdownRun>> Cells)>();
+        int cols = 0;
+        foreach (Block rowBlock in table)
+        {
+            if (rowBlock is not TableRow row)
+            {
+                continue;
+            }
+
+            var cells = new List<List<MarkdownRun>>();
+            GraphicsFontStyle style = row.IsHeader ? GraphicsFontStyle.Bold : GraphicsFontStyle.Regular;
+            GraphicsColor color = quoteDepth > 0 ? QuoteColor : TextColor;
+            foreach (Block cellBlock in row)
+            {
+                if (cellBlock is not TableCell cell)
+                {
+                    continue;
+                }
+
+                var toks = new List<MarkdownRun>();
+                foreach (Block b in cell)
+                {
+                    if (b is LeafBlock { Inline: { } cin })
+                    {
+                        FlattenInlines(cin, 1f, style, color, toks);
+                    }
+                }
+
+                cells.Add(toks);
+            }
+
+            cols = Math.Max(cols, cells.Count);
+            rows.Add((row.IsHeader, cells));
+        }
+
+        if (cols == 0)
+        {
+            return;
+        }
+
+        float indent = quoteDepth * _indentStep + indentLevel * _indentStep;
+        float avail = PageSize.Width - indent;
+        float pad = _baseSizePx * 0.4f;
+
+        // Column widths: natural content width per column, scaled to fit the available width.
+        float[] widths = new float[cols];
+        foreach ((bool _, List<List<MarkdownRun>> cells) in rows)
+        {
+            for (int c = 0; c < cells.Count; c++)
+            {
+                widths[c] = Math.Max(widths[c], MeasureTokens(g, fonts, cells[c]) + 2 * pad);
+            }
+        }
+
+        float total = widths.Sum();
+        if (total > avail && total > 0)
+        {
+            for (int c = 0; c < cols; c++)
+            {
+                widths[c] *= avail / total;
+            }
+        }
+
+        float[] edges = new float[cols + 1];
+        edges[0] = indent;
+        for (int c = 0; c < cols; c++)
+        {
+            edges[c + 1] = edges[c] + widths[c];
+        }
+
+        IReadOnlyList<float> edgeList = edges;
+
+        for (int r = 0; r < rows.Count; r++)
+        {
+            (bool header, List<List<MarkdownRun>> cells) = rows[r];
+            var cellLines = new List<List<MarkdownLine>>();
+            int visual = 1;
+            for (int c = 0; c < cols; c++)
+            {
+                List<MarkdownRun> toks = c < cells.Count ? cells[c] : [];
+                List<MarkdownLine> wrapped = WrapTokens(toks, g, fonts, 0f, 0f, Math.Max(1f, widths[c] - 2 * pad));
+                cellLines.Add(wrapped);
+                visual = Math.Max(visual, wrapped.Count);
+            }
+
+            for (int k = 0; k < visual; k++)
+            {
+                var rowLine = new MarkdownLine
+                {
+                    Indent = indent,
+                    Height = _baseLineHeight,
+                    ColumnEdges = edgeList,
+                    TableRowTop = k == 0,
+                    TableRowBottom = r == rows.Count - 1 && k == visual - 1,
+                    HeaderShade = header,
+                    QuoteBar = quoteDepth > 0,
+                    SpaceBefore = r == 0 && k == 0 ? _baseLineHeight * 0.5f : 0f
+                };
+
+                for (int c = 0; c < cols; c++)
+                {
+                    if (k >= cellLines[c].Count)
+                    {
+                        continue;
+                    }
+
+                    bool firstInCell = true;
+                    foreach (MarkdownRun run in cellLines[c][k].Runs)
+                    {
+                        if (firstInCell)
+                        {
+                            run.X = edges[c] + pad;
+                            firstInCell = false;
+                        }
+
+                        rowLine.Runs.Add(run);
+                    }
+                }
+
+                _lines.Add(rowLine);
+            }
+        }
+    }
+
+    private float MeasureTokens(IGraphicsContext g, Dictionary<string, IGraphicsFont> fonts, List<MarkdownRun> tokens)
+    {
+        float w = 0f;
+        foreach (MarkdownRun t in tokens)
+        {
+            if (t.Text == "\n")
+            {
+                continue;
+            }
+
+            w += Measure(g, t.Text, GetFont(g, fonts, t.Scale, t.Style)).Width;
+        }
+
+        return w;
+    }
+
     private void EmitInline(ContainerInline? inline, IGraphicsContext g, Dictionary<string, IGraphicsFont> fonts,
         float scale, GraphicsFontStyle style, GraphicsColor color, int indentLevel, int quoteDepth, float spaceBefore)
     {
@@ -324,7 +500,7 @@ public class MarkdownCte : ContentTypeEngineBase
         }
 
         float indent = quoteDepth * _indentStep + indentLevel * _indentStep;
-        List<MarkdownLine> lines = WrapTokens(tokens, g, fonts, indent, indent);
+        List<MarkdownLine> lines = WrapTokens(tokens, g, fonts, indent, indent, PageSize.Width);
         Decorate(lines, spaceBefore, quoteDepth > 0);
         _lines.AddRange(lines);
     }
@@ -440,7 +616,7 @@ public class MarkdownCte : ContentTypeEngineBase
     // ---- wrapping & pagination --------------------------------------------------------------------
 
     private List<MarkdownLine> WrapTokens(List<MarkdownRun> tokens, IGraphicsContext g,
-        Dictionary<string, IGraphicsFont> fonts, float firstIndent, float restIndent)
+        Dictionary<string, IGraphicsFont> fonts, float firstIndent, float restIndent, float maxWidth)
     {
         var lines = new List<MarkdownLine>();
         var line = new MarkdownLine { Indent = firstIndent };
@@ -469,7 +645,7 @@ public class MarkdownCte : ContentTypeEngineBase
             IGraphicsFont font = GetFont(g, fonts, tok.Scale, tok.Style);
             float w = Measure(g, tok.Text, font).Width;
             float h = font.GetHeight(_dpiY);
-            float avail = PageSize.Width - line.Indent;
+            float avail = maxWidth - line.Indent;
 
             if (tok.IsSpace)
             {

--- a/src/WinPrint.Core/ContentTypeEngines/MarkdownCte.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/MarkdownCte.cs
@@ -1,51 +1,569 @@
 // Copyright Kindel, LLC - http://www.kindel.com
 // Published under the MIT License at https://github.com/tig/winprint
 
+using System.Globalization;
+using System.Runtime.InteropServices;
 using Markdig;
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
+using Serilog;
+using WinPrint.Core.Abstractions;
 using WinPrint.Core.Models;
 using WinPrint.Core.Services;
 
 namespace WinPrint.Core.ContentTypeEngines;
 
 /// <summary>
-///     Implements text/x-markdown (Markdown) file type support.
-///     Uses Markdig to convert the Markdown source to plain text, then renders it through the
-///     text rendering pipeline (inherited from <see cref="TextCte" />), including line numbers
-///     and word/line wrapping. Markdown formatting (emphasis, headings, links, etc.) is flattened
-///     to readable plain text; the document is not syntax highlighted.
+///     Implements text/x-markdown by rendering the Markdig AST richly through the
+///     <see cref="IGraphicsContext" /> pipeline: headings (scaled + bold), bold/italic, inline code,
+///     bulleted/numbered/nested lists, blockquotes (indented with a bar), fenced/indented code blocks
+///     (monospace on a shaded background), horizontal rules, and links (colored). Reflow word-wraps
+///     styled runs into variable-height <see cref="MarkdownLine" />s and paginates by cumulative height.
+///     Images render as alt text — <see cref="IGraphicsContext" /> has no image primitive.
 /// </summary>
-public class MarkdownCte : TextCte
+public class MarkdownCte : ContentTypeEngineBase
 {
     private static readonly string[] s_supportedContentTypes = ["text/x-markdown"];
 
-    /// <summary>
-    ///     The Markdig pipeline used to flatten Markdown to plain text. Enabling advanced
-    ///     extensions ensures tables, task lists, etc. are handled gracefully.
-    /// </summary>
     private static readonly MarkdownPipeline s_pipeline =
         new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
 
-    /// <summary>
-    ///     ContentType identifier (shorthand for class name).
-    /// </summary>
+    private static readonly GraphicsColor TextColor = GraphicsColor.FromRgb(0x1d, 0x1d, 0x1f);
+    private static readonly GraphicsColor LinkColor = GraphicsColor.FromRgb(0x0b, 0x57, 0xd0);
+    private static readonly GraphicsColor CodeColor = GraphicsColor.FromRgb(0x37, 0x37, 0x37);
+    private static readonly GraphicsColor InlineCodeColor = GraphicsColor.FromRgb(0x9a, 0x34, 0x4f);
+    private static readonly GraphicsColor QuoteColor = GraphicsColor.FromRgb(0x5a, 0x5a, 0x5a);
+    private static readonly GraphicsColor CodeBgColor = GraphicsColor.FromRgb(0xf3, 0xf3, 0xf5);
+    private static readonly GraphicsColor QuoteBarColor = GraphicsColor.FromRgb(0xcf, 0xd3, 0xda);
+    private static readonly GraphicsColor RuleColor = GraphicsColor.FromRgb(0xc7, 0xcc, 0xd6);
+
+    private readonly List<MarkdownLine> _lines = [];
+    private float _baseLineHeight;
+    private float _baseSizePx;
+    private int _dpiY = 96;
+    private float _indentStep;
+    private int _pageCount;
+
     public override string[] SupportedContentTypes => s_supportedContentTypes;
 
-    public new static MarkdownCte Create()
+    public static MarkdownCte Create()
     {
         var engine = new MarkdownCte();
-        // Populate it with the common settings
         engine.CopyPropertiesFrom(ModelLocator.Current.Settings.MarkdownContentTypeEngineSettings);
         return engine;
     }
 
-    /// <summary>
-    ///     Converts the Markdown <paramref name="doc" /> to plain text before handing it to the
-    ///     text rendering pipeline.
-    /// </summary>
     public override async Task<bool> SetDocumentAsync(string doc)
     {
-        LogService.TraceMessage($"Converting {doc?.Length ?? 0} chars of Markdown to plain text.");
-        string plainText = Markdown.ToPlainText(doc ?? string.Empty, s_pipeline);
-        return await base.SetDocumentAsync(plainText);
+        Document = doc ?? string.Empty;
+        return await Task.FromResult(true);
+    }
+
+    public override async Task<int> RenderAsync(PrintResolution? printerResolution, EventHandler<string>? reflowProgress)
+    {
+        LogService.TraceMessage();
+        if (Document is null)
+        {
+            throw new InvalidOperationException("Document can't be null for RenderAsync");
+        }
+
+        ArgumentNullException.ThrowIfNull(printerResolution);
+        int dpiX = printerResolution.X;
+        int dpiY = printerResolution.Y;
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || dpiX < 0 || dpiY < 0)
+        {
+            dpiX = dpiY = 96;
+        }
+
+        _dpiY = dpiY;
+        _lines.Clear();
+
+        IGraphicsContext g = ResolveMeasurementContext(dpiX, dpiY, out IDisposable? owner);
+        var fontCache = new Dictionary<string, IGraphicsFont>();
+        try
+        {
+            g.SetTextRenderingMode(GraphicsTextRenderingMode);
+            _baseSizePx = ContentSettings!.Font.Size / 72F * 96F;
+            _baseLineHeight = GetFont(g, fontCache, 1f, GraphicsFontStyle.Regular).GetHeight(dpiY);
+            _indentStep = _baseSizePx * 1.6f;
+
+            if (PageSize.Height < _baseLineHeight)
+            {
+                throw new InvalidOperationException(
+                    $"Line height ({_baseLineHeight:F2}) exceeds page height ({PageSize.Height:F2}).");
+            }
+
+            MarkdownDocument ast = Markdown.Parse(Document, s_pipeline);
+            WalkBlocks(ast, g, fontCache, indentLevel: 0, quoteDepth: 0);
+
+            _pageCount = Paginate();
+            Log.Debug("Rendered {pages} Markdown pages from {lines} lines.", _pageCount, _lines.Count);
+            return await Task.FromResult(_pageCount);
+        }
+        finally
+        {
+            foreach (IGraphicsFont f in fontCache.Values)
+            {
+                f.Dispose();
+            }
+
+            owner?.Dispose();
+        }
+    }
+
+    public override void PaintPage(IGraphicsContext g, int pageNum)
+    {
+        LogService.TraceMessage($"{pageNum}");
+        if (_lines.Count == 0)
+        {
+            return;
+        }
+
+        g.SetTextRenderingMode(GraphicsTextRenderingMode);
+        GraphicsFontUnit unit = g.IsDisplayUnit ? GraphicsFontUnit.Point : GraphicsFontUnit.Pixel;
+        float basePt = g.IsDisplayUnit ? ContentSettings!.Font.Size : ContentSettings!.Font.Size / 72F * 96F;
+
+        using IGraphicsBrush codeBg = g.CreateSolidBrush(CodeBgColor);
+        using IGraphicsBrush quoteBar = g.CreateSolidBrush(QuoteBarColor);
+        using IGraphicsPen rulePen = g.CreatePen(RuleColor, 2f);
+
+        foreach (MarkdownLine line in _lines)
+        {
+            if (line.Page != pageNum)
+            {
+                continue;
+            }
+
+            if (line.CodeBackground)
+            {
+                g.FillRectangle(codeBg, line.Indent - _indentStep * 0.3f, line.Y,
+                    PageSize.Width - (line.Indent - _indentStep * 0.3f), line.Height);
+            }
+
+            if (line.QuoteBar)
+            {
+                g.FillRectangle(quoteBar, line.Indent - _indentStep * 0.6f, line.Y, _baseSizePx * 0.22f, line.Height);
+            }
+
+            if (line.Rule)
+            {
+                float midY = line.Y + (line.Height / 2f);
+                g.DrawLine(rulePen, line.Indent, midY, PageSize.Width, midY);
+                continue;
+            }
+
+            float x = line.Indent;
+            foreach (MarkdownRun run in line.Runs)
+            {
+                if (run.Text.Length == 0)
+                {
+                    continue;
+                }
+
+                using IGraphicsFont font = g.CreateFont(ContentSettings.Font.Family, basePt * run.Scale, run.Style, unit);
+                using IGraphicsBrush brush = g.CreateSolidBrush(run.Color);
+                g.DrawString(run.Text, font, brush, x, line.Y, GraphicsStringFormat);
+                x += Measure(g, run.Text, font).Width;
+            }
+        }
+    }
+
+    // ---- AST walk ---------------------------------------------------------------------------------
+
+    private void WalkBlocks(IEnumerable<Block> blocks, IGraphicsContext g, Dictionary<string, IGraphicsFont> fonts,
+        int indentLevel, int quoteDepth)
+    {
+        foreach (Block block in blocks)
+        {
+            switch (block)
+            {
+                case HeadingBlock h:
+                    EmitInline(h.Inline, g, fonts, HeadingScale(h.Level), GraphicsFontStyle.Bold,
+                        quoteDepth > 0 ? QuoteColor : TextColor, indentLevel, quoteDepth,
+                        _baseLineHeight * (h.Level <= 2 ? 1.0f : 0.7f));
+                    break;
+                case ParagraphBlock p:
+                    EmitInline(p.Inline, g, fonts, 1f, GraphicsFontStyle.Regular,
+                        quoteDepth > 0 ? QuoteColor : TextColor, indentLevel, quoteDepth, _baseLineHeight * 0.5f);
+                    break;
+                case ListBlock list:
+                    EmitList(list, g, fonts, indentLevel, quoteDepth);
+                    break;
+                case QuoteBlock quote:
+                    WalkBlocks(quote, g, fonts, indentLevel, quoteDepth + 1);
+                    break;
+                case Markdig.Syntax.CodeBlock code: // covers FencedCodeBlock too
+                    EmitCodeBlock(code, g, fonts, indentLevel, quoteDepth);
+                    break;
+                case ThematicBreakBlock:
+                    EmitRule(indentLevel, quoteDepth);
+                    break;
+                case ContainerBlock container:
+                    WalkBlocks(container, g, fonts, indentLevel, quoteDepth);
+                    break;
+                case LeafBlock leaf when leaf.Inline is not null:
+                    EmitInline(leaf.Inline, g, fonts, 1f, GraphicsFontStyle.Regular, TextColor, indentLevel,
+                        quoteDepth, _baseLineHeight * 0.5f);
+                    break;
+            }
+        }
+    }
+
+    private void EmitList(ListBlock list, IGraphicsContext g, Dictionary<string, IGraphicsFont> fonts,
+        int indentLevel, int quoteDepth)
+    {
+        int ordinal = TryParseStart(list.OrderedStart, 1);
+        foreach (Block child in list)
+        {
+            if (child is not ListItemBlock item)
+            {
+                continue;
+            }
+
+            string marker = list.IsOrdered
+                ? $"{ordinal.ToString(CultureInfo.InvariantCulture)}."
+                : "•";
+            ordinal++;
+            EmitListItem(item, marker, g, fonts, indentLevel, quoteDepth);
+        }
+    }
+
+    private void EmitListItem(ListItemBlock item, string marker, IGraphicsContext g,
+        Dictionary<string, IGraphicsFont> fonts, int indentLevel, int quoteDepth)
+    {
+        List<Block> children = [.. item];
+        ContainerInline? firstInline = children.Count > 0 && children[0] is LeafBlock { Inline: { } li } ? li : null;
+
+        IGraphicsFont markerFont = GetFont(g, fonts, 1f, GraphicsFontStyle.Regular);
+        var tokens = new List<MarkdownRun>();
+        AppendText($"{marker} ", 1f, GraphicsFontStyle.Regular, quoteDepth > 0 ? QuoteColor : TextColor, tokens);
+        float markerWidth = Measure(g, $"{marker} ", markerFont).Width;
+        if (firstInline is not null)
+        {
+            FlattenInlines(firstInline, 1f, GraphicsFontStyle.Regular, quoteDepth > 0 ? QuoteColor : TextColor, tokens);
+        }
+
+        float quoteGutter = quoteDepth * _indentStep;
+        float markerIndent = quoteGutter + (indentLevel * _indentStep) + (_indentStep * 0.4f);
+        List<MarkdownLine> lines = WrapTokens(tokens, g, fonts, markerIndent, markerIndent + markerWidth);
+        Decorate(lines, _baseLineHeight * 0.18f, quoteDepth > 0);
+        _lines.AddRange(lines);
+
+        // Nested blocks (sub-lists, extra paragraphs) render one level deeper.
+        for (int i = firstInline is null ? 0 : 1; i < children.Count; i++)
+        {
+            WalkBlocks([children[i]], g, fonts, indentLevel + 1, quoteDepth);
+        }
+    }
+
+    private void EmitCodeBlock(Markdig.Syntax.CodeBlock code, IGraphicsContext g,
+        Dictionary<string, IGraphicsFont> fonts, int indentLevel, int quoteDepth)
+    {
+        float indent = (quoteDepth * _indentStep) + (indentLevel * _indentStep) + (_indentStep * 0.4f);
+        IGraphicsFont font = GetFont(g, fonts, 0.92f, GraphicsFontStyle.Regular);
+        float height = font.GetHeight(_dpiY);
+        float charWidth = Math.Max(1f, Measure(g, "M", font).Width);
+        int maxChars = Math.Max(8, (int)Math.Floor((PageSize.Width - indent) / charWidth));
+
+        bool first = true;
+        for (int n = 0; n < code.Lines.Count; n++)
+        {
+            string raw = code.Lines.Lines[n].Slice.ToString().Replace("\t", "    ");
+            // char-wrap long code lines so they don't clip
+            for (int start = 0; start == 0 || start < raw.Length; start += maxChars)
+            {
+                string seg = raw.Length == 0 ? string.Empty : raw.Substring(start, Math.Min(maxChars, raw.Length - start));
+                var line = new MarkdownLine
+                {
+                    Indent = indent,
+                    Height = height,
+                    CodeBackground = true,
+                    QuoteBar = quoteDepth > 0,
+                    SpaceBefore = first ? _baseLineHeight * 0.5f : 0f
+                };
+                if (seg.Length > 0)
+                {
+                    line.Runs.Add(new MarkdownRun { Text = seg, Scale = 0.92f, Color = CodeColor });
+                }
+
+                _lines.Add(line);
+                first = false;
+                if (raw.Length == 0)
+                {
+                    break;
+                }
+            }
+        }
+    }
+
+    private void EmitRule(int indentLevel, int quoteDepth)
+    {
+        float indent = (quoteDepth * _indentStep) + (indentLevel * _indentStep);
+        _lines.Add(new MarkdownLine
+        {
+            Indent = indent,
+            Height = _baseLineHeight,
+            Rule = true,
+            QuoteBar = quoteDepth > 0,
+            SpaceBefore = _baseLineHeight * 0.5f
+        });
+    }
+
+    private void EmitInline(ContainerInline? inline, IGraphicsContext g, Dictionary<string, IGraphicsFont> fonts,
+        float scale, GraphicsFontStyle style, GraphicsColor color, int indentLevel, int quoteDepth, float spaceBefore)
+    {
+        var tokens = new List<MarkdownRun>();
+        FlattenInlines(inline, scale, style, color, tokens);
+        if (tokens.Count == 0)
+        {
+            return;
+        }
+
+        float indent = (quoteDepth * _indentStep) + (indentLevel * _indentStep);
+        List<MarkdownLine> lines = WrapTokens(tokens, g, fonts, indent, indent);
+        Decorate(lines, spaceBefore, quoteDepth > 0);
+        _lines.AddRange(lines);
+    }
+
+    private static void Decorate(List<MarkdownLine> lines, float spaceBefore, bool quote)
+    {
+        for (int i = 0; i < lines.Count; i++)
+        {
+            if (i == 0)
+            {
+                lines[i].SpaceBefore = spaceBefore;
+            }
+
+            if (quote)
+            {
+                lines[i].QuoteBar = true;
+            }
+        }
+    }
+
+    // ---- inline flattening ------------------------------------------------------------------------
+
+    private void FlattenInlines(ContainerInline? container, float scale, GraphicsFontStyle style,
+        GraphicsColor color, List<MarkdownRun> tokens)
+    {
+        if (container is null)
+        {
+            return;
+        }
+
+        foreach (Inline node in container)
+        {
+            switch (node)
+            {
+                case LiteralInline lit:
+                    AppendText(lit.Content.ToString(), scale, style, color, tokens);
+                    break;
+                case EmphasisInline em:
+                    GraphicsFontStyle emStyle = style |
+                                                (em.DelimiterCount >= 2 ? GraphicsFontStyle.Bold : GraphicsFontStyle.Italic);
+                    FlattenInlines(em, scale, emStyle, color, tokens);
+                    break;
+                case CodeInline ci:
+                    tokens.Add(new MarkdownRun { Text = ci.Content, Scale = scale, Style = style, Color = InlineCodeColor });
+                    break;
+                case LinkInline link when link.IsImage:
+                    AppendText($"🖼 {GetInlineText(link)}", scale, GraphicsFontStyle.Italic, QuoteColor, tokens);
+                    break;
+                case LinkInline link:
+                    FlattenInlines(link, scale, style, LinkColor, tokens);
+                    break;
+                case AutolinkInline auto:
+                    AppendText(auto.Url, scale, style, LinkColor, tokens);
+                    break;
+                case LineBreakInline lb when lb.IsHard:
+                    tokens.Add(new MarkdownRun { Text = "\n" });
+                    break;
+                case LineBreakInline:
+                    AppendText(" ", scale, style, color, tokens);
+                    break;
+                case ContainerInline nested:
+                    FlattenInlines(nested, scale, style, color, tokens);
+                    break;
+            }
+        }
+    }
+
+    private static string GetInlineText(ContainerInline container)
+    {
+        var sb = new System.Text.StringBuilder();
+        foreach (Inline node in container)
+        {
+            if (node is LiteralInline lit)
+            {
+                sb.Append(lit.Content.ToString());
+            }
+            else if (node is ContainerInline nested)
+            {
+                sb.Append(GetInlineText(nested));
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static void AppendText(string text, float scale, GraphicsFontStyle style, GraphicsColor color,
+        List<MarkdownRun> tokens)
+    {
+        int i = 0;
+        while (i < text.Length)
+        {
+            bool space = char.IsWhiteSpace(text[i]);
+            int start = i;
+            while (i < text.Length && char.IsWhiteSpace(text[i]) == space)
+            {
+                i++;
+            }
+
+            tokens.Add(new MarkdownRun
+            {
+                Text = space ? " " : text[start..i],
+                Scale = scale,
+                Style = style,
+                Color = color,
+                IsSpace = space
+            });
+        }
+    }
+
+    // ---- wrapping & pagination --------------------------------------------------------------------
+
+    private List<MarkdownLine> WrapTokens(List<MarkdownRun> tokens, IGraphicsContext g,
+        Dictionary<string, IGraphicsFont> fonts, float firstIndent, float restIndent)
+    {
+        var lines = new List<MarkdownLine>();
+        var line = new MarkdownLine { Indent = firstIndent };
+        float x = 0f;
+        float maxHeight = 0f;
+        bool any = false;
+
+        void Flush()
+        {
+            line.Height = maxHeight > 0 ? maxHeight : _baseLineHeight;
+            lines.Add(line);
+            line = new MarkdownLine { Indent = restIndent };
+            x = 0f;
+            maxHeight = 0f;
+            any = false;
+        }
+
+        foreach (MarkdownRun tok in tokens)
+        {
+            if (tok.Text == "\n")
+            {
+                Flush();
+                continue;
+            }
+
+            IGraphicsFont font = GetFont(g, fonts, tok.Scale, tok.Style);
+            float w = Measure(g, tok.Text, font).Width;
+            float h = font.GetHeight(_dpiY);
+            float avail = PageSize.Width - line.Indent;
+
+            if (tok.IsSpace)
+            {
+                if (!any)
+                {
+                    continue; // drop leading space
+                }
+
+                line.Runs.Add(tok);
+                x += w;
+                maxHeight = Math.Max(maxHeight, h);
+                continue;
+            }
+
+            if (any && x + w > avail)
+            {
+                Flush();
+            }
+
+            line.Runs.Add(tok);
+            x += w;
+            maxHeight = Math.Max(maxHeight, h);
+            any = true;
+        }
+
+        if (any || lines.Count == 0)
+        {
+            line.Height = maxHeight > 0 ? maxHeight : _baseLineHeight;
+            lines.Add(line);
+        }
+
+        return lines;
+    }
+
+    private int Paginate()
+    {
+        if (_lines.Count == 0)
+        {
+            return 0;
+        }
+
+        int page = 1;
+        float y = 0f;
+        bool firstOnPage = true;
+        foreach (MarkdownLine line in _lines)
+        {
+            float gap = firstOnPage ? 0f : line.SpaceBefore;
+            if (!firstOnPage && y + gap + line.Height > PageSize.Height)
+            {
+                page++;
+                y = 0f;
+                gap = 0f;
+                firstOnPage = true;
+            }
+
+            y += gap;
+            line.Page = page;
+            line.Y = y;
+            y += line.Height;
+            firstOnPage = false;
+        }
+
+        return page;
+    }
+
+    // ---- fonts / measuring ------------------------------------------------------------------------
+
+    private IGraphicsFont GetFont(IGraphicsContext g, Dictionary<string, IGraphicsFont> cache, float scale,
+        GraphicsFontStyle style)
+    {
+        string key = $"{scale:F3}|{(int)style}";
+        if (!cache.TryGetValue(key, out IGraphicsFont? font))
+        {
+            font = g.CreateFont(ContentSettings!.Font.Family, _baseSizePx * scale, style, GraphicsFontUnit.Pixel);
+            cache[key] = font;
+        }
+
+        return font;
+    }
+
+    private GraphicsSizeF Measure(IGraphicsContext g, string text, IGraphicsFont font)
+    {
+        var proposed = new GraphicsSizeF(PageSize.Width, _baseLineHeight * 4f);
+        return g.MeasureString(text, font, proposed, GraphicsStringFormat, out _, out _);
+    }
+
+    private static float HeadingScale(int level)
+    {
+        return level switch
+        {
+            1 => 1.9f,
+            2 => 1.55f,
+            3 => 1.3f,
+            4 => 1.15f,
+            5 => 1.05f,
+            _ => 0.95f
+        };
+    }
+
+    private static int TryParseStart(string? start, int fallback)
+    {
+        return int.TryParse(start, NumberStyles.Integer, CultureInfo.InvariantCulture, out int n) ? n : fallback;
     }
 }

--- a/src/WinPrint.Core/ContentTypeEngines/MarkdownCte.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/MarkdownCte.cs
@@ -59,7 +59,8 @@ public class MarkdownCte : ContentTypeEngineBase
         return await Task.FromResult(true);
     }
 
-    public override async Task<int> RenderAsync(PrintResolution? printerResolution, EventHandler<string>? reflowProgress)
+    public override async Task<int> RenderAsync(PrintResolution? printerResolution,
+        EventHandler<string>? reflowProgress)
     {
         LogService.TraceMessage();
         if (Document is null)
@@ -94,7 +95,7 @@ public class MarkdownCte : ContentTypeEngineBase
             }
 
             MarkdownDocument ast = Markdown.Parse(Document, s_pipeline);
-            WalkBlocks(ast, g, fontCache, indentLevel: 0, quoteDepth: 0);
+            WalkBlocks(ast, g, fontCache, 0, 0);
 
             _pageCount = Paginate();
             Log.Debug("Rendered {pages} Markdown pages from {lines} lines.", _pageCount, _lines.Count);
@@ -147,7 +148,7 @@ public class MarkdownCte : ContentTypeEngineBase
 
             if (line.Rule)
             {
-                float midY = line.Y + (line.Height / 2f);
+                float midY = line.Y + line.Height / 2f;
                 g.DrawLine(rulePen, line.Indent, midY, PageSize.Width, midY);
                 continue;
             }
@@ -160,7 +161,8 @@ public class MarkdownCte : ContentTypeEngineBase
                     continue;
                 }
 
-                using IGraphicsFont font = g.CreateFont(ContentSettings.Font.Family, basePt * run.Scale, run.Style, unit);
+                using IGraphicsFont font = g.CreateFont(ContentSettings.Font.Family, basePt * run.Scale, run.Style,
+                    unit);
                 using IGraphicsBrush brush = g.CreateSolidBrush(run.Color);
                 g.DrawString(run.Text, font, brush, x, line.Y, GraphicsStringFormat);
                 x += Measure(g, run.Text, font).Width;
@@ -192,7 +194,7 @@ public class MarkdownCte : ContentTypeEngineBase
                 case QuoteBlock quote:
                     WalkBlocks(quote, g, fonts, indentLevel, quoteDepth + 1);
                     break;
-                case Markdig.Syntax.CodeBlock code: // covers FencedCodeBlock too
+                case CodeBlock code: // covers FencedCodeBlock too
                     EmitCodeBlock(code, g, fonts, indentLevel, quoteDepth);
                     break;
                 case ThematicBreakBlock:
@@ -244,7 +246,7 @@ public class MarkdownCte : ContentTypeEngineBase
         }
 
         float quoteGutter = quoteDepth * _indentStep;
-        float markerIndent = quoteGutter + (indentLevel * _indentStep) + (_indentStep * 0.4f);
+        float markerIndent = quoteGutter + indentLevel * _indentStep + _indentStep * 0.4f;
         List<MarkdownLine> lines = WrapTokens(tokens, g, fonts, markerIndent, markerIndent + markerWidth);
         Decorate(lines, _baseLineHeight * 0.18f, quoteDepth > 0);
         _lines.AddRange(lines);
@@ -256,10 +258,10 @@ public class MarkdownCte : ContentTypeEngineBase
         }
     }
 
-    private void EmitCodeBlock(Markdig.Syntax.CodeBlock code, IGraphicsContext g,
+    private void EmitCodeBlock(CodeBlock code, IGraphicsContext g,
         Dictionary<string, IGraphicsFont> fonts, int indentLevel, int quoteDepth)
     {
-        float indent = (quoteDepth * _indentStep) + (indentLevel * _indentStep) + (_indentStep * 0.4f);
+        float indent = quoteDepth * _indentStep + indentLevel * _indentStep + _indentStep * 0.4f;
         IGraphicsFont font = GetFont(g, fonts, 0.92f, GraphicsFontStyle.Regular);
         float height = font.GetHeight(_dpiY);
         float charWidth = Math.Max(1f, Measure(g, "M", font).Width);
@@ -272,7 +274,9 @@ public class MarkdownCte : ContentTypeEngineBase
             // char-wrap long code lines so they don't clip
             for (int start = 0; start == 0 || start < raw.Length; start += maxChars)
             {
-                string seg = raw.Length == 0 ? string.Empty : raw.Substring(start, Math.Min(maxChars, raw.Length - start));
+                string seg = raw.Length == 0
+                    ? string.Empty
+                    : raw.Substring(start, Math.Min(maxChars, raw.Length - start));
                 var line = new MarkdownLine
                 {
                     Indent = indent,
@@ -298,7 +302,7 @@ public class MarkdownCte : ContentTypeEngineBase
 
     private void EmitRule(int indentLevel, int quoteDepth)
     {
-        float indent = (quoteDepth * _indentStep) + (indentLevel * _indentStep);
+        float indent = quoteDepth * _indentStep + indentLevel * _indentStep;
         _lines.Add(new MarkdownLine
         {
             Indent = indent,
@@ -319,7 +323,7 @@ public class MarkdownCte : ContentTypeEngineBase
             return;
         }
 
-        float indent = (quoteDepth * _indentStep) + (indentLevel * _indentStep);
+        float indent = quoteDepth * _indentStep + indentLevel * _indentStep;
         List<MarkdownLine> lines = WrapTokens(tokens, g, fonts, indent, indent);
         Decorate(lines, spaceBefore, quoteDepth > 0);
         _lines.AddRange(lines);
@@ -360,11 +364,14 @@ public class MarkdownCte : ContentTypeEngineBase
                     break;
                 case EmphasisInline em:
                     GraphicsFontStyle emStyle = style |
-                                                (em.DelimiterCount >= 2 ? GraphicsFontStyle.Bold : GraphicsFontStyle.Italic);
+                                                (em.DelimiterCount >= 2
+                                                    ? GraphicsFontStyle.Bold
+                                                    : GraphicsFontStyle.Italic);
                     FlattenInlines(em, scale, emStyle, color, tokens);
                     break;
                 case CodeInline ci:
-                    tokens.Add(new MarkdownRun { Text = ci.Content, Scale = scale, Style = style, Color = InlineCodeColor });
+                    tokens.Add(new MarkdownRun
+                    { Text = ci.Content, Scale = scale, Style = style, Color = InlineCodeColor });
                     break;
                 case LinkInline link when link.IsImage:
                     AppendText($"🖼 {GetInlineText(link)}", scale, GraphicsFontStyle.Italic, QuoteColor, tokens);

--- a/src/WinPrint.Core/ContentTypeEngines/MarkdownLine.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/MarkdownLine.cs
@@ -1,0 +1,40 @@
+// Copyright Kindel, LLC - http://www.kindel.com
+// Published under the MIT License at https://github.com/tig/winprint
+
+namespace WinPrint.Core.ContentTypeEngines;
+
+/// <summary>
+///     One laid-out visual line produced by <see cref="MarkdownCte" />'s reflow: a left indent, a
+///     stack of styled <see cref="MarkdownRun" />s painted left-to-right, a height, and optional
+///     block decorations (a shaded code background, a blockquote bar, or a horizontal rule). Unlike
+///     the plain/TextMate engines (uniform line height), Markdown lines vary in height and spacing.
+/// </summary>
+public sealed class MarkdownLine
+{
+    /// <summary>Styled spans painted left-to-right from <see cref="Indent" />.</summary>
+    public List<MarkdownRun> Runs { get; } = [];
+
+    /// <summary>Left indent in pixels (lists, blockquotes, code blocks).</summary>
+    public float Indent { get; set; }
+
+    /// <summary>Line height in pixels (depends on the largest run's font).</summary>
+    public float Height { get; set; }
+
+    /// <summary>Extra space above this line in pixels (block separation).</summary>
+    public float SpaceBefore { get; set; }
+
+    /// <summary>Shade a code-block background behind this line.</summary>
+    public bool CodeBackground { get; set; }
+
+    /// <summary>Draw a blockquote bar at the left edge of this line's indent.</summary>
+    public bool QuoteBar { get; set; }
+
+    /// <summary>Draw a horizontal rule centered in this line (thematic break).</summary>
+    public bool Rule { get; set; }
+
+    /// <summary>1-based page this line was assigned to during reflow.</summary>
+    public int Page { get; set; }
+
+    /// <summary>Y offset (pixels) of this line within its page, set during reflow.</summary>
+    public float Y { get; set; }
+}

--- a/src/WinPrint.Core/ContentTypeEngines/MarkdownLine.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/MarkdownLine.cs
@@ -32,6 +32,18 @@ public sealed class MarkdownLine
     /// <summary>Draw a horizontal rule centered in this line (thematic break).</summary>
     public bool Rule { get; set; }
 
+    /// <summary>Absolute x of each table column edge (n+1 values) when this line is a table row.</summary>
+    public IReadOnlyList<float>? ColumnEdges { get; set; }
+
+    /// <summary>Draw the top gridline of a table row above this line.</summary>
+    public bool TableRowTop { get; set; }
+
+    /// <summary>Draw the bottom gridline of a table (below the last row).</summary>
+    public bool TableRowBottom { get; set; }
+
+    /// <summary>Shade this table row as a header.</summary>
+    public bool HeaderShade { get; set; }
+
     /// <summary>1-based page this line was assigned to during reflow.</summary>
     public int Page { get; set; }
 

--- a/src/WinPrint.Core/ContentTypeEngines/MarkdownRun.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/MarkdownRun.cs
@@ -1,0 +1,29 @@
+// Copyright Kindel, LLC - http://www.kindel.com
+// Published under the MIT License at https://github.com/tig/winprint
+
+using WinPrint.Core.Abstractions;
+
+namespace WinPrint.Core.ContentTypeEngines;
+
+/// <summary>
+///     One styled, already-wrapped span of text on a <see cref="MarkdownLine" />. Produced by
+///     <see cref="MarkdownCte" /> while walking the Markdig AST. A run is the unit both wrapping
+///     (word-by-word) and painting operate on, mirroring <c>TextMateWrappedRun</c>.
+/// </summary>
+public sealed class MarkdownRun
+{
+    /// <summary>The run's text (a word, a run of whitespace, or inline content).</summary>
+    public string Text { get; set; } = string.Empty;
+
+    /// <summary>Bold/italic style for this run.</summary>
+    public GraphicsFontStyle Style { get; set; } = GraphicsFontStyle.Regular;
+
+    /// <summary>Font size as a multiple of the base body size (headings &gt; 1).</summary>
+    public float Scale { get; set; } = 1f;
+
+    /// <summary>Foreground color.</summary>
+    public GraphicsColor Color { get; set; } = GraphicsColor.FromRgb(0x1d, 0x1d, 0x1f);
+
+    /// <summary>Whether this run is whitespace (collapsible at the start/end of a wrapped line).</summary>
+    public bool IsSpace { get; set; }
+}

--- a/src/WinPrint.Core/ContentTypeEngines/MarkdownRun.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/MarkdownRun.cs
@@ -26,4 +26,10 @@ public sealed class MarkdownRun
 
     /// <summary>Whether this run is whitespace (collapsible at the start/end of a wrapped line).</summary>
     public bool IsSpace { get; set; }
+
+    /// <summary>
+    ///     Absolute x (pixels) to paint this run at, overriding the normal left-to-right flow. Used to
+    ///     place the first run of each table cell at its column; null means flow from the previous run.
+    /// </summary>
+    public float? X { get; set; }
 }

--- a/tests/WinPrint.Core.UnitTests/Cte/CteRenderingTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Cte/CteRenderingTests.cs
@@ -154,7 +154,7 @@ public class CteRenderingTests
     }
 
     [Fact]
-    public async Task MarkdownCte_RendersFlattenedText()
+    public async Task MarkdownCte_RendersRichMarkdown_Structurally()
     {
         var measure = new RecordingGraphicsContext();
         var cte = new MarkdownCte
@@ -166,12 +166,21 @@ public class CteRenderingTests
                 TabSpaces = 4
             },
             MeasurementContext = measure,
-            PageSize = new System.Drawing.SizeF(200, 200)
+            PageSize = new System.Drawing.SizeF(400, 4000)
         };
 
-        Assert.True(await cte.SetDocumentAsync("# Title\n\nHello world"));
-        int pages = await cte.RenderAsync(Dpi96, null);
+        const string md =
+            "# Title\n\n" +
+            "Some **bold** and *italic* and `code` and a [link](https://x.com).\n\n" +
+            "- one\n- two\n\n" +
+            "> a quote\n\n" +
+            "```\ncodeblock\n```\n\n" +
+            "![alt](img.png)\n\n" +
+            "---\n\n" +
+            "End.";
 
+        Assert.True(await cte.SetDocumentAsync(md));
+        int pages = await cte.RenderAsync(Dpi96, null);
         Assert.True(pages >= 1);
 
         var paint = new RecordingGraphicsContext();
@@ -180,9 +189,26 @@ public class CteRenderingTests
             cte.PaintPage(paint, p);
         }
 
-        // Markdown markers are gone; the prose is rendered.
-        Assert.Contains(paint.DrawnStrings, s => s.Text.Contains("Title"));
-        Assert.Contains(paint.DrawnStrings, s => s.Text.Contains("Hello world"));
-        Assert.DoesNotContain(paint.DrawnStrings, s => s.Text.Contains("#"));
+        List<string> texts = [.. paint.DrawnStrings.Select(s => s.Text)];
+        string all = string.Concat(texts);
+
+        // Inline/prose content is rendered as styled runs (word by word).
+        foreach (string word in new[] { "Title", "bold", "italic", "code", "link", "one", "two", "quote", "codeblock", "End." })
+        {
+            Assert.Contains(word, texts);
+        }
+
+        // List bullet marker and image alt-text fallback are emitted.
+        Assert.Contains(texts, t => t.Contains('•'));
+        Assert.Contains(texts, t => t.Contains("🖼", StringComparison.Ordinal));
+
+        // Raw Markdown markers never reach the page.
+        Assert.DoesNotContain('#', all);
+        Assert.DoesNotContain('*', all);
+        Assert.DoesNotContain("```", all);
+
+        // Code background + blockquote bar are filled rectangles; the horizontal rule is a drawn line.
+        Assert.NotEmpty(paint.FilledRectangles);
+        Assert.NotEmpty(paint.DrawnLines);
     }
 }

--- a/tests/WinPrint.Core.UnitTests/Cte/CteRenderingTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Cte/CteRenderingTests.cs
@@ -214,6 +214,64 @@ public class CteRenderingTests
     }
 
     [Fact]
+    public async Task MarkdownCte_CodeBlock_HonorsTabSpacesSetting()
+    {
+        var measure = new RecordingGraphicsContext();
+        var cte = new MarkdownCte
+        {
+            ContentSettings = new ContentSettings
+            { Font = new Font { Family = "Courier New", Size = 10 }, TabSpaces = 2 },
+            MeasurementContext = measure,
+            PageSize = new System.Drawing.SizeF(400, 4000)
+        };
+
+        const string md = "```\n\tcode\n```\n";
+
+        Assert.True(await cte.SetDocumentAsync(md));
+        int pages = await cte.RenderAsync(Dpi96, null);
+
+        var paint = new RecordingGraphicsContext();
+        for (int p = 1; p <= pages; p++)
+        {
+            cte.PaintPage(paint, p);
+        }
+
+        // The leading tab expands to TabSpaces (2) spaces, not a hard-coded 4.
+        Assert.Contains(paint.DrawnStrings, s => s.Text == "  code");
+        Assert.DoesNotContain(paint.DrawnStrings, s => s.Text.Contains("    code"));
+    }
+
+    [Fact]
+    public async Task MarkdownCte_WrapsOversizedToken_ToFitPageWidth()
+    {
+        var measure = new RecordingGraphicsContext();
+        var cte = new MarkdownCte
+        {
+            ContentSettings = new ContentSettings
+            { Font = new Font { Family = "Courier New", Size = 10 }, TabSpaces = 4 },
+            MeasurementContext = measure,
+            // 100pt page fits exactly 10 chars (CharWidth = 10).
+            PageSize = new System.Drawing.SizeF(100, 4000)
+        };
+
+        // A single token far wider than the page (no spaces to wrap at), e.g. a long URL/word.
+        string word = new('a', 25);
+        Assert.True(await cte.SetDocumentAsync(word));
+        int pages = await cte.RenderAsync(Dpi96, null);
+
+        var paint = new RecordingGraphicsContext();
+        for (int p = 1; p <= pages; p++)
+        {
+            cte.PaintPage(paint, p);
+        }
+
+        List<string> pieces = [.. paint.DrawnStrings.Select(s => s.Text).Where(t => t.Contains('a'))];
+        // Every painted piece fits the page (<= 10 chars) and together they reconstruct the word.
+        Assert.All(pieces, t => Assert.True(t.Length <= 10, $"piece '{t}' overflows the page width"));
+        Assert.Equal(word, string.Concat(pieces));
+    }
+
+    [Fact]
     public async Task MarkdownCte_RendersTable_WithGridHeaderAndColumns()
     {
         var measure = new RecordingGraphicsContext();

--- a/tests/WinPrint.Core.UnitTests/Cte/CteRenderingTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Cte/CteRenderingTests.cs
@@ -212,4 +212,46 @@ public class CteRenderingTests
         Assert.NotEmpty(paint.FilledRectangles);
         Assert.NotEmpty(paint.DrawnLines);
     }
+
+    [Fact]
+    public async Task MarkdownCte_RendersTable_WithGridHeaderAndColumns()
+    {
+        var measure = new RecordingGraphicsContext();
+        var cte = new MarkdownCte
+        {
+            ContentSettings = new ContentSettings
+            {
+                Font = new Font { Family = "Courier New", Size = 10 },
+                TabSpaces = 4
+            },
+            MeasurementContext = measure,
+            PageSize = new System.Drawing.SizeF(600, 4000)
+        };
+
+        const string md = "| Name | Role |\n|------|------|\n| Tig | Author |\n| You | Reader |\n";
+
+        Assert.True(await cte.SetDocumentAsync(md));
+        int pages = await cte.RenderAsync(Dpi96, null);
+        Assert.True(pages >= 1);
+
+        var paint = new RecordingGraphicsContext();
+        for (int p = 1; p <= pages; p++)
+        {
+            cte.PaintPage(paint, p);
+        }
+
+        List<string> texts = [.. paint.DrawnStrings.Select(s => s.Text)];
+        foreach (string cell in new[] { "Name", "Role", "Tig", "Author", "You", "Reader" })
+        {
+            Assert.Contains(cell, texts);
+        }
+
+        // Gridlines (column verticals + row borders) are drawn, the header row is shaded, and the
+        // second column is positioned to the right of the first (distinct column x-offsets).
+        Assert.NotEmpty(paint.DrawnLines);
+        Assert.NotEmpty(paint.FilledRectangles);
+        float nameX = paint.DrawnStrings.First(s => s.Text == "Name").X;
+        float roleX = paint.DrawnStrings.First(s => s.Text == "Role").X;
+        Assert.True(roleX > nameX, "Second column should be right of the first.");
+    }
 }

--- a/tests/WinPrint.Core.UnitTests/Cte/CteRenderingTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Cte/CteRenderingTests.cs
@@ -193,7 +193,8 @@ public class CteRenderingTests
         string all = string.Concat(texts);
 
         // Inline/prose content is rendered as styled runs (word by word).
-        foreach (string word in new[] { "Title", "bold", "italic", "code", "link", "one", "two", "quote", "codeblock", "End." })
+        foreach (string word in new[]
+                     { "Title", "bold", "italic", "code", "link", "one", "two", "quote", "codeblock", "End." })
         {
             Assert.Contains(word, texts);
         }

--- a/tests/WinPrint.Core.UnitTests/Cte/MarkdownCteTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Cte/MarkdownCteTests.cs
@@ -64,31 +64,16 @@ public class MarkdownCteTests
     }
 
     [Fact]
-    public async Task SetDocumentAsync_FlattensMarkdownToPlainText()
+    public async Task SetDocumentAsync_StoresRawMarkdown()
     {
         var cte = new MarkdownCte();
 
-        Assert.True(await cte.SetDocumentAsync("# Heading\n\nSome **bold** and *italic* text."));
+        const string md = "# Heading\n\nSome **bold** and *italic* text.";
+        Assert.True(await cte.SetDocumentAsync(md));
 
-        // Markdig's plain-text renderer strips the formatting markers, leaving readable text.
-        Assert.NotNull(cte.Document);
-        Assert.Contains("Heading", cte.Document!);
-        Assert.Contains("Some bold and italic text.", cte.Document!);
-        Assert.DoesNotContain("**", cte.Document!);
-        Assert.DoesNotContain("# ", cte.Document!);
-    }
-
-    [Fact]
-    public async Task SetDocumentAsync_StripsLinkSyntaxKeepingText()
-    {
-        var cte = new MarkdownCte();
-
-        Assert.True(await cte.SetDocumentAsync("See [the docs](https://example.com) for details."));
-
-        Assert.NotNull(cte.Document);
-        Assert.Contains("the docs", cte.Document!);
-        Assert.DoesNotContain("https://example.com", cte.Document!);
-        Assert.DoesNotContain("](", cte.Document!);
+        // The rich renderer keeps the raw Markdown and styles it during reflow (it no longer
+        // flattens to plain text), so the source markers are preserved on the Document.
+        Assert.Equal(md, cte.Document);
     }
 
     [Fact]


### PR DESCRIPTION
## What & why
`MarkdownCte` used to call Markdig's `ToPlainText` — **throwing away all formatting** (a test even asserted `# Title` → `Title`) and rendering monospace plain text. It now parses the **Markdig AST** and renders it **richly** through the existing `IGraphicsContext` pipeline.

## Best-tech approach
- **Markdig AST** (already a dependency, cross-platform, AOT-tolerable) — *not* an HTML/browser engine (the old `HtmlCte` native renderer was removed; Electron/Flutter were rejected; a browser engine breaks the cross-platform + Native-AOT roadmap).
- Reuses the **styled-run model `TextMateCte` already proves** (per-span color/bold/italic via the graphics abstraction), but gives Markdown a **block layout** (variable line heights, indents, block spacing, decorations) instead of `TextCte`'s uniform-line model.

## Rendered (Rich MVP)
- Headings (scaled + bold), **bold**/*italic*, `inline code` (colored), links (colored)
- Bulleted / numbered / **nested** lists (hanging indents)
- Blockquotes (indent + bar), horizontal rules
- Fenced/indented code blocks — monospace on a shaded background (char-wrapped)
- Images → alt text (`IGraphicsContext` has no image primitive)
- **Tables** (header shading, column gridlines, cell wrapping, page-spanning) — folded in after the original MVP write-up

## New types / tests
- `MarkdownRun` / `MarkdownLine` model the laid-out spans/lines.
- `CteRenderingTests.MarkdownCte_RendersRichMarkdown_Structurally` drives SetDocument → RenderAsync → PaintPage via `RecordingGraphicsContext` and asserts words, list markers, image alt, code-background fills, rule lines, and **absence of raw markdown markers**. `MarkdownCteTests` updated for the keep-raw-and-style behavior.
- Verified live in the `wp` engine on a sample doc (headings, colored inline code/links, nested lists, blockquote, shaded code block, rule all render).

## Deferred (from the chosen Rich-MVP scope)
- **Per-token TextMate syntax highlighting inside code fences** — today code fences are monospace on a shaded background (single color). The integration point is `EmitCodeBlock`; this is the natural fast-follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
