### PR TITLE
MarkdownCte: render images (local, data URI, http/https)

### DIFF
--- a/src/WinPrint.Core/Abstractions/IGraphicsContext.cs
+++ b/src/WinPrint.Core/Abstractions/IGraphicsContext.cs
@@ -47,4 +47,17 @@ public interface IGraphicsContext
     void DrawRectangle(IGraphicsPen pen, float x, float y, float width, float height);
     void FillRectangle(IGraphicsBrush brush, GraphicsRectF rect);
     void FillRectangle(IGraphicsBrush brush, float x, float y, float width, float height);
+
+    /// <summary>
+    ///     Decodes an image from <paramref name="stream" /> into a backend-specific
+    ///     <see cref="IGraphicsImage" />, or returns <see langword="null" /> if the data can't be
+    ///     decoded. The caller owns the result and must dispose it.
+    /// </summary>
+    IGraphicsImage? LoadImage(Stream stream);
+
+    /// <summary>
+    ///     Paints <paramref name="image" /> into the rectangle (<paramref name="x" />,
+    ///     <paramref name="y" />, <paramref name="width" />, <paramref name="height" />), scaling to fit.
+    /// </summary>
+    void DrawImage(IGraphicsImage image, float x, float y, float width, float height);
 }

--- a/src/WinPrint.Core/Abstractions/IGraphicsImage.cs
+++ b/src/WinPrint.Core/Abstractions/IGraphicsImage.cs
@@ -1,0 +1,17 @@
+namespace WinPrint.Core.Abstractions;
+
+/// <summary>
+///     A decoded raster image bound to a specific <see cref="IGraphicsContext" /> backend, obtained
+///     from <see cref="IGraphicsContext.LoadImage" /> and painted with
+///     <see cref="IGraphicsContext.DrawImage" />. <see cref="Width" />/<see cref="Height" /> are the
+///     image's intrinsic pixel dimensions, used by callers to compute an aspect-preserving draw size.
+///     Instances own native resources and must be disposed.
+/// </summary>
+public interface IGraphicsImage : IDisposable
+{
+    /// <summary>Intrinsic pixel width of the decoded image.</summary>
+    float Width { get; }
+
+    /// <summary>Intrinsic pixel height of the decoded image.</summary>
+    float Height { get; }
+}

--- a/src/WinPrint.Core/Abstractions/SystemDrawingGraphicsContext.cs
+++ b/src/WinPrint.Core/Abstractions/SystemDrawingGraphicsContext.cs
@@ -169,7 +169,11 @@ public sealed class SystemDrawingGraphicsContext : IGraphicsContext
     {
         try
         {
-            return new SystemDrawingImage(Image.FromStream(stream));
+            // Image.FromStream keeps a reference to the source stream and reads pixels lazily, so it
+            // would fault once the caller disposes/rewinds the stream. Copy into an owned Bitmap so the
+            // returned image is fully decoded and independent of the stream.
+            using var decoded = Image.FromStream(stream);
+            return new SystemDrawingImage(new Bitmap(decoded));
         }
         catch (Exception)
         {

--- a/src/WinPrint.Core/Abstractions/SystemDrawingGraphicsContext.cs
+++ b/src/WinPrint.Core/Abstractions/SystemDrawingGraphicsContext.cs
@@ -165,6 +165,26 @@ public sealed class SystemDrawingGraphicsContext : IGraphicsContext
         Graphics.FillRectangle(GetBrush(brush), x, y, width, height);
     }
 
+    public IGraphicsImage? LoadImage(Stream stream)
+    {
+        try
+        {
+            return new SystemDrawingImage(Image.FromStream(stream));
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    public void DrawImage(IGraphicsImage image, float x, float y, float width, float height)
+    {
+        if (image is SystemDrawingImage sdi)
+        {
+            Graphics.DrawImage(sdi.Image, x, y, width, height);
+        }
+    }
+
     public static GraphicsRectF FromRectangleF(RectangleF rect)
     {
         return new GraphicsRectF(rect.X, rect.Y, rect.Width, rect.Height);

--- a/src/WinPrint.Core/Abstractions/SystemDrawingImage.cs
+++ b/src/WinPrint.Core/Abstractions/SystemDrawingImage.cs
@@ -1,0 +1,25 @@
+using System.Drawing;
+
+namespace WinPrint.Core.Abstractions;
+
+/// <summary>
+///     A <see cref="System.Drawing.Image" />-backed <see cref="IGraphicsImage" /> for the Windows
+///     GDI+ context. Windows-only (compiled for the <c>net10.0-windows</c> TFM).
+/// </summary>
+public sealed class SystemDrawingImage : IGraphicsImage
+{
+    public SystemDrawingImage(Image image)
+    {
+        Image = image ?? throw new ArgumentNullException(nameof(image));
+    }
+
+    public Image Image { get; }
+
+    public float Width => Image.Width;
+    public float Height => Image.Height;
+
+    public void Dispose()
+    {
+        Image.Dispose();
+    }
+}

--- a/src/WinPrint.Core/ContentTypeEngines/ContentTypeEngineBase.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/ContentTypeEngineBase.cs
@@ -116,6 +116,13 @@ public abstract class ContentTypeEngineBase : ModelBase, INotifyPropertyChanged
     }
 
     /// <summary>
+    ///     Path of the source file being rendered, when known. Used to resolve document-relative
+    ///     references (e.g. local images in Markdown). May be empty/null for string-loaded content.
+    /// </summary>
+    [JsonIgnore]
+    public string? SourceFileName { get; set; }
+
+    /// <summary>
     ///     The contents encoding of the file to be printed.
     /// </summary>
     [JsonIgnore]

--- a/src/WinPrint.Core/ContentTypeEngines/MarkdownCte.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/MarkdownCte.cs
@@ -152,12 +152,6 @@ public class MarkdownCte : ContentTypeEngineBase
                 continue;
             }
 
-            if (line.Image is { } image)
-            {
-                PaintImage(g, line, image);
-                continue;
-            }
-
             if (line.CodeBackground)
             {
                 g.FillRectangle(codeBg, line.Indent - _indentStep * 0.3f, line.Y,
@@ -167,6 +161,13 @@ public class MarkdownCte : ContentTypeEngineBase
             if (line.QuoteBar)
             {
                 g.FillRectangle(quoteBar, line.Indent - _indentStep * 0.6f, line.Y, _baseSizePx * 0.22f, line.Height);
+            }
+
+            // After block decoration (so an image inside a blockquote still gets its gutter bar).
+            if (line.Image is { } image)
+            {
+                PaintImage(g, line, image);
+                continue;
             }
 
             if (line.Rule)
@@ -219,17 +220,24 @@ public class MarkdownCte : ContentTypeEngineBase
 
     private void PaintImage(IGraphicsContext g, MarkdownLine line, MarkdownImage image)
     {
-        if (!_imageCache.TryGetValue(image.CacheKey, out byte[]? bytes) || bytes is not { Length: > 0 })
+        if (_imageCache.TryGetValue(image.CacheKey, out byte[]? bytes) && bytes is { Length: > 0 })
         {
-            return;
+            using var ms = new MemoryStream(bytes);
+            using IGraphicsImage? decoded = g.LoadImage(ms);
+            if (decoded is not null)
+            {
+                g.DrawImage(decoded, line.Indent, line.Y, image.Width, image.Height);
+                return;
+            }
         }
 
-        using var ms = new MemoryStream(bytes);
-        using IGraphicsImage? decoded = g.LoadImage(ms);
-        if (decoded is not null)
-        {
-            g.DrawImage(decoded, line.Indent, line.Y, image.Width, image.Height);
-        }
+        // The image decoded during reflow but not on this paint context (e.g. a backend format
+        // mismatch). Fall back to alt text so the page never shows a blank hole.
+        GraphicsFontUnit unit = g.IsDisplayUnit ? GraphicsFontUnit.Point : GraphicsFontUnit.Pixel;
+        float basePt = g.IsDisplayUnit ? ContentSettings!.Font.Size : ContentSettings!.Font.Size / 72F * 96F;
+        using IGraphicsFont font = g.CreateFont(ContentSettings.Font.Family, basePt, GraphicsFontStyle.Italic, unit);
+        using IGraphicsBrush brush = g.CreateSolidBrush(QuoteColor);
+        g.DrawString($"🖼 {image.AltText}", font, brush, line.Indent, line.Y, GraphicsStringFormat);
     }
 
     // ---- AST walk ---------------------------------------------------------------------------------
@@ -437,7 +445,7 @@ public class MarkdownCte : ContentTypeEngineBase
                 Height = drawHeight,
                 SpaceBefore = _baseLineHeight * 0.5f,
                 QuoteBar = quoteDepth > 0,
-                Image = new MarkdownImage { CacheKey = url, Width = drawWidth, Height = drawHeight }
+                Image = new MarkdownImage { CacheKey = url, AltText = alt, Width = drawWidth, Height = drawHeight }
             });
         }
     }

