### PR TITLE
Automate winget-pkgs submission on stable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ env:
   VPK_VERSION: 1.1.1
   HAS_AZURE_SIGNING: ${{ secrets.AZURE_CLIENT_ID != '' && secrets.AZURE_TENANT_ID != '' && secrets.AZURE_SUBSCRIPTION_ID != '' && secrets.AZURE_SIGNING_ACCOUNT != '' && secrets.AZURE_SIGNING_PROFILE != '' && secrets.AZURE_SIGNING_ENDPOINT != '' }}
   HAS_APPLE_SIGNING: ${{ secrets.APPLE_CERTIFICATE_BASE64 != '' && secrets.APPLE_CERTIFICATE_PASSWORD != '' && secrets.APPLE_ID != '' && secrets.APPLE_APP_SPECIFIC_PASSWORD != '' && secrets.APPLE_TEAM_ID != '' && secrets.APPLE_SIGNING_IDENTITY != '' }}
+  HAS_WINGET: ${{ secrets.WINGET_TOKEN != '' }}
 
 jobs:
   package:
@@ -291,3 +292,26 @@ jobs:
           # Tags with a pre-release label (e.g. v2.6.0-rc.1) publish as a pre-release so
           # GitHub doesn't mark them "Latest"; stable tags (v2.6.0) become the latest release.
           prerelease: ${{ contains(github.ref_name, '-') }}
+
+  # Auto-update the winget-pkgs manifest on every STABLE release. Pre-releases are skipped.
+  # Requires a classic PAT in the WINGET_TOKEN secret (public_repo scope) and a one-time
+  # manual bootstrap of the package into microsoft/winget-pkgs — see packaging/winget/README.md.
+  winget:
+    name: Submit to winget-pkgs
+    needs: publish
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.ref_name, '-') }}
+    steps:
+      - name: Derive winget version (strip leading v)
+        id: ver
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Submit to winget-pkgs
+        if: ${{ env.HAS_WINGET == 'true' }}
+        uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: Kindel.WinPrint
+          version: ${{ steps.ver.outputs.version }}
+          release-tag: ${{ github.ref_name }}
+          installers-regex: 'win-Setup\.exe$'
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/packaging/winget/Kindel.WinPrint.installer.yaml
+++ b/packaging/winget/Kindel.WinPrint.installer.yaml
@@ -1,6 +1,8 @@
 PackageIdentifier: Kindel.WinPrint
 PackageVersion: "{{version}}"
 InstallerType: exe
+# Velopack installs per-user into %LocalAppData% (no admin required).
+Scope: user
 InstallModes:
   - interactive
   - silent
@@ -9,6 +11,14 @@ InstallerSwitches:
   SilentWithProgress: --silent
 UpgradeBehavior: install
 ReleaseDate: "{{releaseDate}}"
