### PR TITLE
CI: speed up the Windows job (skip redundant MacCatalyst build, cache NuGet)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,13 @@ jobs:
   build-and-test:
     runs-on: windows-latest
 
+    # Build only WinPrint.Maui's Windows head on this job — the macOS job builds AND UI-tests MacCatalyst,
+    # so cross-compiling it here is redundant. With the MacCatalyst TFM dropped (honored by every MSBuild
+    # tool below, incl. jb cleanupcode and dotnet format) we install just the maui-windows workload and skip
+    # the multi-minute Apple/Android pack download.
+    env:
+      WinPrintWindowsOnly: 'true'
+
     steps:
       - name: Checkout source
         uses: actions/checkout@v5
@@ -25,7 +32,15 @@ jobs:
           dotnet-version: '10.0.x'
 
       - name: Install MAUI workloads
-        run: dotnet workload install maui
+        # maui-windows only — the MacCatalyst head isn't built on this job (see WinPrintWindowsOnly).
+        run: dotnet workload install maui-windows
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.slnx', 'Directory.Build.props', 'Directory.Build.targets', 'global.json') }}
+          restore-keys: ${{ runner.os }}-nuget-
 
       - name: Restore
         run: dotnet restore WinPrint.slnx /p:Configuration=Debug
@@ -109,6 +124,13 @@ jobs:
 
       - name: Install MAUI workloads
         run: dotnet workload install maui
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.slnx', 'Directory.Build.props', 'Directory.Build.targets', 'global.json') }}
+          restore-keys: ${{ runner.os }}-nuget-
 
       - name: Select Xcode 26.5
         # Pin explicitly rather than rely on the image default so the MacCatalyst SDK <-> Xcode pairing is

--- a/src/WinPrint.Maui/WinPrint.Maui.csproj
+++ b/src/WinPrint.Maui/WinPrint.Maui.csproj
@@ -5,6 +5,11 @@
 		     doesn't try (and fail NETSDK1100) to build the Windows head. -->
 		<TargetFrameworks>net10.0-maccatalyst</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">net10.0-windows10.0.19041.0;net10.0-maccatalyst</TargetFrameworks>
+		<!-- CI opt-in: on Windows, build only the Windows head. The macOS job already builds AND UI-tests
+		     MacCatalyst, so the Windows job's MacCatalyst cross-compile is redundant; dropping it lets that
+		     job install just the maui-windows workload and skip the heavy Apple/Android packs. Unset locally,
+		     so a normal Windows build still produces both heads. -->
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(WinPrintWindowsOnly)' == 'true'">net10.0-windows10.0.19041.0</TargetFrameworks>
 
 		<!-- Note for MacCatalyst:
 		The default runtime is maccatalyst-x64, except in Release config, in which case the default is maccatalyst-x64;maccatalyst-arm64.


### PR DESCRIPTION
**Stacked on #118** (base = `fix/anycpu-platform`; retarget to `develop` once #118 merges).

## Problem

Timing of the Windows `build-and-test` job on the #118 run (14m02s total):

| Step | Duration |
|---|---:|
| Install MAUI workloads | **5m04s** |
| Verify code style | 3m33s |
| Restore (NuGet) | 1m27s |
| Setup .NET | 1m04s |
| Build | 58s |
| all 8 test steps combined | 60s |

So ~2 min of real build+test signal in a 14-min run. The two biggest costs are pure overhead: the full `maui` workload install (Android + iOS + **MacCatalyst** + Windows packs), and an uncached NuGet restore. The job also **cross-compiles WinPrint.Maui's MacCatalyst head — which the `maui-ui-tests` (macOS) job already builds *and* UI-tests.**

## Changes

- **Skip the redundant MacCatalyst build on Windows.** `WinPrint.Maui` gets an opt-in `WinPrintWindowsOnly` property that drops the MacCatalyst TFM on Windows. It's **unset locally**, so a normal Windows `dotnet build` still produces both heads (verified both ways with `-getProperty:TargetFrameworks`).
- **Install `maui-windows` instead of `maui`** on the Windows job — skips the Apple/Android pack download entirely. The job sets `WinPrintWindowsOnly=true` at job scope; MSBuild imports it as a property, so restore, build, `jb cleanupcode`, `dotnet format`, and the test steps all drop MacCatalyst uniformly.
- **Cache `~/.nuget/packages`** on both jobs, keyed on project/props files.

MacCatalyst coverage is unchanged — it's fully built + Appium-UI-tested on the macOS job.

## Deliberately *not* done

- **Workload caching** — per the [dotnet/maui guidance](https://github.com/dotnet/maui/discussions/20601) it's unreliable on hosted runners (packs re-download even on a cache hit; no stable cross-platform install path). Installing the narrower `maui-windows` is the reliable equivalent.
- **Parallelizing the style gate** into its own job — would shave ~3 min off the critical path but duplicates the workload+restore+build setup onto a second runner. Left as a future call.

## Verified locally (Windows arm64)

- `-getProperty:TargetFrameworks`: default → `net10.0-windows…;net10.0-maccatalyst`; with the flag (property *and* env-var form) → `net10.0-windows…` only.
- Full `dotnet build WinPrint.slnx` with `WinPrintWindowsOnly=true` succeeds; `WinPrint.Maui` emits only the Windows head, no MacCatalyst output.

The actual CI time reduction will show on this PR's own run — I'll report the new Windows-job timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)