### PR TITLE
Build release macOS legs on macos-26 (fixes #124)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
             mainExe: wp.exe
             icon: src/WinPrint.cli/winprint.ico
 
-          - os: macos-latest
+          - os: macos-26
             runtime: osx-x64
             tuiFramework: net10.0
             includeGui: true
@@ -46,7 +46,7 @@ jobs:
             mainExe: wp
             icon: ''
 
-          - os: macos-latest
+          - os: macos-26
             runtime: osx-arm64
             tuiFramework: net10.0
             includeGui: true


### PR DESCRIPTION
Fixes #124.

The `osx-x64` / `osx-arm64` package legs in `release.yml` ran on `macos-latest` (macOS 15, newest Xcode 26.3), whose MacCatalyst SDK is too old for `net10.0-maccatalyst` — publish failed with `MT4162` (UIKit types introduced in MacCatalyst 26.0) plus a follow-on `NETSDK1144` trim failure.

Pin both macOS legs to **`macos-26`** (Xcode 26 / MacCatalyst 26.x), matching the already-proven `ci.yml` `maui-ui-tests` job (which documents exactly this requirement).

Verified together with the first real `main` release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)