--- a/src/WinPrint.Core/ContentTypeEngines/MarkdownCte.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/MarkdownCte.cs
@@ -2,7 +2,9 @@
 // Published under the MIT License at https://github.com/tig/winprint
 
 using System.Globalization;
+using System.Net.Http;
 using System.Runtime.InteropServices;
+using System.Text;
 using Markdig;
 using Markdig.Extensions.Tables;
 using Markdig.Syntax;
@@ -20,7 +22,11 @@ namespace WinPrint.Core.ContentTypeEngines;
 ///     bulleted/numbered/nested lists, blockquotes (indented with a bar), fenced/indented code blocks
 ///     (monospace on a shaded background), horizontal rules, and links (colored). Reflow word-wraps
 ///     styled runs into variable-height <see cref="MarkdownLine" />s and paginates by cumulative height.
-///     Images render as alt text — <see cref="IGraphicsContext" /> has no image primitive.
+///     Images that sit alone in a paragraph (<c>![alt](src)</c>) are decoded and drawn through
+///     <see cref="IGraphicsContext.DrawImage" />, scaled to fit the page; local files (resolved relative
+///     to <see cref="ContentTypeEngineBase.SourceFileName" />), <c>data:</c> URIs, and <c>http(s)</c>
+///     URLs are supported. Anything that fails to load (and inline images mixed with text) falls back
+///     to alt text.
 /// </summary>
 public class MarkdownCte : ContentTypeEngineBase
 {
@@ -28,6 +34,11 @@ public class MarkdownCte : ContentTypeEngineBase
 
     private static readonly MarkdownPipeline s_pipeline =
         new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
+
+    private static readonly HttpClient s_http = new() { Timeout = TimeSpan.FromSeconds(10) };
+
+    /// <summary>Decoded image bytes keyed by source URL/path; null marks a load that failed (don't retry).</summary>
+    private readonly Dictionary<string, byte[]?> _imageCache = new(StringComparer.Ordinal);
 
     private static readonly GraphicsColor TextColor = GraphicsColor.FromRgb(0x1d, 0x1d, 0x1f);
     private static readonly GraphicsColor LinkColor = GraphicsColor.FromRgb(0x0b, 0x57, 0xd0);
@@ -80,6 +91,7 @@ public class MarkdownCte : ContentTypeEngineBase
 
         _dpiY = dpiY;
         _lines.Clear();
+        _imageCache.Clear();
 
         IGraphicsContext g = ResolveMeasurementContext(dpiX, dpiY, out IDisposable? owner);
         var fontCache = new Dictionary<string, IGraphicsFont>();
@@ -97,6 +109,7 @@ public class MarkdownCte : ContentTypeEngineBase
             }
 
             MarkdownDocument ast = Markdown.Parse(Document, s_pipeline);
