### PR TITLE
Build AnyCPU instead of forced x64 (multi-arch friendly)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,10 +82,18 @@ jobs:
 
   # MAUI UI automation: Appium (mac2 driver) against the MacCatalyst app. Needs a macOS host with Xcode,
   # Appium, and the built app — hence a separate job from the Windows build/test matrix.
-  # Non-blocking for now: this job is new and can't be validated off-CI; it needs the runner's Xcode to
-  # match the MacCatalyst SDK and Appium/app-launch to settle. Flip continue-on-error off once it's green.
+  #
+  # Runner: macos-26 (NOT macos-latest). The .NET 10 maui workload's Microsoft.MacCatalyst pack hard-
+  # requires the MacCatalyst 26.5 SDK (Xcode 26.5) — its ILLink 'Setup' step version-checks the SDK and
+  # fails with MT0180/NETSDK1144 on anything older, regardless of trim/link mode. macos-latest is still
+  # macOS 15, whose newest Xcode is 26.3, so the build can never satisfy the gate there. macos-26 ships
+  # Xcode 26.5 (its default), which pairs with this SDK. Bump both together when the SDK requires a newer
+  # Xcode (the error names the exact version).
+  #
+  # Still continue-on-error: the build is now sound, but the Appium app-launch/menu locators were authored
+  # without a local runner and may need a fixup pass. Flip this off once a full green run is observed.
   maui-ui-tests:
-    runs-on: macos-latest
+    runs-on: macos-26
     continue-on-error: true
 
     steps:
@@ -102,15 +110,15 @@ jobs:
       - name: Install MAUI workloads
         run: dotnet workload install maui
 
+      - name: Select Xcode 26.5
+        # Pin explicitly rather than rely on the image default so the MacCatalyst SDK <-> Xcode pairing is
+        # deterministic across image refreshes. 26.5 is the macos-26 default today; this is a no-op now but
+        # guards against a future default bump leaving the SDK requirement unmet.
+        run: sudo xcode-select -s /Applications/Xcode_26.5.app
+
       - name: Build MacCatalyst app
-        # Use the runner's default Xcode (do NOT xcode-select — the highest-numbered Xcode_*.app on the
-        # image can be a broken/partial install missing actool/MacOSX SDK).
-        # MtouchLink=None disables trimming (MacCatalyst forces PublishTrimmed=true); we only need a
-        # launchable Debug bundle for the UI tests, and trimming would otherwise require MacCatalyst SDK
-        # headers the runner's Xcode may predate (MT0180 / NETSDK1144).
-        # NOTE: the maui workload can resolve to a MacCatalyst SDK newer than the runner's Xcode; if this
-        # build still fails on that skew, the job is continue-on-error and does not gate the PR. TODO:
-        # pin the workload to the runner's Xcode once a stable pairing is known.
+        # We only need a launchable Debug bundle for the Appium UI tests. MtouchLink=None asks for the
+        # lightest link mode; with Xcode 26.5 present the Apple linker's SDK check (MT0180) now passes.
         run: dotnet build src/WinPrint.Maui/WinPrint.Maui.csproj -c Debug -f net10.0-maccatalyst -p:MtouchLink=None
 
       - name: Install Appium + mac2 driver

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,11 +90,11 @@ jobs:
   # Xcode 26.5 (its default), which pairs with this SDK. Bump both together when the SDK requires a newer
   # Xcode (the error names the exact version).
   #
-  # Still continue-on-error: the build is now sound, but the Appium app-launch/menu locators were authored
-  # without a local runner and may need a fixup pass. Flip this off once a full green run is observed.
+  # Gating: build, Appium session, app activation, and the File-menu UI assertions all pass on macos-26.
+  # If the Appium menu-bar tests prove timing-flaky in practice, re-add continue-on-error rather than
+  # leaving a red gate.
   maui-ui-tests:
     runs-on: macos-26
-    continue-on-error: true
 
     steps:
       - name: Checkout source

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,8 +139,10 @@ jobs:
         # Don't hardcode the runtime-identifier subfolder — Debug's default RID differs by host/arch
         # (maccatalyst-x64 vs -arm64). Find the bundle the build actually produced.
         run: |
-          app=$(find src/WinPrint.Maui/bin/Debug/net10.0-maccatalyst -maxdepth 2 -name 'WinPrint.app' -type d | head -1)
+          app=$(find "$PWD/src/WinPrint.Maui/bin/Debug/net10.0-maccatalyst" -maxdepth 2 -name 'WinPrint.app' -type d | head -1)
           echo "Found app bundle: $app"
