### PR TITLE
Mark pre-release tags as prereleases in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,3 +288,6 @@ jobs:
         with:
           files: release-artifacts/**/*
           generate_release_notes: true
+          # Tags with a pre-release label (e.g. v2.6.0-rc.1) publish as a pre-release so
+          # GitHub doesn't mark them "Latest"; stable tags (v2.6.0) become the latest release.
+          prerelease: ${{ contains(github.ref_name, '-') }}


### PR DESCRIPTION
The publish step (`softprops/action-gh-release`) had no `prerelease` input, so every tag published as a normal **Latest** release — including pre-release tags like `v2.6.0-rc.1` (observed during the first `main` release test).

Add `prerelease: ${{ contains(github.ref_name, '-') }}`: tags with a SemVer pre-release label (contain `-`) publish as pre-releases (GitHub won't mark them Latest); stable tags (`v2.6.0`) become the latest release as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)