### PR TITLE
Fix release.yml Windows MAUI build (NU1102 Mono.win-x64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,8 +111,15 @@ jobs:
       - name: Restore TUI
         run: dotnet restore src/WinPrint.TUI/WinPrint.TUI.csproj
 
-      - name: Restore MAUI
-        if: ${{ matrix.includeGui }}
+      # Restore the same single head we publish. Without WinPrintWindowsOnly the csproj
+      # also exposes net10.0-maccatalyst on Windows, so a plain restore would evaluate the
+      # MacCatalyst head even though only the maui-windows workload is installed.
+      - name: Restore MAUI (Windows head only)
+        if: ${{ matrix.includeGui && runner.os == 'Windows' }}
+        run: dotnet restore src/WinPrint.Maui/WinPrint.Maui.csproj /p:WinPrintWindowsOnly=true
+
+      - name: Restore MAUI (full)
+        if: ${{ matrix.includeGui && runner.os != 'Windows' }}
         run: dotnet restore src/WinPrint.Maui/WinPrint.Maui.csproj
 
       - name: Get version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,8 +85,17 @@ jobs:
             8.0.x
             10.0.x
 
-      - name: Install MAUI workload
-        if: ${{ matrix.includeGui }}
+      # Windows: install only the maui-windows workload and build only the Windows head
+      # (WinPrintWindowsOnly below). Installing the full `maui` workload + leaving the
+      # MacCatalyst head active makes the Windows job try to cross-compile MacCatalyst from
+      # win-x64, which demands the host Mono cross-pack Microsoft.NETCore.App.Runtime.Mono.win-x64
+      # (not published on nuget.org) and fails restore (NU1102). Mirrors ci.yml.
+      - name: Install MAUI workload (Windows head only)
+        if: ${{ matrix.includeGui && runner.os == 'Windows' }}
+        run: dotnet workload install maui-windows
+
+      - name: Install MAUI workload (full)
+        if: ${{ matrix.includeGui && runner.os != 'Windows' }}
         run: dotnet workload install maui
 
       - name: Install Velopack CLI
@@ -141,7 +150,8 @@ jobs:
             -r "${{ matrix.mauiRuntime }}" `
             --self-contained true `
             -o $publishDir `
-            /p:WindowsPackageType=None
+            /p:WindowsPackageType=None `
+            /p:WinPrintWindowsOnly=true
 
       - name: Publish macOS GUI
         if: ${{ matrix.includeGui && runner.os == 'macOS' }}


### PR DESCRIPTION
## Problem

`release.yml`'s first real run failed in **Package win-x64** at the *Publish Windows GUI* step — **before any signing ran**:

```
error NU1102: Unable to find package Microsoft.NETCore.App.Runtime.Mono.win-x64 with version (= 10.0.9)
```

### Root cause

The Windows package job installed the **full `maui` workload** and left the MacCatalyst TFM active (it never set `WinPrintWindowsOnly`). The `WinPrint.Maui` csproj therefore builds **both** heads on Windows (`net10.0-windows…;net10.0-maccatalyst`). Publishing self-contained then tries to **cross-compile the MacCatalyst head from the win-x64 host**, which needs the host Mono cross-pack `Microsoft.NETCore.App.Runtime.Mono.win-x64 @ 10.0.9` — not published on nuget.org → restore fails.

The already-working `ci.yml` avoids this on purpose (see its `WinPrintWindowsOnly: 'true'` + `dotnet workload install maui-windows`). `release.yml` simply didn't inherit that pattern.

## Fix

Mirror `ci.yml` on the Windows job:
- Install **`maui-windows`** on Windows (full `maui` still used on macOS).
- Pass **`/p:WinPrintWindowsOnly=true`** to the Windows GUI publish so only the Windows head is built — no MacCatalyst cross-compile, no `Mono.win-x64` pack.

## Verification

Triggered via prerelease tag `v2.0.6-signing-test2`. The win-x64 job now gets past publish into **Azure Trusted Signing** + `vpk` pack, producing a signed `winprint.exe` (verified out-of-band with `osslsigncode`).

> Note: macOS jobs still fail separately (`MT4162`: runner's MacCatalyst SDK too old — `release.yml` uses `macos-latest`; `ci.yml` uses `macos-26`). Tracked separately; not required for Windows signing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)