+          # Absolute path: the Appium server runs as a separate background process, so a relative path
+          # would resolve against its CWD, not the test's.
           echo "APPIUM_APP=$app" >> "$GITHUB_ENV"
 
       - name: Test (MAUI UI / Appium)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,13 @@ jobs:
   build-and-test:
     runs-on: windows-latest
 
+    # Build only WinPrint.Maui's Windows head on this job — the macOS job builds AND UI-tests MacCatalyst,
+    # so cross-compiling it here is redundant. With the MacCatalyst TFM dropped (honored by every MSBuild
+    # tool below, incl. jb cleanupcode and dotnet format) we install just the maui-windows workload and skip
+    # the multi-minute Apple/Android pack download.
+    env:
+      WinPrintWindowsOnly: 'true'
+
     steps:
       - name: Checkout source
         uses: actions/checkout@v5
@@ -25,7 +32,15 @@ jobs:
           dotnet-version: '10.0.x'
 
       - name: Install MAUI workloads
-        run: dotnet workload install maui
+        # maui-windows only — the MacCatalyst head isn't built on this job (see WinPrintWindowsOnly).
+        run: dotnet workload install maui-windows
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.slnx', 'Directory.Build.props', 'Directory.Build.targets', 'global.json') }}
+          restore-keys: ${{ runner.os }}-nuget-
 
       - name: Restore
         run: dotnet restore WinPrint.slnx /p:Configuration=Debug
@@ -109,6 +124,13 @@ jobs:
 
       - name: Install MAUI workloads
         run: dotnet workload install maui
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.slnx', 'Directory.Build.props', 'Directory.Build.targets', 'global.json') }}
+          restore-keys: ${{ runner.os }}-nuget-
 
       - name: Select Xcode 26.5
         # Pin explicitly rather than rely on the image default so the MacCatalyst SDK <-> Xcode pairing is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: dotnet workload install maui
 
       - name: Restore
-        run: dotnet restore WinPrint.slnx /p:Configuration=Debug /p:Platform=x64
+        run: dotnet restore WinPrint.slnx /p:Configuration=Debug
 
       - name: Build analyzer
         # Pre-build the WinPrint.Analyzers project so the solution build doesn't
@@ -36,7 +36,7 @@ jobs:
         run: dotnet build tools/WinPrint.Analyzers/WinPrint.Analyzers.csproj --no-restore /p:Configuration=Debug
 
       - name: Build
-        run: dotnet build WinPrint.slnx --no-restore /p:Configuration=Debug /p:Platform=x64 /p:DefineConstants="CI_BUILD"
+        run: dotnet build WinPrint.slnx --no-restore /p:Configuration=Debug /p:DefineConstants="CI_BUILD"
 
       - name: Restore .NET tools
         run: dotnet tool restore
@@ -57,28 +57,28 @@ jobs:
       # TUI (headless render), cli (process e2e), and WinForms (FlaUI). The MAUI Appium UI tests run on
       # the macOS job below; MAUI unit tests (pure geometry) run here.
       - name: Test (Core)
-        run: dotnet test tests/WinPrint.Core.UnitTests/WinPrint.Core.UnitTests.csproj --configuration Debug -p:Platform=x64 --no-build --verbosity normal
+        run: dotnet test tests/WinPrint.Core.UnitTests/WinPrint.Core.UnitTests.csproj --configuration Debug --no-build --verbosity normal
 
       - name: Test (TUI unit)
-        run: dotnet test tests/WinPrint.TUI.UnitTests/WinPrint.TUI.UnitTests.csproj --configuration Debug -p:Platform=x64 --no-build --verbosity normal
+        run: dotnet test tests/WinPrint.TUI.UnitTests/WinPrint.TUI.UnitTests.csproj --configuration Debug --no-build --verbosity normal
 
       - name: Test (TUI UI)
-        run: dotnet test tests/WinPrint.TUI.UITests/WinPrint.TUI.UITests.csproj --configuration Debug -p:Platform=x64 --no-build --verbosity normal
+        run: dotnet test tests/WinPrint.TUI.UITests/WinPrint.TUI.UITests.csproj --configuration Debug --no-build --verbosity normal
 
       - name: Test (cli unit)
-        run: dotnet test tests/WinPrint.cli.UnitTests/WinPrint.cli.UnitTests.csproj --configuration Debug -p:Platform=x64 --no-build --verbosity normal
+        run: dotnet test tests/WinPrint.cli.UnitTests/WinPrint.cli.UnitTests.csproj --configuration Debug --no-build --verbosity normal
 
       - name: Test (cli UI / e2e)
