### PR TITLE
Prep for repo transfer to the Kindel org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,3 +315,7 @@ jobs:
           release-tag: ${{ github.ref_name }}
           installers-regex: 'win-Setup\.exe$'
           token: ${{ secrets.WINGET_TOKEN }}
+          # WINGET_TOKEN is tig's PAT and the winget-pkgs fork lives under tig; pin the
+          # fork account so this keeps working after the repo moves to the Kindel org
+          # (the action otherwise defaults fork-user to the repo owner).
+          fork-user: tig

--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -29,10 +29,10 @@ Entra ID (tenant)
 └─ App registration: winprint                           ← scripted
    ├─ Service principal                                 ← scripted
    ├─ Federated credentials                             ← scripted
-   │    • gh-develop / gh-main : exact subject  repo:tig/winprint:ref:refs/heads/<branch>
+   │    • gh-develop / gh-main : exact subject  repo:Kindel/winprint:ref:refs/heads/<branch>
    │    • gh-tags (FLEXIBLE)   : claimsMatchingExpression  matches refs/tags/*  (see gotchas)
    └─ Role: "Artifact Signing Certificate Profile Signer" @ cert-profile scope  ← scripted
-GitHub repo: tig/winprint
+GitHub repo: Kindel/winprint
 └─ Secrets: AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID,
             AZURE_SIGNING_ACCOUNT, AZURE_SIGNING_PROFILE, AZURE_SIGNING_ENDPOINT   ← scripted (-SetGitHubSecrets)
 ```
@@ -87,10 +87,10 @@ A failed run throws on the first missing piece.
 ## Gotchas / lessons baked into the scripts
 
 - **Entra federated `subject` is EXACT-match — wildcards do not work.** A credential with
-  subject `repo:tig/winprint:ref:refs/tags/*` never matches a real tag token
+  subject `repo:Kindel/winprint:ref:refs/tags/*` never matches a real tag token
   (`…/refs/tags/v2.0.6`) and OIDC login fails with **AADSTS700213**. Tags therefore use a
   **flexible federated identity credential** (`claimsMatchingExpression`:
-  `claims['sub'] matches 'repo:tig/winprint:ref:refs/tags/*'`), created via the **beta**
+  `claims['sub'] matches 'repo:Kindel/winprint:ref:refs/tags/*'`), created via the **beta**
   Microsoft Graph endpoint (`/beta/applications/{id}/federatedIdentityCredentials`) — the
   `v1.0` endpoint and `az ad app federated-credential create` reject/omit it. Branches
   (`develop`, `main`) are fixed strings, so they keep plain exact-match subjects.

--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -29,10 +29,10 @@ Entra ID (tenant)
 └─ App registration: winprint                           ← scripted
    ├─ Service principal                                 ← scripted
    ├─ Federated credentials                             ← scripted
-   │    • gh-develop / gh-main : exact subject  repo:Kindel/winprint:ref:refs/heads/<branch>
+   │    • gh-develop / gh-main : exact subject  repo:kindel/winprint:ref:refs/heads/<branch>
    │    • gh-tags (FLEXIBLE)   : claimsMatchingExpression  matches refs/tags/*  (see gotchas)
    └─ Role: "Artifact Signing Certificate Profile Signer" @ cert-profile scope  ← scripted
-GitHub repo: Kindel/winprint
+GitHub repo: kindel/winprint
 └─ Secrets: AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID,
             AZURE_SIGNING_ACCOUNT, AZURE_SIGNING_PROFILE, AZURE_SIGNING_ENDPOINT   ← scripted (-SetGitHubSecrets)
 ```
@@ -87,10 +87,10 @@ A failed run throws on the first missing piece.
 ## Gotchas / lessons baked into the scripts
 
 - **Entra federated `subject` is EXACT-match — wildcards do not work.** A credential with
-  subject `repo:Kindel/winprint:ref:refs/tags/*` never matches a real tag token
+  subject `repo:kindel/winprint:ref:refs/tags/*` never matches a real tag token
   (`…/refs/tags/v2.0.6`) and OIDC login fails with **AADSTS700213**. Tags therefore use a
   **flexible federated identity credential** (`claimsMatchingExpression`:
-  `claims['sub'] matches 'repo:Kindel/winprint:ref:refs/tags/*'`), created via the **beta**
+  `claims['sub'] matches 'repo:kindel/winprint:ref:refs/tags/*'`), created via the **beta**
   Microsoft Graph endpoint (`/beta/applications/{id}/federatedIdentityCredentials`) — the
   `v1.0` endpoint and `az ad app federated-credential create` reject/omit it. Branches
   (`develop`, `main`) are fixed strings, so they keep plain exact-match subjects.

--- a/packaging/homebrew/Casks/winprint.rb
+++ b/packaging/homebrew/Casks/winprint.rb
@@ -4,10 +4,10 @@ cask "winprint" do
   version "{{version}}"
   sha256 "{{sha256}}"
 
-  url "https://github.com/tig/winprint/releases/download/v#{version}/{{macosArtifactName}}"
+  url "https://github.com/Kindel/winprint/releases/download/v#{version}/{{macosArtifactName}}"
   name "WinPrint"
   desc "Advanced source code and text file printing"
-  homepage "https://github.com/tig/winprint"
+  homepage "https://github.com/Kindel/winprint"
 
   app "WinPrint.app"
   binary "wp"

--- a/packaging/homebrew/Casks/winprint.rb
+++ b/packaging/homebrew/Casks/winprint.rb
@@ -4,10 +4,10 @@ cask "winprint" do
   version "{{version}}"
   sha256 "{{sha256}}"
 
-  url "https://github.com/Kindel/winprint/releases/download/v#{version}/{{macosArtifactName}}"
+  url "https://github.com/kindel/winprint/releases/download/v#{version}/{{macosArtifactName}}"
   name "WinPrint"
   desc "Advanced source code and text file printing"
-  homepage "https://github.com/Kindel/winprint"
+  homepage "https://github.com/kindel/winprint"
 
   app "WinPrint.app"
   binary "wp"

--- a/packaging/homebrew/Formula/winprint.rb
+++ b/packaging/homebrew/Formula/winprint.rb
@@ -2,8 +2,8 @@
 # Replace the version, sha256, and URL after publishing a Linux Velopack artifact.
 class Winprint < Formula
   desc "Advanced source code and text file printing terminal UI"
-  homepage "https://github.com/Kindel/winprint"
-  url "https://github.com/Kindel/winprint/releases/download/v{{version}}/{{linuxArtifactName}}"
+  homepage "https://github.com/kindel/winprint"
+  url "https://github.com/kindel/winprint/releases/download/v{{version}}/{{linuxArtifactName}}"
   sha256 "{{sha256}}"
   license "MIT"
 

--- a/packaging/homebrew/Formula/winprint.rb
+++ b/packaging/homebrew/Formula/winprint.rb
@@ -2,8 +2,8 @@
 # Replace the version, sha256, and URL after publishing a Linux Velopack artifact.
 class Winprint < Formula
   desc "Advanced source code and text file printing terminal UI"
-  homepage "https://github.com/tig/winprint"
-  url "https://github.com/tig/winprint/releases/download/v{{version}}/{{linuxArtifactName}}"
+  homepage "https://github.com/Kindel/winprint"
+  url "https://github.com/Kindel/winprint/releases/download/v{{version}}/{{linuxArtifactName}}"
   sha256 "{{sha256}}"
   license "MIT"
 

--- a/packaging/winget/Kindel.WinPrint.locale.en-US.yaml
+++ b/packaging/winget/Kindel.WinPrint.locale.en-US.yaml
@@ -6,7 +6,7 @@ PackageName: WinPrint
 License: MIT
 ShortDescription: Advanced source code and text file printing.
 Description: WinPrint is a modern source code and text printing app with a cross-platform terminal UI and Windows/macOS GUI.
-PackageUrl: https://github.com/tig/winprint
-PublisherUrl: https://github.com/tig
+PackageUrl: https://github.com/Kindel/winprint
+PublisherUrl: https://github.com/Kindel
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/packaging/winget/Kindel.WinPrint.locale.en-US.yaml
+++ b/packaging/winget/Kindel.WinPrint.locale.en-US.yaml
@@ -6,7 +6,7 @@ PackageName: WinPrint
 License: MIT
 ShortDescription: Advanced source code and text file printing.
 Description: WinPrint is a modern source code and text printing app with a cross-platform terminal UI and Windows/macOS GUI.
-PackageUrl: https://github.com/Kindel/winprint
-PublisherUrl: https://github.com/Kindel
+PackageUrl: https://github.com/kindel/winprint
+PublisherUrl: https://github.com/kindel
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -27,7 +27,7 @@ which smooths winget validation.
      ```bash
      komac update Kindel.WinPrint \
        --version 2.6.0 \
-       --urls https://github.com/tig/winprint/releases/download/v2.6.0/Kindel.WinPrint-win-Setup.exe \
+       --urls https://github.com/Kindel/winprint/releases/download/v2.6.0/Kindel.WinPrint-win-Setup.exe \
        --token <PAT> --submit
      ```
      (For a brand-new package use `komac new Kindel.WinPrint`.)
@@ -44,7 +44,7 @@ are needed** — each stable release auto-submits its update.
 
 ```
 PackageVersion:  2.6.0
-InstallerUrl:    https://github.com/tig/winprint/releases/download/v2.6.0/Kindel.WinPrint-win-Setup.exe
+InstallerUrl:    https://github.com/Kindel/winprint/releases/download/v2.6.0/Kindel.WinPrint-win-Setup.exe
 InstallerSha256: F19CCCE38A0AE67059343648E11C3898614507817893FD01FD3D62D875AD3CE1
 ReleaseDate:     2026-06-20
 ```

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -27,7 +27,7 @@ which smooths winget validation.
      ```bash
      komac update Kindel.WinPrint \
        --version 2.6.0 \
-       --urls https://github.com/Kindel/winprint/releases/download/v2.6.0/Kindel.WinPrint-win-Setup.exe \
+       --urls https://github.com/kindel/winprint/releases/download/v2.6.0/Kindel.WinPrint-win-Setup.exe \
        --token <PAT> --submit
      ```
      (For a brand-new package use `komac new Kindel.WinPrint`.)
@@ -44,7 +44,7 @@ are needed** — each stable release auto-submits its update.
 
 ```
 PackageVersion:  2.6.0
-InstallerUrl:    https://github.com/Kindel/winprint/releases/download/v2.6.0/Kindel.WinPrint-win-Setup.exe
+InstallerUrl:    https://github.com/kindel/winprint/releases/download/v2.6.0/Kindel.WinPrint-win-Setup.exe
 InstallerSha256: F19CCCE38A0AE67059343648E11C3898614507817893FD01FD3D62D875AD3CE1
 ReleaseDate:     2026-06-20
 ```

--- a/scripts/Azure.Config.ps1
+++ b/scripts/Azure.Config.ps1
@@ -23,7 +23,7 @@
     AppDisplayName = 'winprint'
 
     # --- GitHub repo + the refs allowed to mint an OIDC token ---
-    GhOwner        = 'tig'
+    GhOwner        = 'Kindel'
     GhRepo         = 'winprint'
     Branches       = @('develop', 'main')   # plus refs/tags/* (always added)
 

--- a/scripts/Azure.Config.ps1
+++ b/scripts/Azure.Config.ps1
@@ -23,7 +23,7 @@
     AppDisplayName = 'winprint'
 
     # --- GitHub repo + the refs allowed to mint an OIDC token ---
-    GhOwner        = 'Kindel'
+    GhOwner        = 'kindel'
     GhRepo         = 'winprint'
     Branches       = @('develop', 'main')   # plus refs/tags/* (always added)
 

--- a/scripts/SetupAzure.ps1
+++ b/scripts/SetupAzure.ps1
@@ -109,19 +109,26 @@ if (-not $SpObjectId) {
 #    fails with AADSTS700213. The flexible form (beta Graph endpoint) supports
 #    the `matches` operator and covers every `v*` tag with one credential.
 # ---------------------------------------------------------------------------
+#    Idempotency keys on the credential SUBJECT / EXPRESSION, never on a fixed name, and
+#    new credentials are named per-owner (gh-<branch>-<owner>, gh-tags-<owner>). Entra
+#    federated-credential names are unique and immutable, so owner-qualified names let the
+#    `tig` and `Kindel` credentials coexist during a repo transfer without collisions, and
+#    keying on subject/expression means we never mistake a different owner's `gh-tags` for
+#    this owner's tag trust.
 Write-Host "==> Federated credentials" -ForegroundColor Cyan
 $AppObjectId = az ad app show --id $AppId --query id -o tsv
 $ficUrl = "https://graph.microsoft.com/beta/applications/$AppObjectId/federatedIdentityCredentials"
 $existing = (az rest --method get --url $ficUrl | ConvertFrom-Json).value
+$ownerSlug = $cfg.GhOwner.ToLower()
 
 # 3a. Branch credentials (exact subject)
 foreach ($b in $cfg.Branches) {
-    $name = "gh-$b"
     $subject = "repo:$($cfg.GhOwner)/$($cfg.GhRepo):ref:refs/heads/$b"
     if (@($existing.subject) -contains $subject) {
-        Write-Host "    exists  $name -> $subject"
+        Write-Host "    exists  (branch) $subject"
         continue
     }
+    $name = "gh-$b-$ownerSlug"
     $body = @{
         name      = $name
         issuer    = 'https://token.actions.githubusercontent.com'
@@ -135,19 +142,21 @@ foreach ($b in $cfg.Branches) {
     Write-Host "    created $name -> $subject"
 }
 
-# 3b. Tag credential (flexible claimsMatchingExpression)
-$tagName = 'gh-tags'
-$tagExpr = "claims['sub'] matches 'repo:$($cfg.GhOwner)/$($cfg.GhRepo):ref:refs/tags/*'"
-$tagCred = $existing | Where-Object { $_.name -eq $tagName }
-if ($tagCred -and $tagCred.subject) {
-    # Legacy broken form (wildcard subject) from before the flexible-FIC fix — replace it.
-    az ad app federated-credential delete --id $AppId --federated-credential-id $tagCred.id --only-show-errors | Out-Null
-    Write-Host "    removed legacy subject-based $tagName"
-    $tagCred = $null
+# 3b. Tag credential (flexible claimsMatchingExpression), detected by expression for THIS owner.
+$tagPattern = "repo:$($cfg.GhOwner)/$($cfg.GhRepo):ref:refs/tags/*"
+$tagExpr = "claims['sub'] matches '$tagPattern'"
+# Remove any legacy wildcard-SUBJECT tag credential for this owner (pre-flexible-FIC bug).
+foreach ($l in @($existing | Where-Object { $_.subject -eq $tagPattern })) {
+    az ad app federated-credential delete --id $AppId --federated-credential-id $l.id --only-show-errors | Out-Null
+    Write-Host "    removed legacy subject-based $($l.name)"
 }
-if (-not $tagCred) {
+$tagCred = $existing | Where-Object { $_.claimsMatchingExpression -and $_.claimsMatchingExpression.value -eq $tagExpr }
+if ($tagCred) {
+    Write-Host "    exists  (flexible) $($tagCred.name)"
+} else {
+    $name = "gh-tags-$ownerSlug"
     $body = @{
-        name                     = $tagName
+        name                     = $name
         issuer                   = 'https://token.actions.githubusercontent.com'
         audiences                = @('api://AzureADTokenExchange')
         claimsMatchingExpression = @{ value = $tagExpr; languageVersion = 1 }
@@ -156,9 +165,7 @@ if (-not $tagCred) {
     Set-Content -Path $tmp -Value $body -Encoding utf8
     az rest --method post --url $ficUrl --headers "Content-Type=application/json" --body "@$tmp" | Out-Null
     Remove-Item $tmp
-    Write-Host "    created (flexible) $tagName -> $tagExpr"
-} else {
-    Write-Host "    exists  (flexible) $tagName"
+    Write-Host "    created (flexible) $name -> $tagExpr"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Owner/URL updates ahead of moving the repo from `tig` to the **Kindel** org. **Hold until the transfer happens** (the `github.com/Kindel/winprint` URLs won't resolve until then).

## Changes
- **`scripts/Azure.Config.ps1`** — `GhOwner = 'Kindel'` (drives the OIDC federated-credential subjects that Setup/ValidateAzure.ps1 create/check).
- **`release.yml`** winget job — pin **`fork-user: tig`** (the `WINGET_TOKEN` PAT and the winget-pkgs fork are tig's; the action otherwise defaults `fork-user` to the repo owner = the org).
- **winget + homebrew manifests/README + `docs/code-signing.md`** — `github.com/tig` → `github.com/Kindel`.

## Already handled in Azure (live)
Federated credentials for `repo:Kindel/winprint` (2 branches + flexible tag FIC) were **pre-staged alongside the `tig` ones**, so signing works straight through the transfer with zero downtime.

## Transfer-day checklist (after the move)
1. Merge this PR.
2. **Verify repo Actions secrets survived** the transfer (6 `AZURE_*` + `WINGET_TOKEN`); re-add any that didn't.
3. Cut a test tag → confirm `azure/login` succeeds under `repo:Kindel/winprint` (watch for `AADSTS700213`, which would indicate an org-name case mismatch).
4. Once confirmed, **delete the 3 `tig` federated credentials** (`gh-develop`, `gh-main`, `gh-tags`).
5. Update local git remotes (`git remote set-url origin …/Kindel/winprint`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)