+# Lets `winget upgrade` correlate an installed copy with this package. Values mirror the
+# Add/Remove Programs entry Velopack registers (key = PackId, DisplayName = packTitle).
+AppsAndFeaturesEntries:
+  - DisplayName: WinPrint
+    Publisher: Kindel
+    DisplayVersion: "{{version}}"
+    ProductCode: Kindel.WinPrint
+    InstallerType: exe
 Installers:
   - Architecture: x64
     InstallerUrl: "{{installerUrl}}"

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -1,0 +1,60 @@
+# winget packaging
+
+Makes `winget install Kindel.WinPrint` work by publishing manifests to the
+[microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) community repository
+(winget's default source). The files here are the manifest **templates** and the source of
+truth for the one-time bootstrap; ongoing version updates are automated by CI.
+
+## How it works
+
+| Stage | Who | What |
+|-------|-----|------|
+| First version | **manual, once** | Submit the initial manifests to winget-pkgs (winget-pkgs requires a package to already exist before it can be auto-updated). |
+| Every later release | **automated** | The `winget` job in `.github/workflows/release.yml` runs `winget-releaser` on each **stable** tag, opening a winget-pkgs PR with the new version + signed installer. |
+
+The installer is Authenticode-signed (Azure Trusted Signing — see `docs/code-signing.md`),
+which smooths winget validation.
+
+## One-time setup
+
+1. **Create the token.** A classic GitHub **PAT** with **`public_repo`** scope
+   (fine-grained PATs are *not* supported by winget-releaser). Save it as the repo secret
+   **`WINGET_TOKEN`**. The PAT's account must have a fork of `microsoft/winget-pkgs`.
+   Until this secret exists, the `winget` CI job is a no-op (gated on `HAS_WINGET`).
+
+2. **Bootstrap the first version** into winget-pkgs (pick one):
+   - `komac` (recommended):
+     ```bash
+     komac update Kindel.WinPrint \
+       --version 2.6.0 \
+       --urls https://github.com/tig/winprint/releases/download/v2.6.0/Kindel.WinPrint-win-Setup.exe \
+       --token <PAT> --submit
+     ```
+     (For a brand-new package use `komac new Kindel.WinPrint`.)
+   - or render the templates in this folder (replace `{{version}}`, `{{installerUrl}}`,
+     `{{installerSha256}}`, `{{releaseDate}}`) and open the PR under
+     `manifests/k/Kindel/WinPrint/<version>/` by hand.
+
+   First submissions for a new publisher are **manually reviewed** by winget-pkgs moderators.
+
+After the package exists in winget-pkgs and `WINGET_TOKEN` is set, **no further manual steps
+are needed** — each stable release auto-submits its update.
+
+## Values for the current release (v2.6.0)
+
+```
+PackageVersion:  2.6.0
+InstallerUrl:    https://github.com/tig/winprint/releases/download/v2.6.0/Kindel.WinPrint-win-Setup.exe
+InstallerSha256: F19CCCE38A0AE67059343648E11C3898614507817893FD01FD3D62D875AD3CE1
+ReleaseDate:     2026-06-20
+```
+
+## Notes / things to validate on a real install
+
+- **Silent switch:** Velopack's `Setup.exe` is invoked with `--silent` (used by winget's
+  silent install mode and by winget-pkgs sandbox validation).
+- **`AppsAndFeaturesEntries.ProductCode`** is set to the Velopack PackId (`Kindel.WinPrint`),
+  which is the Add/Remove Programs registry key Velopack creates. If `winget upgrade` ever
+  fails to detect an installed copy, confirm the actual ARP key on a real install and adjust.
+- Only the **x64** Windows installer is published; add more `Installers` entries if other
+  arches ship later.


### PR DESCRIPTION
Makes `winget install Kindel.WinPrint` maintainable: every **stable** release auto-submits its update to [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs).

## What

- **`release.yml`** — new `winget` job (after `publish`) using `vedantmgoyal9/winget-releaser@v2`. Runs only on stable tags (skips `-` pre-releases) and only when the `WINGET_TOKEN` secret exists (`HAS_WINGET` gate, mirroring the signing gates). Pulls the signed `*win-Setup.exe` from the release.
- **`Kindel.WinPrint.installer.yaml`** — correctness fixes: `Scope: user` (Velopack is per-user) and `AppsAndFeaturesEntries` (DisplayName=WinPrint, Publisher=Kindel, ProductCode=Kindel.WinPrint, from the verified Velopack package identity) so `winget upgrade` can match an installed copy.
- **`packaging/winget/README.md`** — documents the flow.

## Two one-time human steps (can't be automated away)

1. Add a classic **PAT** (`public_repo` scope) as repo secret **`WINGET_TOKEN`** (fine-grained PATs aren't supported by winget-releaser).
2. **Bootstrap** the first version into winget-pkgs (winget-pkgs requires a package to already exist before it auto-updates) — `komac update … --submit`, see the README. First submissions are moderator-reviewed.

After that, releases auto-submit with no manual steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)