-        run: dotnet test tests/WinPrint.cli.UITests/WinPrint.cli.UITests.csproj --configuration Debug -p:Platform=x64 --no-build --verbosity normal
+        run: dotnet test tests/WinPrint.cli.UITests/WinPrint.cli.UITests.csproj --configuration Debug --no-build --verbosity normal
 
       - name: Test (WinForms unit)
-        run: dotnet test tests/WinPrint.WinForms.UnitTests/WinPrint.WinForms.UnitTests.csproj --configuration Debug -p:Platform=x64 --no-build --verbosity normal
+        run: dotnet test tests/WinPrint.WinForms.UnitTests/WinPrint.WinForms.UnitTests.csproj --configuration Debug --no-build --verbosity normal
 
       - name: Test (WinForms UI / FlaUI)
-        run: dotnet test tests/WinPrint.WinForms.UITests/WinPrint.WinForms.UITests.csproj --configuration Debug -p:Platform=x64 --no-build --verbosity normal
+        run: dotnet test tests/WinPrint.WinForms.UITests/WinPrint.WinForms.UITests.csproj --configuration Debug --no-build --verbosity normal
 
       - name: Test (MAUI unit)
-        run: dotnet test tests/WinPrint.Maui.UnitTests/WinPrint.Maui.UnitTests.csproj --configuration Debug -p:Platform=x64 --no-build --verbosity normal
+        run: dotnet test tests/WinPrint.Maui.UnitTests/WinPrint.Maui.UnitTests.csproj --configuration Debug --no-build --verbosity normal
 
   # MAUI UI automation: Appium (mac2 driver) against the MacCatalyst app. Needs a macOS host with Xcode,
   # Appium, and the built app — hence a separate job from the Windows build/test matrix.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,7 @@ jobs:
       - name: Test (MAUI UI / Appium)
         env:
           APPIUM_SERVER: http://127.0.0.1:4723
+          MENU_TREE_DUMP_DIR: ${{ github.workspace }}
         run: dotnet test tests/WinPrint.Maui.UITests/WinPrint.Maui.UITests.csproj --configuration Debug --verbosity normal
 
       - name: Upload Appium log
@@ -154,4 +155,14 @@ jobs:
         with:
           name: appium-log
           path: appium.log
+          if-no-files-found: ignore
+
+      - name: Upload menu accessibility tree
+        # Written by the UI test when a menu item locator misses — the actual XCUITest tree for the
+        # Catalyst File menu, so the locator can be corrected from real data rather than guesswork.
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: menu-tree
+          path: menu-tree.xml
           if-no-files-found: ignore

--- a/WinPrint.slnx
+++ b/WinPrint.slnx
@@ -17,46 +17,18 @@
   <Folder Name="/tools/">
     <Project Path="tools/WinPrint.Analyzers/WinPrint.Analyzers.csproj" />
   </Folder>