+            await PreloadImagesAsync(ast);
             WalkBlocks(ast, g, fontCache, 0, 0);
 
             _pageCount = Paginate();
@@ -136,6 +149,12 @@ public class MarkdownCte : ContentTypeEngineBase
         {
             if (line.Page != pageNum)
             {
+                continue;
+            }
+
+            if (line.Image is { } image)
+            {
+                PaintImage(g, line, image);
                 continue;
             }
 
@@ -198,6 +217,21 @@ public class MarkdownCte : ContentTypeEngineBase
         }
     }
 
+    private void PaintImage(IGraphicsContext g, MarkdownLine line, MarkdownImage image)
+    {
+        if (!_imageCache.TryGetValue(image.CacheKey, out byte[]? bytes) || bytes is not { Length: > 0 })
+        {
+            return;
+        }
+
+        using var ms = new MemoryStream(bytes);
+        using IGraphicsImage? decoded = g.LoadImage(ms);
+        if (decoded is not null)
+        {
+            g.DrawImage(decoded, line.Indent, line.Y, image.Width, image.Height);
+        }
+    }
+
     // ---- AST walk ---------------------------------------------------------------------------------
 
     private void WalkBlocks(IEnumerable<Block> blocks, IGraphicsContext g, Dictionary<string, IGraphicsFont> fonts,
@@ -211,6 +245,13 @@ public class MarkdownCte : ContentTypeEngineBase
                     EmitInline(h.Inline, g, fonts, HeadingScale(h.Level), GraphicsFontStyle.Bold,
                         quoteDepth > 0 ? QuoteColor : TextColor, indentLevel, quoteDepth,
                         _baseLineHeight * (h.Level <= 2 ? 1.0f : 0.7f));
+                    break;
+                case ParagraphBlock p when GetStandaloneImages(p) is { } images:
+                    foreach (LinkInline image in images)
+                    {
+                        EmitImage(image.Url ?? string.Empty, GetInlineText(image), g, fonts, indentLevel, quoteDepth);
+                    }
+
                     break;
                 case ParagraphBlock p:
                     EmitInline(p.Inline, g, fonts, 1f, GraphicsFontStyle.Regular,
@@ -343,6 +384,72 @@ public class MarkdownCte : ContentTypeEngineBase
             QuoteBar = quoteDepth > 0,
             SpaceBefore = _baseLineHeight * 0.5f
         });
+    }
+
+    private void EmitImage(string url, string alt, IGraphicsContext g, Dictionary<string, IGraphicsFont> fonts,
+        int indentLevel, int quoteDepth)
+    {
+        float indent = quoteDepth * _indentStep + indentLevel * _indentStep;
+        byte[]? bytes = url.Length > 0 && _imageCache.TryGetValue(url, out byte[]? cached) ? cached : null;
+
+        IGraphicsImage? probe = null;
+        if (bytes is { Length: > 0 })
+        {
+            using var ms = new MemoryStream(bytes);
+            probe = g.LoadImage(ms);
+        }
+
+        if (probe is null)
+        {
+            EmitImageAltFallback(alt, g, fonts, indent, quoteDepth);
+            return;
+        }
+
+        using (probe)
+        {
+            float maxWidth = Math.Max(1f, PageSize.Width - indent);
+            float maxHeight = Math.Max(1f, PageSize.Height - _baseLineHeight * 0.5f);
+            float drawWidth = probe.Width;
+            float drawHeight = probe.Height;
+            if (drawWidth <= 0 || drawHeight <= 0)
+            {
+                EmitImageAltFallback(alt, g, fonts, indent, quoteDepth);
+                return;
+            }
+
+            if (drawWidth > maxWidth)
+            {
+                float s = maxWidth / drawWidth;
+                drawWidth *= s;
+                drawHeight *= s;
+            }
+
+            if (drawHeight > maxHeight)
+            {
+                float s = maxHeight / drawHeight;
+                drawWidth *= s;
+                drawHeight *= s;
+            }
+
+            _lines.Add(new MarkdownLine
+            {
+                Indent = indent,
+                Height = drawHeight,
+                SpaceBefore = _baseLineHeight * 0.5f,
+                QuoteBar = quoteDepth > 0,
+                Image = new MarkdownImage { CacheKey = url, Width = drawWidth, Height = drawHeight }
+            });
+        }
+    }
+
+    private void EmitImageAltFallback(string alt, IGraphicsContext g, Dictionary<string, IGraphicsFont> fonts,
+        float indent, int quoteDepth)
+    {
+        var tokens = new List<MarkdownRun>();
+        AppendText($"🖼 {alt}", 1f, GraphicsFontStyle.Italic, QuoteColor, tokens);
+        List<MarkdownLine> lines = WrapTokens(tokens, g, fonts, indent, indent, PageSize.Width);
+        Decorate(lines, _baseLineHeight * 0.5f, quoteDepth > 0);
+        _lines.AddRange(lines);
     }
 
     private void EmitTable(Table table, IGraphicsContext g, Dictionary<string, IGraphicsFont> fonts,
@@ -489,6 +596,145 @@ public class MarkdownCte : ContentTypeEngineBase
         return w;
     }
 
