### PR TITLE
Reproducible Azure Trusted Signing setup (scripts + runbook)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,15 @@ in `.claude/settings.json`) installs the .NET 10 SDK, `libgdiplus`, the local `j
 and warms NuGet restore. `global.json` pins .NET 10. The hook runs only when
 `CLAUDE_CODE_REMOTE=true`.
 
+## Release / Windows code signing
+Windows installers are signed with **Azure Trusted Signing** via **GitHub OIDC** (no client
+secret). The full, reproducible setup lives in `scripts/` (`Azure.Config.ps1` = single source
+of truth, `SetupAzure.ps1` = idempotent one-shot creator, `ValidateAzure.ps1` = verifier) and
+is documented in **`docs/code-signing.md`**. An authorized operator recreates the CI trust with
+`az login && pwsh scripts/SetupAzure.ps1 -SetGitHubSecrets`. The Trusted Signing account +
+PublicTrust cert profile are a one-time **manual** prerequisite (identity validation can't be
+scripted); everything else is automated. Read `docs/code-signing.md` before touching signing.
+
 ## Content Type Engines (CTEs)
 CTEs live in `src/WinPrint.Core/ContentTypeEngines` and derive from
 `ContentTypeEngineBase`. They are discovered by reflection via `SupportedContentTypes`

--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -1,0 +1,105 @@
+# Windows code signing — Azure Trusted Signing (runbook)
+
+WinPrint's `release.yml` signs Windows installers with **Azure Trusted Signing**,
+authenticating from GitHub Actions via **OIDC federation** — there is **no client secret**
+and nothing sensitive to rotate. This doc is the single place that explains the whole
+setup so any authorized operator (human or agent) can **recreate it in one shot**.
+
+> Audience note for agents: the scriptable parts are idempotent — re-running is safe and
+> converges. The only non-scriptable part is the one-time identity validation (step 1).
+> Do not invent values; everything stable lives in `scripts/Azure.Config.ps1`.
+
+## Files
+
+| File | Role |
+|------|------|
+| `scripts/Azure.Config.ps1`   | Single source of truth — subscription, RG, account, profile, repo, branches. Edit here only. |
+| `scripts/SetupAzure.ps1`     | Idempotent one-shot: creates app reg + SP + federated creds + role assignment; optionally pushes GitHub secrets. |
+| `scripts/ValidateAzure.ps1`  | Read-only verification that the trust is correct. |
+| `.github/workflows/release.yml` | Consumer — uses the six `AZURE_*` secrets, gated on `HAS_AZURE_SIGNING`. |
+
+## What gets created
+
+```
+Subscription (Kindel LLC)
+└─ Resource group: WinPrint_Resources
+   └─ Trusted Signing account: winprint                 ← step 1, MANUAL (identity validation)
+      └─ Certificate profile: WinPrint (PublicTrust)    ← step 1, MANUAL
+Entra ID (tenant)
+└─ App registration: winprint                           ← scripted
+   ├─ Service principal                                 ← scripted
+   ├─ Federated credentials: refs/tags/*, refs/heads/develop, refs/heads/main   ← scripted
+   └─ Role: "Artifact Signing Certificate Profile Signer" @ cert-profile scope  ← scripted
+GitHub repo: tig/winprint
+└─ Secrets: AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID,
+            AZURE_SIGNING_ACCOUNT, AZURE_SIGNING_PROFILE, AZURE_SIGNING_ENDPOINT   ← scripted (-SetGitHubSecrets)
+```
+
+## Step 1 — the one manual prerequisite (cannot be fully scripted)
+
+A **PublicTrust** certificate profile requires Microsoft to **validate the publisher's
+identity** before any public-trust cert can be issued. That request is submitted and
+completed in the **Azure Portal** (Trusted Signing → your account → Identity validation),
+and Microsoft reviews it out-of-band. Because it gates on a human/Microsoft review, it is
+**not** in the scripts. Do this once:
+
+1. Portal → create a **Trusted Signing account** (`winprint`) in `WinPrint_Resources`.
+2. Submit an **Identity validation** request; wait for it to reach **Completed**.
+3. Create a **certificate profile** (`WinPrint`, type **Public Trust**) bound to that
+   validated identity.
+
+Everything below is fully automated and re-runnable. (`SetupAzure.ps1` will refuse to
+proceed with a clear error if the account/profile from this step don't exist yet.)
+
+## Step 2 — recreate the OIDC trust in one shot
+
+Prereqs: `pwsh` 7+, `az` (`brew install azure-cli`), and — to push secrets — `gh`.
+
+```bash
+az login                                   # an account with App Registration + RBAC rights
+pwsh scripts/SetupAzure.ps1 -SetGitHubSecrets
+pwsh scripts/ValidateAzure.ps1             # confirm
+```
+
+`SetupAzure.ps1` is **find-or-create** at every step, so it's the same command whether
+you're building fresh or reconciling drift (e.g. after editing `Branches` in the config).
+Omit `-SetGitHubSecrets` to print the values without touching the repo. Pass
+`-CreateResourceGroup` if even the RG is gone.
+
+## Step 3 — verify
+
+`ValidateAzure.ps1` asserts the federated-credential subjects and the signer role
+assignment, and prints the six secret values. A clean run ends with `Validation complete.`
+A failed run throws on the first missing piece.
+
+## How `release.yml` consumes it
+
+- `HAS_AZURE_SIGNING` (env) is true only when all six secrets are present; signing steps
+  are gated on it, so forks/unsigned builds still work.
+- The job requests `permissions: id-token: write` and `azure/login@v2` with
+  `client-id`/`tenant-id`/`subscription-id` — no secret, the OIDC token is exchanged for
+  the federated credential.
+- Releases trigger on `v*` **tags** → covered by the `refs/tags/*` credential. Manual
+  `workflow_dispatch` runs are covered by the per-branch credentials (`develop`, `main`).
+
+## Gotchas / lessons baked into the scripts
+
+- **PowerShell `$var:` trap.** `"...$GhRepo:ref..."` makes PowerShell read `GhRepo:` as a
+  scope qualifier and silently drops the repo name. Always brace: `${GhRepo}`. (This bit
+  us once; both scripts now use the braced form.)
+- **Role was renamed.** "Trusted Signing Certificate Profile Signer" →
+  "Artifact Signing Certificate Profile Signer". `ValidateAzure.ps1` accepts both; the
+  config uses the current name. If assignment fails with "role doesn't exist", list with
+  `az role definition list --query "[?contains(roleName,'Signer')].roleName"`.
+- **RBAC propagation.** A freshly created role assignment can take a few minutes before the
+  first CI signing call succeeds.
+- **No secrets to rotate.** Federation means there is no client secret. The only "rotation"
+  is the cert profile's identity validation, which Trusted Signing renews on its own cadence.
+
+## Teardown (if ever needed)
+
+```bash
+# Remove the CI trust (leaves the signing account/profile intact):
+APPID=$(az ad app list --display-name winprint --query "[0].appId" -o tsv)
+az ad app delete --id "$APPID"     # deletes app + SP + federated creds; role assignment is orphaned & GC'd
+```

--- a/scripts/Azure.Config.ps1
+++ b/scripts/Azure.Config.ps1
@@ -1,0 +1,34 @@
+<#
+.SYNOPSIS
+  Single source of truth for WinPrint's Azure Trusted Signing + GitHub OIDC trust.
+
+.DESCRIPTION
+  Dot-sourced/invoked by SetupAzure.ps1 and ValidateAzure.ps1. Edit values HERE only.
+  Returns a hashtable when invoked:  $cfg = & "$PSScriptRoot/Azure.Config.ps1"
+
+  None of these values are secret — they are Azure/GitHub identifiers, not credentials.
+  The actual trust is the federated credential (no client secret is ever created).
+#>
+@{
+    # --- Azure (Kindel LLC subscription) ---
+    SubscriptionId = '7bee0c7c-3217-4628-a783-dd7d687112d3'   # Kindel LLC
+    ResourceGroup  = 'WinPrint_Resources'
+    Location       = 'eastus'
+
+    # --- Trusted Signing account + certificate profile (created in the portal; see docs) ---
+    SigningAccount = 'winprint'
+    CertProfile    = 'WinPrint'
+
+    # --- Entra ID app registration that GitHub Actions authenticates as via OIDC ---
+    AppDisplayName = 'winprint'
+
+    # --- GitHub repo + the refs allowed to mint an OIDC token ---
+    GhOwner        = 'tig'
+    GhRepo         = 'winprint'
+    Branches       = @('develop', 'main')   # plus refs/tags/* (always added)
+
+    # --- RBAC role granted to the app's service principal at the cert-profile scope.
+    #     Microsoft renamed "Trusted Signing Certificate Profile Signer" ->
+    #     "Artifact Signing Certificate Profile Signer"; both grant signing. ---
+    SignerRole     = 'Artifact Signing Certificate Profile Signer'
+}

--- a/scripts/SetupAzure.ps1
+++ b/scripts/SetupAzure.ps1
@@ -1,0 +1,175 @@
+<#
+.SYNOPSIS
+  One-shot, idempotent setup of WinPrint's Azure Trusted Signing OIDC trust for CI.
+
+.DESCRIPTION
+  Creates (or reuses, if already present) everything release.yml needs to sign Windows
+  builds with Azure Trusted Signing using GitHub OIDC — NO client secret:
+
+    1. Entra ID app registration  (Azure.Config.ps1 -> AppDisplayName)
+    2. Its service principal
+    3. Federated credentials      (refs/tags/* + each configured branch)
+    4. Role assignment            (SignerRole, at the certificate-profile scope)
+    5. (optional) the six GitHub Actions repo secrets
+
+  Re-running is safe: each step is find-or-create. Run it again any time the config
+  changes (e.g. you add a branch) and it will converge.
+
+  PREREQUISITES THAT THIS SCRIPT DOES NOT CREATE (manual, one-time — see docs/code-signing.md):
+    * The Trusted Signing *account* and a *PublicTrust certificate profile*. Public-trust
+      profiles require a Microsoft identity-validation request that is completed in the
+      Azure Portal and cannot be fully scripted. Create those first; this script then
+      wires CI up to them. Pass -CreateResourceGroup to create just the resource group.
+
+.EXAMPLE
+  pwsh scripts/SetupAzure.ps1
+  pwsh scripts/SetupAzure.ps1 -SetGitHubSecrets        # also push the 6 repo secrets via gh
+
+.NOTES
+  Requires: pwsh 7+, Azure CLI (az) logged in (`az login`) with rights to create app
+  registrations and role assignments, and — for -SetGitHubSecrets — GitHub CLI (gh) auth'd.
+#>
+#requires -Version 7
+[CmdletBinding()]
+param(
+    [string]$ConfigPath = "$PSScriptRoot/Azure.Config.ps1",
+    [switch]$CreateResourceGroup,
+    [switch]$SetGitHubSecrets
+)
+
+$ErrorActionPreference = 'Stop'
+$cfg = & $ConfigPath
+
+function Require-Cli([string]$name, [string]$hint) {
+    if (-not (Get-Command $name -ErrorAction SilentlyContinue)) {
+        throw "Required CLI '$name' not found. $hint"
+    }
+}
+Require-Cli az  "Install: brew install azure-cli  (then: az login)"
+if ($SetGitHubSecrets) { Require-Cli gh "Install: brew install gh  (then: gh auth login)" }
+
+# Fail early with a clear message if not logged in.
+$null = az account show 2>$null
+if ($LASTEXITCODE -ne 0) { throw "Not logged in to Azure. Run: az login" }
+
+Write-Host "==> Selecting subscription $($cfg.SubscriptionId)" -ForegroundColor Cyan
+az account set --subscription $cfg.SubscriptionId
+$TenantId = az account show --query tenantId -o tsv
+
+# ---------------------------------------------------------------------------
+# 0. (optional) resource group — the signing account/profile must be made by hand.
+# ---------------------------------------------------------------------------
+if ($CreateResourceGroup) {
+    Write-Host "==> Ensuring resource group $($cfg.ResourceGroup)" -ForegroundColor Cyan
+    az group create --name $cfg.ResourceGroup --location $cfg.Location --only-show-errors | Out-Null
+}
+
+$ProfileScope = "/subscriptions/$($cfg.SubscriptionId)/resourceGroups/$($cfg.ResourceGroup)" +
+    "/providers/Microsoft.CodeSigning/codeSigningAccounts/$($cfg.SigningAccount)" +
+    "/certificateProfiles/$($cfg.CertProfile)"
+
+# Verify the manually-created signing account/profile actually exist before wiring CI to them.
+$acct = az resource show --ids "/subscriptions/$($cfg.SubscriptionId)/resourceGroups/$($cfg.ResourceGroup)/providers/Microsoft.CodeSigning/codeSigningAccounts/$($cfg.SigningAccount)" --query "name" -o tsv 2>$null
+if (-not $acct) {
+    throw "Trusted Signing account '$($cfg.SigningAccount)' not found in RG '$($cfg.ResourceGroup)'. " +
+          "Create the account + a PublicTrust certificate profile in the Azure Portal first (see docs/code-signing.md)."
+}
+
+# ---------------------------------------------------------------------------
+# 1. App registration (find-or-create by display name)
+# ---------------------------------------------------------------------------
+Write-Host "==> App registration '$($cfg.AppDisplayName)'" -ForegroundColor Cyan
+$AppId = az ad app list --display-name $cfg.AppDisplayName --query "[0].appId" -o tsv
+if (-not $AppId) {
+    $AppId = az ad app create --display-name $cfg.AppDisplayName --query appId -o tsv
+    Write-Host "    created appId=$AppId"
+} else {
+    Write-Host "    exists  appId=$AppId"
+}
+
+# ---------------------------------------------------------------------------
+# 2. Service principal (find-or-create)
+# ---------------------------------------------------------------------------
+Write-Host "==> Service principal" -ForegroundColor Cyan
+$SpObjectId = az ad sp show --id $AppId --query id -o tsv 2>$null
+if (-not $SpObjectId) {
+    $SpObjectId = az ad sp create --id $AppId --query id -o tsv
+    Write-Host "    created spObjectId=$SpObjectId"
+} else {
+    Write-Host "    exists  spObjectId=$SpObjectId"
+}
+
+# ---------------------------------------------------------------------------
+# 3. Federated credentials: refs/tags/* + one per configured branch
+# ---------------------------------------------------------------------------
+Write-Host "==> Federated credentials" -ForegroundColor Cyan
+$desired = [ordered]@{ 'gh-tags' = "repo:$($cfg.GhOwner)/$($cfg.GhRepo):ref:refs/tags/*" }
+foreach ($b in $cfg.Branches) {
+    $desired["gh-$b"] = "repo:$($cfg.GhOwner)/$($cfg.GhRepo):ref:refs/heads/$b"
+}
+$existing = (az ad app federated-credential list --id $AppId | ConvertFrom-Json)
+$existingSubjects = @($existing.subject)
+foreach ($name in $desired.Keys) {
+    $subject = $desired[$name]
+    if ($existingSubjects -contains $subject) {
+        Write-Host "    exists  $name -> $subject"
+        continue
+    }
+    $body = @{
+        name      = $name
+        issuer    = 'https://token.actions.githubusercontent.com'
+        subject   = $subject
+        audiences = @('api://AzureADTokenExchange')
+    } | ConvertTo-Json -Compress
+    $tmp = New-TemporaryFile
+    Set-Content -Path $tmp -Value $body -Encoding utf8
+    az ad app federated-credential create --id $AppId --parameters "@$tmp" --only-show-errors | Out-Null
+    Remove-Item $tmp
+    Write-Host "    created $name -> $subject"
+}
+
+# ---------------------------------------------------------------------------
+# 4. Role assignment at the certificate-profile scope
+# ---------------------------------------------------------------------------
+Write-Host "==> Role assignment '$($cfg.SignerRole)'" -ForegroundColor Cyan
+$have = az role assignment list --assignee-object-id $SpObjectId --scope $ProfileScope --include-inherited `
+    --query "[?roleDefinitionName=='$($cfg.SignerRole)'] | length(@)" -o tsv
+if ($have -eq '0' -or -not $have) {
+    az role assignment create `
+        --assignee-object-id $SpObjectId `
+        --assignee-principal-type ServicePrincipal `
+        --role $cfg.SignerRole `
+        --scope $ProfileScope --only-show-errors | Out-Null
+    Write-Host "    created (propagation can take a few minutes)"
+} else {
+    Write-Host "    exists"
+}
+
+# ---------------------------------------------------------------------------
+# 5. Discover the signing endpoint and emit the GitHub secret values
+# ---------------------------------------------------------------------------
+$Endpoint = az rest --method get `
+    --url "https://management.azure.com$('/subscriptions/' + $cfg.SubscriptionId + '/resourceGroups/' + $cfg.ResourceGroup + '/providers/Microsoft.CodeSigning/codeSigningAccounts/' + $cfg.SigningAccount)?api-version=2024-02-05-preview" `
+    --query "properties.accountUri" -o tsv
+
+$secrets = [ordered]@{
+    AZURE_CLIENT_ID       = $AppId
+    AZURE_TENANT_ID       = $TenantId
+    AZURE_SUBSCRIPTION_ID = $cfg.SubscriptionId
+    AZURE_SIGNING_ACCOUNT = $cfg.SigningAccount
+    AZURE_SIGNING_PROFILE = $cfg.CertProfile
+    AZURE_SIGNING_ENDPOINT = $Endpoint
+}
+
+Write-Host "`n==> GitHub Actions secrets (release.yml):" -ForegroundColor Green
+foreach ($k in $secrets.Keys) { "{0}={1}" -f $k, $secrets[$k] }
+
+if ($SetGitHubSecrets) {
+    Write-Host "`n==> Pushing secrets to $($cfg.GhOwner)/$($cfg.GhRepo)" -ForegroundColor Cyan
+    foreach ($k in $secrets.Keys) {
+        gh secret set $k --repo "$($cfg.GhOwner)/$($cfg.GhRepo)" --body $secrets[$k]
+        Write-Host "    set $k"
+    }
+}
+
+Write-Host "`nSetup complete. Verify with: pwsh scripts/ValidateAzure.ps1" -ForegroundColor Green

--- a/scripts/ValidateAzure.ps1
+++ b/scripts/ValidateAzure.ps1
@@ -1,0 +1,84 @@
+<#
+.SYNOPSIS
+  Verifies WinPrint's Azure Trusted Signing OIDC trust is correctly configured for CI.
+
+.DESCRIPTION
+  Read-only. Reads scripts/Azure.Config.ps1, discovers the app registration by display
+  name, then asserts: the expected federated-credential subjects exist and a valid signer
+  role is assigned at the certificate-profile scope. Throws on the first problem.
+  Run after SetupAzure.ps1 (or any time you suspect drift).
+
+.NOTES
+  Requires: pwsh 7+, Azure CLI (az) logged in with read access to the app + subscription.
+#>
+#requires -Version 7
+[CmdletBinding()]
+param(
+    [string]$ConfigPath = "$PSScriptRoot/Azure.Config.ps1"
+)
+
+$ErrorActionPreference = 'Stop'
+$cfg = & $ConfigPath
+
+az account set --subscription $cfg.SubscriptionId
+$TenantId = az account show --query tenantId -o tsv
+
+$AppId = az ad app list --display-name $cfg.AppDisplayName --query "[0].appId" -o tsv
+if (-not $AppId) { throw "App registration '$($cfg.AppDisplayName)' not found. Run scripts/SetupAzure.ps1 first." }
+$SpObjectId = az ad sp show --id $AppId --query id -o tsv
+
+$ProfileScope = "/subscriptions/$($cfg.SubscriptionId)/resourceGroups/$($cfg.ResourceGroup)" +
+    "/providers/Microsoft.CodeSigning/codeSigningAccounts/$($cfg.SigningAccount)" +
+    "/certificateProfiles/$($cfg.CertProfile)"
+
+Write-Host "TenantId:     $TenantId"
+Write-Host "AppId:        $AppId"
+Write-Host "SP ObjectId:  $SpObjectId"
+Write-Host "ProfileScope: $ProfileScope"
+
+# 1) Federated credentials — note ${GhRepo}: the bare $GhRepo:ref form makes PowerShell
+#    treat 'GhRepo:' as a scope qualifier and silently drops the repo name.
+$fics = az ad app federated-credential list --id $AppId | ConvertFrom-Json
+$expectedSubjects = @("repo:$($cfg.GhOwner)/$($cfg.GhRepo):ref:refs/tags/*")
+foreach ($b in $cfg.Branches) {
+    $expectedSubjects += "repo:$($cfg.GhOwner)/$($cfg.GhRepo):ref:refs/heads/$b"
+}
+
+$fics | Select-Object name, subject, issuer, audiences | Format-Table -AutoSize
+foreach ($subject in $expectedSubjects) {
+    if (-not ($fics.subject -contains $subject)) {
+        throw "Missing federated credential subject: $subject"
+    }
+}
+
+# 2) Role assignment at the certificate-profile scope
+$assignments = az role assignment list `
+    --assignee-object-id $SpObjectId `
+    --scope $ProfileScope `
+    --include-inherited `
+    --query "[].{role:roleDefinitionName,scope:scope,principalType:principalType}" | ConvertFrom-Json
+
+$assignments | Format-Table -AutoSize
+
+# Accept either the current or the legacy role name (Microsoft renamed it).
+$validRoles = @(
+    'Artifact Signing Certificate Profile Signer',
+    'Trusted Signing Certificate Profile Signer'
+)
+if (-not ($assignments | Where-Object { $validRoles -contains $_.role })) {
+    throw "Expected signer role not found at certificate profile scope."
+}
+
+# 3) GitHub secret values to set/confirm
+$Endpoint = az rest --method get `
+    --url "https://management.azure.com$('/subscriptions/' + $cfg.SubscriptionId + '/resourceGroups/' + $cfg.ResourceGroup + '/providers/Microsoft.CodeSigning/codeSigningAccounts/' + $cfg.SigningAccount)?api-version=2024-02-05-preview" `
+    --query "properties.accountUri" -o tsv
+
+"AZURE_CLIENT_ID=$AppId"
+"AZURE_TENANT_ID=$TenantId"
+"AZURE_SUBSCRIPTION_ID=$($cfg.SubscriptionId)"
+"AZURE_SIGNING_ACCOUNT=$($cfg.SigningAccount)"
+"AZURE_SIGNING_PROFILE=$($cfg.CertProfile)"
+"AZURE_SIGNING_ENDPOINT=$Endpoint"
+
+Write-Host "`nValidation complete." -ForegroundColor Green


### PR DESCRIPTION
## What

Makes WinPrint's Windows code-signing infrastructure (Azure Trusted Signing via GitHub OIDC) **reproducible in one shot**. Any authorized operator — human or agent — can recreate the CI trust with `az login && pwsh scripts/SetupAzure.ps1 -SetGitHubSecrets`.

Supports the release pipeline in #82 (which is the consumer of the six `AZURE_*` secrets).

## Files

| File | Role |
|------|------|
| `scripts/Azure.Config.ps1` | Single source of truth — subscription, RG, signing account, cert profile, repo, branches, role. Edit here only. |
| `scripts/SetupAzure.ps1` | Idempotent one-shot: find-or-creates the app registration, service principal, federated credentials (`refs/tags/*` + per-branch), and the signer role assignment. `-SetGitHubSecrets` pushes the six repo secrets; `-CreateResourceGroup` for a bare rebuild. |
| `scripts/ValidateAzure.ps1` | Read-only verification, config-driven (discovers the appId by display name). |
| `docs/code-signing.md` | Operator/agent runbook: full resource inventory, the one manual prerequisite, one-shot recreate, gotchas. |
| `CLAUDE.md` | Pointer to the runbook. |

## Notes

- **No client secret** — trust is OIDC federation; nothing sensitive is committed (the values in the config are Azure/GitHub identifiers).
- The Trusted Signing **account + PublicTrust certificate profile** remain a one-time **manual** prerequisite (Microsoft identity validation can't be scripted). `SetupAzure.ps1` verifies they exist and errors clearly if not.
- Fixes two latent traps, both documented: a PowerShell `${GhRepo}` scope-qualifier bug that silently mangled the expected federated-credential subjects, and the role rename to *Artifact Signing Certificate Profile Signer*.
- Verified end-to-end against the live resources: idempotent re-run reports all components as existing, and validation passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)