-  <Project Path="tests/WinPrint.Core.UnitTests/WinPrint.Core.UnitTests.csproj">
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="tests/WinPrint.TUI.UnitTests/WinPrint.TUI.UnitTests.csproj">
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="tests/WinPrint.TUI.UITests/WinPrint.TUI.UITests.csproj">
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="tests/WinPrint.Maui.UnitTests/WinPrint.Maui.UnitTests.csproj">
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="tests/WinPrint.Maui.UITests/WinPrint.Maui.UITests.csproj">
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="tests/WinPrint.cli.UnitTests/WinPrint.cli.UnitTests.csproj">
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="tests/WinPrint.cli.UITests/WinPrint.cli.UITests.csproj">
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="tests/WinPrint.WinForms.UnitTests/WinPrint.WinForms.UnitTests.csproj">
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="tests/WinPrint.WinForms.UITests/WinPrint.WinForms.UITests.csproj">
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/WinPrint.cli/WinPrint.cli.csproj">
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
-  <Project Path="src/WinPrint.Core/WinPrint.Core.csproj">
-    <Platform Solution="*|x64" Project="x64" />
-    <Platform Solution="*|x86" Project="x86" />
-  </Project>
-  <Project Path="src/WinPrint.TUI/WinPrint.TUI.csproj">
-    <Platform Solution="*|x64" Project="x64" />
-    <Platform Solution="*|x86" Project="x86" />
-  </Project>
-  <Project Path="src/WinPrint.WinForms/WinPrint.WinForms.csproj">
-    <Platform Solution="*|x64" Project="x64" />
-  </Project>
+  <Project Path="tests/WinPrint.Core.UnitTests/WinPrint.Core.UnitTests.csproj" />
+  <Project Path="tests/WinPrint.TUI.UnitTests/WinPrint.TUI.UnitTests.csproj" />
+  <Project Path="tests/WinPrint.TUI.UITests/WinPrint.TUI.UITests.csproj" />
+  <Project Path="tests/WinPrint.Maui.UnitTests/WinPrint.Maui.UnitTests.csproj" />
+  <Project Path="tests/WinPrint.Maui.UITests/WinPrint.Maui.UITests.csproj" />
+  <Project Path="tests/WinPrint.cli.UnitTests/WinPrint.cli.UnitTests.csproj" />
+  <Project Path="tests/WinPrint.cli.UITests/WinPrint.cli.UITests.csproj" />
+  <Project Path="tests/WinPrint.WinForms.UnitTests/WinPrint.WinForms.UnitTests.csproj" />
+  <Project Path="tests/WinPrint.WinForms.UITests/WinPrint.WinForms.UITests.csproj" />
+  <Project Path="src/WinPrint.cli/WinPrint.cli.csproj" />
+  <Project Path="src/WinPrint.Core/WinPrint.Core.csproj" />
+  <Project Path="src/WinPrint.TUI/WinPrint.TUI.csproj" />
+  <Project Path="src/WinPrint.WinForms/WinPrint.WinForms.csproj" />
   <Project Path="src/WinPrint.Maui/WinPrint.Maui.csproj" />
 </Solution>

--- a/src/WinPrint.Maui/WinPrint.Maui.csproj
+++ b/src/WinPrint.Maui/WinPrint.Maui.csproj
@@ -5,6 +5,11 @@
 		     doesn't try (and fail NETSDK1100) to build the Windows head. -->
 		<TargetFrameworks>net10.0-maccatalyst</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">net10.0-windows10.0.19041.0;net10.0-maccatalyst</TargetFrameworks>
+		<!-- CI opt-in: on Windows, build only the Windows head. The macOS job already builds AND UI-tests
+		     MacCatalyst, so the Windows job's MacCatalyst cross-compile is redundant; dropping it lets that
+		     job install just the maui-windows workload and skip the heavy Apple/Android packs. Unset locally,
+		     so a normal Windows build still produces both heads. -->
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(WinPrintWindowsOnly)' == 'true'">net10.0-windows10.0.19041.0</TargetFrameworks>
 
 		<!-- Note for MacCatalyst:
 		The default runtime is maccatalyst-x64, except in Release config, in which case the default is maccatalyst-x64;maccatalyst-arm64.

--- a/tests/WinPrint.Maui.UITests/MacMenuUITests.cs
+++ b/tests/WinPrint.Maui.UITests/MacMenuUITests.cs
@@ -62,8 +62,47 @@ public class MacMenuUITests
             By.XPath("//XCUIElementTypeMenuBarItem[@title='File']"));
         fileMenu.Click();
 
-        return driver.FindElement(
-            By.XPath($"//XCUIElementTypeMenuItem[@title='{itemTitle}']"));
+        try
+        {
+            return driver.FindElement(
+                By.XPath($"//XCUIElementTypeMenuItem[@title='{itemTitle}']"));
+        }
+        catch (WebDriverException)
+        {
+            // The menu item wasn't where we expected. Dump the live accessibility tree so the exact
+            // representation of the Catalyst File-menu items (element type / title / label) is visible in
+            // the CI log and uploaded as an artifact, instead of guessing at the locator blind.
+            DumpAccessibilityTree(driver, itemTitle);
+            throw;
+        }
+    }
+
+    private static void DumpAccessibilityTree(MacDriver driver, string itemTitle)
+    {
+        string source;
+        try
+        {
+            source = driver.PageSource;
+        }
+        catch (WebDriverException ex)
+        {
+            source = $"<could-not-capture-page-source>{ex.Message}</could-not-capture-page-source>";
+        }
+
+        Console.WriteLine($"===== ACCESSIBILITY TREE (item '{itemTitle}' not found) =====");
+        Console.WriteLine(source);
+        Console.WriteLine("===== END ACCESSIBILITY TREE =====");
+
+        string dir = Environment.GetEnvironmentVariable("MENU_TREE_DUMP_DIR")
+                     ?? Directory.GetCurrentDirectory();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "menu-tree.xml"), source);
+        }
+        catch (IOException)
+        {
+            // Best-effort: the console dump above is the primary record.
+        }
     }
 
     private static MacDriver CreateDriver()