+    // ---- images -----------------------------------------------------------------------------------
+
+    /// <summary>
+    ///     Returns the image inlines of a paragraph that contains only images and whitespace (so it can
+    ///     be rendered as block images), or null when the paragraph mixes images with other content.
+    /// </summary>
+    private static List<LinkInline>? GetStandaloneImages(ParagraphBlock paragraph)
+    {
+        if (paragraph.Inline is null)
+        {
+            return null;
+        }
+
+        var images = new List<LinkInline>();
+        foreach (Inline node in paragraph.Inline)
+        {
+            switch (node)
+            {
+                case LinkInline { IsImage: true } image:
+                    images.Add(image);
+                    break;
+                case LiteralInline lit when string.IsNullOrWhiteSpace(lit.Content.ToString()):
+                case LineBreakInline:
+                    break;
+                default:
+                    return null;
+            }
+        }
+
+        return images.Count > 0 ? images : null;
+    }
+
+    private async Task PreloadImagesAsync(MarkdownDocument ast)
+    {
+        foreach (ParagraphBlock paragraph in ast.Descendants<ParagraphBlock>())
+        {
+            if (GetStandaloneImages(paragraph) is not { } images)
+            {
+                continue;
+            }
+
+            foreach (LinkInline image in images)
+            {
+                string url = image.Url ?? string.Empty;
+                if (url.Length == 0 || _imageCache.ContainsKey(url))
+                {
+                    continue;
+                }
+
+                _imageCache[url] = await LoadImageBytesAsync(url);
+            }
+        }
+    }
+
+    private async Task<byte[]?> LoadImageBytesAsync(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return null;
+        }
+
+        byte[]? dataUri = TryDecodeDataUri(url);
+        if (dataUri is not null)
+        {
+            return dataUri;
+        }
+
+        if (url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+            url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        {
+            try
+            {
+                return await s_http.GetByteArrayAsync(url);
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "Markdown: failed to fetch image {url}", url);
+                return null;
+            }
+        }
+
+        try
+        {
+            string path = ResolveLocalPath(url);
+            return File.Exists(path) ? await File.ReadAllBytesAsync(path) : null;
+        }
+        catch (Exception ex)
+        {
+            Log.Debug(ex, "Markdown: failed to read image {url}", url);
+            return null;
+        }
+    }
+
+    private string ResolveLocalPath(string url)
+    {
+        string path = url;
+        if (url.StartsWith("file://", StringComparison.OrdinalIgnoreCase) &&
+            Uri.TryCreate(url, UriKind.Absolute, out Uri? fileUri))
+        {
+            return fileUri.LocalPath;
+        }
+
+        path = Uri.UnescapeDataString(path);
+        if (Path.IsPathRooted(path))
+        {
+            return path;
+        }
+
+        string? dir = string.IsNullOrEmpty(SourceFileName) ? null : Path.GetDirectoryName(SourceFileName);
+        return string.IsNullOrEmpty(dir) ? path : Path.Combine(dir, path);
+    }
+
+    private static byte[]? TryDecodeDataUri(string url)
+    {
+        if (!url.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        int comma = url.IndexOf(',');
+        if (comma < 0)
+        {
+            return null;
+        }
+
+        string meta = url[5..comma];
+        string data = url[(comma + 1)..];
+        try
+        {
+            return meta.Contains("base64", StringComparison.OrdinalIgnoreCase)
+                ? Convert.FromBase64String(data)
+                : Encoding.UTF8.GetBytes(Uri.UnescapeDataString(data));
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
     private void EmitInline(ContainerInline? inline, IGraphicsContext g, Dictionary<string, IGraphicsFont> fonts,
         float scale, GraphicsFontStyle style, GraphicsColor color, int indentLevel, int quoteDepth, float spaceBefore)
     {
@@ -573,7 +819,7 @@ public class MarkdownCte : ContentTypeEngineBase
 
     private static string GetInlineText(ContainerInline container)
     {
-        var sb = new System.Text.StringBuilder();
+        var sb = new StringBuilder();
         foreach (Inline node in container)
         {
             if (node is LiteralInline lit)

--- a/src/WinPrint.Core/ContentTypeEngines/MarkdownImage.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/MarkdownImage.cs
@@ -1,0 +1,22 @@
+// Copyright Kindel, LLC - http://www.kindel.com
+// Published under the MIT License at https://github.com/tig/winprint
+
+namespace WinPrint.Core.ContentTypeEngines;
+
+/// <summary>
+///     A resolved image placed on a <see cref="MarkdownLine" /> by <see cref="MarkdownCte" />.
+///     <see cref="CacheKey" /> is the source URL/path used to look the decoded bytes up in the engine's
+///     image cache at paint time; <see cref="Width" />/<see cref="Height" /> are the aspect-preserving
+///     draw dimensions (pixels) computed to fit the page during reflow.
+/// </summary>
+public sealed class MarkdownImage
+{
+    /// <summary>Source URL/path; the key into the engine's decoded-bytes cache.</summary>
+    public string CacheKey { get; set; } = string.Empty;
+
+    /// <summary>Draw width in pixels (already scaled to fit the page).</summary>
+    public float Width { get; set; }
+
+    /// <summary>Draw height in pixels (already scaled to fit the page).</summary>
+    public float Height { get; set; }
+}

--- a/src/WinPrint.Core/ContentTypeEngines/MarkdownImage.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/MarkdownImage.cs
@@ -14,6 +14,9 @@ public sealed class MarkdownImage
     /// <summary>Source URL/path; the key into the engine's decoded-bytes cache.</summary>
     public string CacheKey { get; set; } = string.Empty;
 
+    /// <summary>Alt text, painted as a fallback if the image fails to decode on the paint context.</summary>
+    public string AltText { get; set; } = string.Empty;
+
     /// <summary>Draw width in pixels (already scaled to fit the page).</summary>
     public float Width { get; set; }
 

--- a/src/WinPrint.Core/ContentTypeEngines/MarkdownLine.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/MarkdownLine.cs
@@ -32,6 +32,9 @@ public sealed class MarkdownLine
     /// <summary>Draw a horizontal rule centered in this line (thematic break).</summary>
     public bool Rule { get; set; }
 
+    /// <summary>When set, this line paints a raster image (sized to <see cref="Height" />) instead of runs.</summary>
+    public MarkdownImage? Image { get; set; }
+
     /// <summary>Absolute x of each table column edge (n+1 values) when this line is a table row.</summary>
     public IReadOnlyList<float>? ColumnEdges { get; set; }
 

--- a/src/WinPrint.Core/Printing/Skia/SkiaGraphicsContext.cs
+++ b/src/WinPrint.Core/Printing/Skia/SkiaGraphicsContext.cs
@@ -292,6 +292,31 @@ public sealed class SkiaGraphicsContext : IGraphicsContext
         _canvas.DrawRect(x, y, width, height, paint);
     }
 
+    public IGraphicsImage? LoadImage(Stream stream)
+    {
+        try
+        {
+            using var data = SKData.Create(stream);
+            SKImage? image = data is null ? null : SKImage.FromEncodedData(data);
+            return image is null ? null : new SkiaImage(image);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    public void DrawImage(IGraphicsImage image, float x, float y, float width, float height)
+    {
+        if (_canvas is null || image is not SkiaImage si)
+        {
+            return;
+        }
+
+        using var paint = new SKPaint { IsAntialias = true };
+        _canvas.DrawImage(si.Image, SKRect.Create(x, y, width, height), paint);
+    }
+
     private void DrawTextDecorations(SkiaFont font, SKPaint paint, float x, float baseline, float width)
     {
         bool underline = (font.Style & GraphicsFontStyle.Underline) != 0;

--- a/src/WinPrint.Core/Printing/Skia/SkiaImage.cs
+++ b/src/WinPrint.Core/Printing/Skia/SkiaImage.cs
@@ -1,0 +1,25 @@
+using SkiaSharp;
+using WinPrint.Core.Abstractions;
+
+namespace WinPrint.Core.Printing.Skia;
+
+/// <summary>
+///     An <see cref="SKImage" />-backed <see cref="IGraphicsImage" /> for the cross-platform Skia context.
+/// </summary>
+public sealed class SkiaImage : IGraphicsImage
+{
+    public SkiaImage(SKImage image)
+    {
+        Image = image ?? throw new ArgumentNullException(nameof(image));
+    }
+
+    public SKImage Image { get; }
+
+    public float Width => Image.Width;
+    public float Height => Image.Height;
+
+    public void Dispose()
+    {
+        Image.Dispose();
+    }
+}

--- a/src/WinPrint.Core/ViewModels/SheetViewModel.cs
+++ b/src/WinPrint.Core/ViewModels/SheetViewModel.cs
@@ -533,6 +533,7 @@ public class SheetViewModel : ViewModelBase
 
             ContentEngine.MeasurementContext = MeasurementContext;
             ContentEngine.Encoding = Encoding;
+            ContentEngine.SourceFileName = File;
             retval = await ContentEngine.SetDocumentAsync(document).ConfigureAwait(true);
         }
         catch

--- a/src/WinPrint.Core/WinPrint.Core.csproj
+++ b/src/WinPrint.Core/WinPrint.Core.csproj
@@ -36,6 +36,7 @@
         <Compile Remove="Abstractions\SystemDrawingBrush.cs" />
         <Compile Remove="Abstractions\SystemDrawingFont.cs" />
         <Compile Remove="Abstractions\SystemDrawingGraphicsContext.cs" />
+        <Compile Remove="Abstractions\SystemDrawingImage.cs" />
         <Compile Remove="Abstractions\SystemDrawingPen.cs" />
         <Compile Remove="Abstractions\SystemDrawingState.cs" />
         <Compile Remove="ContentTypeEngines\WindowsMeasurementContext.cs" />

--- a/src/WinPrint.Maui/Graphics/MauiGraphicsContext.cs
+++ b/src/WinPrint.Maui/Graphics/MauiGraphicsContext.cs
@@ -1,5 +1,6 @@
 using Microsoft.Maui.Graphics;
 using WinPrint.Core.Abstractions;
+using IImage = Microsoft.Maui.Graphics.IImage;
 
 namespace WinPrint.Maui.Graphics;
 
@@ -270,6 +271,27 @@ public sealed class MauiGraphicsContext : IGraphicsContext
         var mauiBrush = (MauiBrush)brush;
         _canvas.FillColor = mauiBrush.Color;
         _canvas.FillRectangle(x, y, width, height);
+    }
+
+    public IGraphicsImage? LoadImage(Stream stream)
+    {
+        try
+        {
+            IImage? image = Microsoft.Maui.Graphics.Platform.PlatformImage.FromStream(stream);
+            return image is null ? null : new MauiImage(image);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    public void DrawImage(IGraphicsImage image, float x, float y, float width, float height)
+    {
+        if (image is MauiImage mi)
+        {
+            _canvas.DrawImage(mi.Image, x, y, width, height);
+        }
     }
 
     private void ApplyPen(IGraphicsPen pen)

--- a/src/WinPrint.Maui/Graphics/MauiImage.cs
+++ b/src/WinPrint.Maui/Graphics/MauiImage.cs
@@ -1,0 +1,26 @@
+using Microsoft.Maui.Graphics;
+using WinPrint.Core.Abstractions;
+using IImage = Microsoft.Maui.Graphics.IImage;
+
+namespace WinPrint.Maui.Graphics;
+
+/// <summary>
+///     A MAUI <see cref="IImage" />-backed <see cref="IGraphicsImage" /> for the ICanvas context.
+/// </summary>
+public sealed class MauiImage : IGraphicsImage
+{
+    public MauiImage(IImage image)
+    {
+        Image = image ?? throw new ArgumentNullException(nameof(image));
+    }
+
+    public IImage Image { get; }
+
+    public float Width => Image.Width;
+    public float Height => Image.Height;
+
+    public void Dispose()
+    {
+        Image.Dispose();
+    }
+}

--- a/src/WinPrint.TUI/Graphics/ImageSharpGraphicsContext.cs
+++ b/src/WinPrint.TUI/Graphics/ImageSharpGraphicsContext.cs
@@ -340,6 +340,34 @@ public sealed class ImageSharpGraphicsContext : IGraphicsContext
         _image.Mutate(ctx => ctx.Fill(color, rect));
     }
 
+    public IGraphicsImage? LoadImage(Stream stream)
+    {
+        try
+        {
+            return new ImageSharpImage(Image.Load(stream));
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    public void DrawImage(IGraphicsImage image, float x, float y, float width, float height)
+    {
+        if (image is not ImageSharpImage isi)
+        {
+            return;
+        }
+
+        RectangleF dest = TransformRect(x, y, width, height);
+        int w = Math.Max(1, (int)MathF.Round(dest.Width));
+        int h = Math.Max(1, (int)MathF.Round(dest.Height));
+        var location = new Point((int)MathF.Round(dest.X), (int)MathF.Round(dest.Y));
+
+        using Image resized = isi.Image.Clone(ctx => ctx.Resize(w, h));
+        _image.Mutate(ctx => ctx.DrawImage(resized, location, 1f));
+    }
+
     #region Helpers
 
     private PointF TransformPoint(float x, float y)

--- a/src/WinPrint.TUI/Graphics/ImageSharpImage.cs
+++ b/src/WinPrint.TUI/Graphics/ImageSharpImage.cs
@@ -1,0 +1,25 @@
+using SixLabors.ImageSharp;
+using WinPrint.Core.Abstractions;
+
+namespace WinPrint.TUI.Graphics;
+
+/// <summary>
+///     An ImageSharp <see cref="Image" />-backed <see cref="IGraphicsImage" /> for the TUI raster context.
+/// </summary>
+public sealed class ImageSharpImage : IGraphicsImage
+{
+    public ImageSharpImage(Image image)
+    {
+        Image = image ?? throw new ArgumentNullException(nameof(image));
+    }
+
+    public Image Image { get; }
+
+    public float Width => Image.Width;
+    public float Height => Image.Height;
+
+    public void Dispose()
+    {
+        Image.Dispose();
+    }
+}

--- a/src/WinPrint.TUI/Graphics/ImageSharpMeasurementContext.cs
+++ b/src/WinPrint.TUI/Graphics/ImageSharpMeasurementContext.cs
@@ -142,6 +142,16 @@ public sealed class ImageSharpMeasurementContext : IGraphicsContext, IDisposable
         _inner.FillRectangle(brush, x, y, width, height);
     }
 
+    public IGraphicsImage? LoadImage(Stream stream)
+    {
+        return _inner.LoadImage(stream);
+    }
+
+    public void DrawImage(IGraphicsImage image, float x, float y, float width, float height)
+    {
+        _inner.DrawImage(image, x, y, width, height);
+    }
+
     public void Dispose()
     {
         _image.Dispose();

--- a/tests/WinPrint.Core.UnitTests/Abstractions/SystemDrawingImageTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Abstractions/SystemDrawingImageTests.cs
@@ -1,0 +1,44 @@
+using System.Drawing;
+using WinPrint.Core.Abstractions;
+using Xunit;
+
+namespace WinPrint.Core.UnitTests.Abstractions;
+
+/// <summary>
+///     Windows-only tests for the GDI+ <see cref="SystemDrawingGraphicsContext" /> image path. They no-op
+///     on non-Windows (GDI+/System.Drawing.Common P/Invokes <c>gdiplus</c>, absent on Linux/macOS) and
+///     run for real on the windows-latest CI leg.
+/// </summary>
+public class SystemDrawingImageTests
+{
+    // A minimal valid 1x1 PNG.
+    private const string OnePixelPngBase64 =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=";
+
+    [Fact]
+    public void LoadImage_ReturnsImageThatSurvivesSourceStreamDisposal()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return; // GDI+ is Windows-only; verified on CI.
+        }
+
+        byte[] png = Convert.FromBase64String(OnePixelPngBase64);
+        using var surface = new Bitmap(8, 8);
+        using var graphics = Graphics.FromImage(surface);
+        var ctx = new SystemDrawingGraphicsContext(graphics);
+
+        IGraphicsImage? image;
+        using (var stream = new MemoryStream(png))
+        {
+            image = ctx.LoadImage(stream);
+        }
+
+        // The source stream is now disposed. Image.FromStream keeps a reference to its stream, so a
+        // non-cloned image would throw here when GDI+ lazily reads pixels; the clone must own its data.
+        Assert.NotNull(image);
+        Assert.True(image!.Width > 0);
+        ctx.DrawImage(image, 0, 0, image.Width, image.Height);
+        image.Dispose();
+    }
+}

--- a/tests/WinPrint.Core.UnitTests/Cte/CteRenderingTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Cte/CteRenderingTests.cs
@@ -251,6 +251,64 @@ public class CteRenderingTests
     }
 
     [Fact]
+    public async Task MarkdownCte_RendersImage_InBlockquote_DrawsQuoteBar()
+    {
+        var measure = new RecordingGraphicsContext();
+        var cte = new MarkdownCte
+        {
+            ContentSettings = new ContentSettings
+            { Font = new Font { Family = "Courier New", Size = 10 }, TabSpaces = 4 },
+            MeasurementContext = measure,
+            PageSize = new System.Drawing.SizeF(400, 4000)
+        };
+
+        // An image alone inside a blockquote: it must get the blockquote gutter bar like quoted text.
+        const string md = "> ![logo](data:image/png;base64,iVBORw0KGgo=)\n";
+
+        Assert.True(await cte.SetDocumentAsync(md));
+        int pages = await cte.RenderAsync(Dpi96, null);
+
+        var paint = new RecordingGraphicsContext();
+        for (int p = 1; p <= pages; p++)
+        {
+            cte.PaintPage(paint, p);
+        }
+
+        // The image is drawn AND the blockquote bar (a filled rect left of the image) is drawn.
+        Assert.Single(paint.DrawnImages);
+        Assert.NotEmpty(paint.FilledRectangles);
+    }
+
+    [Fact]
+    public async Task MarkdownCte_ImageDecodeFailsAtPaint_FallsBackToAltText()
+    {
+        var measure = new RecordingGraphicsContext();
+        var cte = new MarkdownCte
+        {
+            ContentSettings = new ContentSettings
+            { Font = new Font { Family = "Courier New", Size = 10 }, TabSpaces = 4 },
+            MeasurementContext = measure,
+            PageSize = new System.Drawing.SizeF(400, 4000)
+        };
+
+        // Decodes fine during reflow (an image line is emitted)...
+        const string md = "![a diagram](data:image/png;base64,iVBORw0KGgo=)\n";
+        Assert.True(await cte.SetDocumentAsync(md));
+        int pages = await cte.RenderAsync(Dpi96, null);
+
+        // ...but the paint context fails to decode: the page must not be left blank.
+        var paint = new RecordingGraphicsContext(failImageLoad: true);
+        for (int p = 1; p <= pages; p++)
+        {
+            cte.PaintPage(paint, p);
+        }
+
+        Assert.Empty(paint.DrawnImages);
+        Assert.Contains(paint.DrawnStrings, s => s.Text.Contains("🖼", StringComparison.Ordinal));
+        Assert.Contains(paint.DrawnStrings, s => s.Text.Contains("diagram", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task MarkdownCte_RendersImage_MissingLocalFile_FallsBackToAltText()
     {
         var measure = new RecordingGraphicsContext();

--- a/tests/WinPrint.Core.UnitTests/Cte/CteRenderingTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Cte/CteRenderingTests.cs
@@ -214,6 +214,74 @@ public class CteRenderingTests
     }
 
     [Fact]
+    public async Task MarkdownCte_RendersImage_FromDataUri_DrawsScaledImage()
+    {
+        var measure = new RecordingGraphicsContext();
+        var cte = new MarkdownCte
+        {
+            ContentSettings = new ContentSettings
+            {
+                Font = new Font { Family = "Courier New", Size = 10 },
+                TabSpaces = 4
+            },
+            MeasurementContext = measure,
+            PageSize = new System.Drawing.SizeF(400, 4000)
+        };
+
+        // A tiny non-empty data URI: the recording context decodes any non-empty stream to a
+        // deterministic 120x60 intrinsic image, which fits the 400pt page unscaled.
+        const string md = "![logo](data:image/png;base64,iVBORw0KGgo=)\n";
+
+        Assert.True(await cte.SetDocumentAsync(md));
+        int pages = await cte.RenderAsync(Dpi96, null);
+        Assert.True(pages >= 1);
+
+        var paint = new RecordingGraphicsContext();
+        for (int p = 1; p <= pages; p++)
+        {
+            cte.PaintPage(paint, p);
+        }
+
+        // The image is drawn (not alt text): one DrawImage at the page's left edge, 120x60, and no 🖼.
+        RecordedImage drawn = Assert.Single(paint.DrawnImages);
+        Assert.Equal(0, drawn.X);
+        Assert.Equal(120, drawn.Width);
+        Assert.Equal(60, drawn.Height);
+        Assert.DoesNotContain(paint.DrawnStrings, s => s.Text.Contains("🖼", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task MarkdownCte_RendersImage_MissingLocalFile_FallsBackToAltText()
+    {
+        var measure = new RecordingGraphicsContext();
+        var cte = new MarkdownCte
+        {
+            ContentSettings = new ContentSettings
+            {
+                Font = new Font { Family = "Courier New", Size = 10 },
+                TabSpaces = 4
+            },
+            MeasurementContext = measure,
+            PageSize = new System.Drawing.SizeF(400, 4000)
+        };
+
+        const string md = "![a diagram](does-not-exist.png)\n";
+
+        Assert.True(await cte.SetDocumentAsync(md));
+        int pages = await cte.RenderAsync(Dpi96, null);
+
+        var paint = new RecordingGraphicsContext();
+        for (int p = 1; p <= pages; p++)
+        {
+            cte.PaintPage(paint, p);
+        }
+
+        Assert.Empty(paint.DrawnImages);
+        Assert.Contains(paint.DrawnStrings, s => s.Text.Contains("🖼", StringComparison.Ordinal));
+        Assert.Contains(paint.DrawnStrings, s => s.Text == "diagram");
+    }
+
+    [Fact]
     public async Task MarkdownCte_RendersTable_WithGridHeaderAndColumns()
     {
         var measure = new RecordingGraphicsContext();

--- a/tests/WinPrint.Core.UnitTests/TestSupport/RecordedImage.cs
+++ b/tests/WinPrint.Core.UnitTests/TestSupport/RecordedImage.cs
@@ -1,0 +1,4 @@
+namespace WinPrint.Core.UnitTests.TestSupport;
+
+/// <summary>An image-drawing operation captured by <see cref="RecordingGraphicsContext" />.</summary>
+public readonly record struct RecordedImage(float X, float Y, float Width, float Height);

--- a/tests/WinPrint.Core.UnitTests/TestSupport/RecordingGraphicsContext.cs
+++ b/tests/WinPrint.Core.UnitTests/TestSupport/RecordingGraphicsContext.cs
@@ -17,12 +17,16 @@ public sealed class RecordingGraphicsContext : IGraphicsContext
     private readonly IGraphicsBrush _brush = new RecordingResource();
     private readonly IGraphicsPen _pen = new RecordingResource();
 
-    public RecordingGraphicsContext(float charWidth = 10f, float lineHeight = 20f, float dpi = 96f)
+    private readonly bool _failImageLoad;
+
+    public RecordingGraphicsContext(float charWidth = 10f, float lineHeight = 20f, float dpi = 96f,
+        bool failImageLoad = false)
     {
         CharWidth = charWidth;
         LineHeight = lineHeight;
         DpiX = dpi;
         DpiY = dpi;
+        _failImageLoad = failImageLoad;
     }
 
     public float CharWidth { get; }
@@ -158,14 +162,15 @@ public sealed class RecordingGraphicsContext : IGraphicsContext
 
     /// <summary>
     ///     Returns a <see cref="RecordingImage" /> with deterministic 120×60 intrinsic dimensions for
-    ///     any non-empty stream, or <see langword="null" /> for an empty stream (mirrors a decode failure,
-    ///     so alt-text fallback can be exercised).
+    ///     any non-empty stream, or <see langword="null" /> for an empty stream — or always when the
+    ///     context was constructed with <c>failImageLoad: true</c> (mirrors a decode failure, so
+    ///     alt-text fallback can be exercised even when bytes are present).
     /// </summary>
     public IGraphicsImage? LoadImage(Stream stream)
     {
         using var ms = new MemoryStream();
         stream.CopyTo(ms);
-        return ms.Length == 0 ? null : new RecordingImage(120f, 60f);
+        return _failImageLoad || ms.Length == 0 ? null : new RecordingImage(120f, 60f);
     }
 
     public void DrawImage(IGraphicsImage image, float x, float y, float width, float height)

--- a/tests/WinPrint.Core.UnitTests/TestSupport/RecordingGraphicsContext.cs
+++ b/tests/WinPrint.Core.UnitTests/TestSupport/RecordingGraphicsContext.cs
@@ -34,6 +34,7 @@ public sealed class RecordingGraphicsContext : IGraphicsContext
     public List<RecordedLine> DrawnLines { get; } = [];
     public List<RecordedRect> DrawnRectangles { get; } = [];
     public List<RecordedRect> FilledRectangles { get; } = [];
+    public List<RecordedImage> DrawnImages { get; } = [];
 
     public float DpiX { get; }
     public float DpiY { get; }
@@ -153,5 +154,22 @@ public sealed class RecordingGraphicsContext : IGraphicsContext
     public void FillRectangle(IGraphicsBrush brush, float x, float y, float width, float height)
     {
         FilledRectangles.Add(new RecordedRect(x, y, width, height));
+    }
+
+    /// <summary>
+    ///     Returns a <see cref="RecordingImage" /> with deterministic 120×60 intrinsic dimensions for
+    ///     any non-empty stream, or <see langword="null" /> for an empty stream (mirrors a decode failure,
+    ///     so alt-text fallback can be exercised).
+    /// </summary>
+    public IGraphicsImage? LoadImage(Stream stream)
+    {
+        using var ms = new MemoryStream();
+        stream.CopyTo(ms);
+        return ms.Length == 0 ? null : new RecordingImage(120f, 60f);
+    }
+
+    public void DrawImage(IGraphicsImage image, float x, float y, float width, float height)
+    {
+        DrawnImages.Add(new RecordedImage(x, y, width, height));
     }
 }

--- a/tests/WinPrint.Core.UnitTests/TestSupport/RecordingImage.cs
+++ b/tests/WinPrint.Core.UnitTests/TestSupport/RecordingImage.cs
@@ -1,0 +1,24 @@
+using WinPrint.Core.Abstractions;
+
+namespace WinPrint.Core.UnitTests.TestSupport;
+
+/// <summary>
+///     A platform-neutral <see cref="IGraphicsImage" /> stub returned by
+///     <see cref="RecordingGraphicsContext.LoadImage" />. Carries deterministic intrinsic dimensions
+///     so image layout (aspect-preserving fit) is exactly predictable in tests.
+/// </summary>
+public sealed class RecordingImage : IGraphicsImage
+{
+    public RecordingImage(float width, float height)
+    {
+        Width = width;
+        Height = height;
+    }
+
+    public float Width { get; }
+    public float Height { get; }
+
+    public void Dispose()
+    {
+    }
+}


### PR DESCRIPTION
Re-opens the images work for develop (original #105 was auto-closed when its stacked base branch `feat/markdown-rich-render` was deleted on #104's merge). Content is unchanged from #105 (green CI, all review threads resolved) plus a clean merge of develop.

A paragraph that contains only `![alt](src)` is rendered as a real raster image, scaled aspect-preserving to fit the page. Sources: **local files** (relative to the source `.md` via `ContentTypeEngineBase.SourceFileName`), **`data:` URIs**, and **`http(s)` URLs** (10s timeout, cached). Failures and inline-mixed images fall back to 🖼 alt text.

New image primitive on the `IGraphicsContext` seam (`IGraphicsImage` + `LoadImage`/`DrawImage`), implemented across all six backends (System.Drawing, Skia, ImageSharp ×2, MAUI, recording test double).

### Review fixes already incorporated (from #105)
- Blockquote images get the gutter bar (paint decoration runs before the image branch).
- Paint-time decode failure falls back to alt text (no blank hole).
- `SystemDrawingGraphicsContext.LoadImage` copies into an owned `Bitmap` (independent of the source stream).

### Tests
Cross-platform `CteRenderingTests` (13 pass): data-URI image draws scaled, blockquote gutter, paint-time alt fallback, missing-file fallback — plus a Windows-gated GDI+ stream-disposal test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)