### PR TITLE
Use a flexible FIC for tag OIDC (fix AADSTS700213)

### DIFF
--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -28,7 +28,9 @@ Subscription (Kindel LLC)
 Entra ID (tenant)
 └─ App registration: winprint                           ← scripted
    ├─ Service principal                                 ← scripted
-   ├─ Federated credentials: refs/tags/*, refs/heads/develop, refs/heads/main   ← scripted
+   ├─ Federated credentials                             ← scripted
+   │    • gh-develop / gh-main : exact subject  repo:tig/winprint:ref:refs/heads/<branch>
+   │    • gh-tags (FLEXIBLE)   : claimsMatchingExpression  matches refs/tags/*  (see gotchas)
    └─ Role: "Artifact Signing Certificate Profile Signer" @ cert-profile scope  ← scripted
 GitHub repo: tig/winprint
 └─ Secrets: AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID,
@@ -79,11 +81,19 @@ A failed run throws on the first missing piece.
 - The job requests `permissions: id-token: write` and `azure/login@v2` with
   `client-id`/`tenant-id`/`subscription-id` — no secret, the OIDC token is exchanged for
   the federated credential.
-- Releases trigger on `v*` **tags** → covered by the `refs/tags/*` credential. Manual
+- Releases trigger on `v*` **tags** → covered by the flexible tag credential. Manual
   `workflow_dispatch` runs are covered by the per-branch credentials (`develop`, `main`).
 
 ## Gotchas / lessons baked into the scripts
 
+- **Entra federated `subject` is EXACT-match — wildcards do not work.** A credential with
+  subject `repo:tig/winprint:ref:refs/tags/*` never matches a real tag token
+  (`…/refs/tags/v2.0.6`) and OIDC login fails with **AADSTS700213**. Tags therefore use a
+  **flexible federated identity credential** (`claimsMatchingExpression`:
+  `claims['sub'] matches 'repo:tig/winprint:ref:refs/tags/*'`), created via the **beta**
+  Microsoft Graph endpoint (`/beta/applications/{id}/federatedIdentityCredentials`) — the
+  `v1.0` endpoint and `az ad app federated-credential create` reject/omit it. Branches
+  (`develop`, `main`) are fixed strings, so they keep plain exact-match subjects.
 - **PowerShell `$var:` trap.** `"...$GhRepo:ref..."` makes PowerShell read `GhRepo:` as a
   scope qualifier and silently drops the repo name. Always brace: `${GhRepo}`. (This bit
   us once; both scripts now use the braced form.)

--- a/scripts/SetupAzure.ps1
+++ b/scripts/SetupAzure.ps1
@@ -100,18 +100,25 @@ if (-not $SpObjectId) {
 }
 
 # ---------------------------------------------------------------------------
-# 3. Federated credentials: refs/tags/* + one per configured branch
+# 3. Federated credentials
+#
+#    Branches use exact-match `subject` credentials. Tags use a *flexible* FIC
+#    (`claimsMatchingExpression`) instead, because Entra federated-credential
+#    `subject` is an EXACT string match — a wildcard subject like
+#    "repo:o/r:ref:refs/tags/*" never matches a real tag token and OIDC login
+#    fails with AADSTS700213. The flexible form (beta Graph endpoint) supports
+#    the `matches` operator and covers every `v*` tag with one credential.
 # ---------------------------------------------------------------------------
 Write-Host "==> Federated credentials" -ForegroundColor Cyan
-$desired = [ordered]@{ 'gh-tags' = "repo:$($cfg.GhOwner)/$($cfg.GhRepo):ref:refs/tags/*" }
+$AppObjectId = az ad app show --id $AppId --query id -o tsv
+$ficUrl = "https://graph.microsoft.com/beta/applications/$AppObjectId/federatedIdentityCredentials"
+$existing = (az rest --method get --url $ficUrl | ConvertFrom-Json).value
+
+# 3a. Branch credentials (exact subject)
 foreach ($b in $cfg.Branches) {
-    $desired["gh-$b"] = "repo:$($cfg.GhOwner)/$($cfg.GhRepo):ref:refs/heads/$b"
-}
-$existing = (az ad app federated-credential list --id $AppId | ConvertFrom-Json)
-$existingSubjects = @($existing.subject)
-foreach ($name in $desired.Keys) {
-    $subject = $desired[$name]
-    if ($existingSubjects -contains $subject) {
+    $name = "gh-$b"
+    $subject = "repo:$($cfg.GhOwner)/$($cfg.GhRepo):ref:refs/heads/$b"
+    if (@($existing.subject) -contains $subject) {
         Write-Host "    exists  $name -> $subject"
         continue
     }
@@ -126,6 +133,32 @@ foreach ($name in $desired.Keys) {
     az ad app federated-credential create --id $AppId --parameters "@$tmp" --only-show-errors | Out-Null
     Remove-Item $tmp
     Write-Host "    created $name -> $subject"
+}
+
+# 3b. Tag credential (flexible claimsMatchingExpression)
+$tagName = 'gh-tags'
+$tagExpr = "claims['sub'] matches 'repo:$($cfg.GhOwner)/$($cfg.GhRepo):ref:refs/tags/*'"
+$tagCred = $existing | Where-Object { $_.name -eq $tagName }
+if ($tagCred -and $tagCred.subject) {
+    # Legacy broken form (wildcard subject) from before the flexible-FIC fix — replace it.
+    az ad app federated-credential delete --id $AppId --federated-credential-id $tagCred.id --only-show-errors | Out-Null
+    Write-Host "    removed legacy subject-based $tagName"
+    $tagCred = $null
+}
+if (-not $tagCred) {
+    $body = @{
+        name                     = $tagName
+        issuer                   = 'https://token.actions.githubusercontent.com'
+        audiences                = @('api://AzureADTokenExchange')
+        claimsMatchingExpression = @{ value = $tagExpr; languageVersion = 1 }
+    } | ConvertTo-Json -Compress -Depth 5
+    $tmp = New-TemporaryFile
+    Set-Content -Path $tmp -Value $body -Encoding utf8
+    az rest --method post --url $ficUrl --headers "Content-Type=application/json" --body "@$tmp" | Out-Null
+    Remove-Item $tmp
+    Write-Host "    created (flexible) $tagName -> $tagExpr"
+} else {
+    Write-Host "    exists  (flexible) $tagName"
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/ValidateAzure.ps1
+++ b/scripts/ValidateAzure.ps1
@@ -36,19 +36,29 @@ Write-Host "AppId:        $AppId"
 Write-Host "SP ObjectId:  $SpObjectId"
 Write-Host "ProfileScope: $ProfileScope"
 
-# 1) Federated credentials — note ${GhRepo}: the bare $GhRepo:ref form makes PowerShell
-#    treat 'GhRepo:' as a scope qualifier and silently drops the repo name.
-$fics = az ad app federated-credential list --id $AppId | ConvertFrom-Json
-$expectedSubjects = @("repo:$($cfg.GhOwner)/$($cfg.GhRepo):ref:refs/tags/*")
-foreach ($b in $cfg.Branches) {
-    $expectedSubjects += "repo:$($cfg.GhOwner)/$($cfg.GhRepo):ref:refs/heads/$b"
-}
+# 1) Federated credentials. Read via the beta Graph endpoint so the flexible tag
+#    credential's claimsMatchingExpression is visible (the v1.0 `az` list omits it).
+#    Branches are exact-match subjects; tags are a flexible claimsMatchingExpression
+#    (Entra `subject` is exact-match, so a wildcard tag subject can't work — see
+#    SetupAzure.ps1 / docs/code-signing.md). Note ${GhRepo}: the bare $GhRepo:ref form
+#    makes PowerShell treat 'GhRepo:' as a scope qualifier and silently drops the repo name.
+$AppObjectId = az ad app show --id $AppId --query id -o tsv
+$fics = (az rest --method get --url "https://graph.microsoft.com/beta/applications/$AppObjectId/federatedIdentityCredentials" | ConvertFrom-Json).value
+$fics | Select-Object name, subject, @{ n = 'claimsExpr'; e = { $_.claimsMatchingExpression.value } } | Format-Table -AutoSize
 
-$fics | Select-Object name, subject, issuer, audiences | Format-Table -AutoSize
-foreach ($subject in $expectedSubjects) {
+# Branches: exact subject must be present
+foreach ($b in $cfg.Branches) {
+    $subject = "repo:$($cfg.GhOwner)/$($cfg.GhRepo):ref:refs/heads/$b"
     if (-not ($fics.subject -contains $subject)) {
         throw "Missing federated credential subject: $subject"
     }
+}
+
+# Tags: a flexible credential whose expression covers refs/tags/* must be present
+$expectedTagPattern = "repo:$($cfg.GhOwner)/$($cfg.GhRepo):ref:refs/tags/*"
+$tagCred = $fics | Where-Object { $_.claimsMatchingExpression -and $_.claimsMatchingExpression.value -like "*$expectedTagPattern*" }
+if (-not $tagCred) {
+    throw "Missing flexible federated credential (claimsMatchingExpression) covering: $expectedTagPattern"
 }
 
 # 2) Role assignment at the certificate-profile scope


### PR DESCRIPTION
## Problem

The first real signed release run failed at **Azure login for Trusted Signing**:

```
AADSTS700213: No matching federated identity record found for presented assertion
subject 'repo:tig/winprint:ref:refs/tags/v2.0.6-signing-test2'
```

The signing scripts (merged in #122) created/validated the **tag** federated credential with a wildcard **`subject`**: `repo:tig/winprint:ref:refs/tags/*`. But Entra matches the federated-credential `subject` **exactly** — a `*` is a literal, so it never matches a real tag token. OIDC login fails and Trusted Signing never runs. (Branch creds worked because `develop`/`main` are exact strings.)

## Fix

Tags now use a **flexible federated identity credential** (`claimsMatchingExpression`):

```
claims['sub'] matches 'repo:tig/winprint:ref:refs/tags/*'
```

created via the **beta** Microsoft Graph endpoint (`/beta/applications/{id}/federatedIdentityCredentials`) — `v1.0` / `az ad app federated-credential create` require a `subject` and reject the expression. Branch credentials stay exact-match subjects.

- `SetupAzure.ps1` — creates the flexible tag FIC and **self-heals** the old wildcard-subject credential (deletes + recreates).
- `ValidateAzure.ps1` — reads via beta Graph and asserts the expression covers `refs/tags/*`.
- `docs/code-signing.md` — documents the exact-match gotcha and the flexible-FIC approach.

## Verification

Applied to the live app registration, then a `v*` tag drove a full release run: **win-x64 signed successfully** with Azure Trusted Signing. `osslsigncode` confirms both `Kindel.WinPrint-win-Setup.exe` and the app `winprint.exe`:

```
Signer:    CN=Kindel, LLC  (Issuer: Microsoft ID Verified CS EOC CA 03)
Timestamp: SHA-256, Microsoft RSA Timestamping CA 2020
Result:    Succeeded
```

Both `SetupAzure.ps1` (idempotent) and `ValidateAzure.ps1` (passes) were re-run against the corrected live setup.

## Related
- #122 introduced the scripts (with the wildcard-subject bug this fixes).
- #123 fixes the Windows MAUI build that was masking this (signing wasn't reached until that was green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)