--- a/tests/WinPrint.Maui.UITests/MacMenuUITests.cs
+++ b/tests/WinPrint.Maui.UITests/MacMenuUITests.cs
@@ -81,7 +81,9 @@ public class MacMenuUITests
         string? appPath = Environment.GetEnvironmentVariable("APPIUM_APP");
         if (!string.IsNullOrEmpty(appPath))
         {
-            options.AddAdditionalAppiumOption("app", appPath);
+            // `app` is a reserved capability with a first-class property; AddAdditionalAppiumOption("app", …)
+            // throws ("use the Application property instead"). Set the property so it serializes to appium:app.
+            options.App = appPath;
         }
         else
         {

--- a/tests/WinPrint.Maui.UITests/MacMenuUITests.cs
+++ b/tests/WinPrint.Maui.UITests/MacMenuUITests.cs
@@ -133,6 +133,24 @@ public class MacMenuUITests
 
         var driver = new MacDriver(new Uri(server), options);
         driver.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(15);
+
+        // Launching by `app` path starts the process but does NOT make it frontmost — XCUITest's menu bar
+        // is owned by whatever app is active (Finder on a fresh CI desktop), so menu-item lookups would hit
+        // Finder's File menu, not ours. Explicitly activate our app so its menu bar is the one in the tree.
+        ActivateApp(driver);
         return driver;
+    }
+
+    private static void ActivateApp(MacDriver driver)
+    {
+        try
+        {
+            driver.ExecuteScript("macos: activateApp", new Dictionary<string, object> { ["bundleId"] = BundleId });
+        }
+        catch (WebDriverException)
+        {
+            // Non-fatal: if activation isn't supported/needed the menu-item find (and its tree dump on
+            // failure) still runs and tells us what actually happened.
+        }
     }
 }


### PR DESCRIPTION
## Summary

The solution forced `Platform=x64` on every managed project. That stamps the managed libraries (`Core`, `TUI`, `cli`, `WinForms`) as **x64** in their PE headers, while the **MAUI app head** — which has no `<Platforms>` and uses a `RuntimeIdentifier` for architecture — compiles **AnyCPU**. The C# compiler then refuses to reference an x64 assembly from an AnyCPU compile (`CS8012` *"targets a different processor"*).

CI on #116 only avoided this by coincidence: on the **x64** Windows runner the MAUI Windows head resolved a `win-x64` RID, which forced `PlatformTarget=x64` and happened to match `Core`. On a **win-arm64** or **mac-arm64** host that coincidence does not hold — a full-solution build there hits `CS8012`.

## Fix

Build & test everything **AnyCPU**; choose architecture with a `RuntimeIdentifier` at **publish** time (`-r win-x64 | win-arm64 | osx-arm64`). AnyCPU managed assemblies are referenceable from any `PlatformTarget` and JIT to the host CPU, so one build/test invocation runs natively on win-x64, win-arm64, and mac-arm64. Native deps (SkiaSharp) already resolve by RID at runtime — unaffected.

- **`WinPrint.slnx`** — drop the per-project `*|x64` / `*|x86` → x64/x86 platform mappings (every project already declares `AnyCPU` in `<Platforms>`).
- **`ci.yml`** — drop `Platform=x64` from the restore, build, and all eight test steps.

## Verified locally (Windows x64)

Clean (`bin`/`obj` removed) AnyCPU restore + build **succeeds, including the MAUI head — no `CS8012`**. Full Windows test matrix: **293 passed / 2 skipped / 0 failed**:

| Project | Result |
|---|---|
| Core.UnitTests | 182 ✅ (2 skipped) |
| TUI.UnitTests | 39 ✅ |
| TUI.UITests | 52 ✅ |
| cli.UnitTests | 7 ✅ |
| cli.UITests | 2 ✅ |
| WinForms.UnitTests | 2 ✅ |
| WinForms.UITests (FlaUI) | 1 ✅ |
| Maui.UnitTests | 8 ✅ |

## Not verified here

This was validated on an **x64 Windows** host (which proves the forced-x64 coupling is removed and the x64 path stays green). A quick `dotnet build WinPrint.slnx` on **win-arm64** and **mac-arm64** is worth doing before merge to confirm clean there too — that's the case this PR is really for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)