### PR TITLE
Automate Homebrew tap for the free TUI (macOS + Linux)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ env:
   HAS_AZURE_SIGNING: ${{ secrets.AZURE_CLIENT_ID != '' && secrets.AZURE_TENANT_ID != '' && secrets.AZURE_SUBSCRIPTION_ID != '' && secrets.AZURE_SIGNING_ACCOUNT != '' && secrets.AZURE_SIGNING_PROFILE != '' && secrets.AZURE_SIGNING_ENDPOINT != '' }}
   HAS_APPLE_SIGNING: ${{ secrets.APPLE_CERTIFICATE_BASE64 != '' && secrets.APPLE_CERTIFICATE_PASSWORD != '' && secrets.APPLE_ID != '' && secrets.APPLE_APP_SPECIFIC_PASSWORD != '' && secrets.APPLE_TEAM_ID != '' && secrets.APPLE_SIGNING_IDENTITY != '' }}
   HAS_WINGET: ${{ secrets.WINGET_TOKEN != '' }}
+  HAS_BREW_TAP: ${{ secrets.HOMEBREW_TAP_TOKEN != '' }}
 
 jobs:
   package:
@@ -146,6 +147,23 @@ jobs:
             --self-contained true `
             -o $publishDir `
             /p:PublishSingleFile=false
+
+      # Capture a TUI-only tarball for the Homebrew tap BEFORE the GUI publish writes into
+      # the same dir, so `wp` ships without the (separately-distributed) GUI. macOS + Linux only.
+      - name: Package TUI tarball (Homebrew)
+        if: ${{ runner.os != 'Windows' }}
+        shell: bash
+        run: |
+          mkdir -p artifacts/cli
+          tar -C "artifacts/publish/${{ matrix.runtime }}" -czf "artifacts/cli/wp-${{ matrix.runtime }}.tar.gz" .
+
+      - name: Upload TUI tarball
+        if: ${{ runner.os != 'Windows' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: wp-${{ matrix.runtime }}
+          path: artifacts/cli/wp-${{ matrix.runtime }}.tar.gz
+          if-no-files-found: error
 
       - name: Publish Windows GUI
         if: ${{ matrix.includeGui && runner.os == 'Windows' }}
@@ -315,3 +333,48 @@ jobs:
           release-tag: ${{ github.ref_name }}
           installers-regex: 'win-Setup\.exe$'
           token: ${{ secrets.WINGET_TOKEN }}
+
+  # Update the Homebrew tap (kindel/homebrew-winprint) with the new TUI on every STABLE
+  # release. Renders packaging/homebrew/Formula/winprint.rb with the version + per-arch
+  # SHA256s and pushes it to the tap. Requires a classic PAT (repo scope) in HOMEBREW_TAP_TOKEN
+  # with push access to the tap; no-op until that secret is set.
+  brew:
+    name: Update Homebrew tap
+    needs: publish
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.ref_name, '-') }}
+    steps:
+      - name: Checkout source
+        if: ${{ env.HAS_BREW_TAP == 'true' }}
+        uses: actions/checkout@v5
+
+      - name: Render formula and push to tap
+        if: ${{ env.HAS_BREW_TAP == 'true' }}
+        shell: bash
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          base="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}"
+          sha() { curl -fsSL "$base/$1" | sha256sum | awk '{print $1}'; }
+
+          sed -e "s|{{version}}|${version}|g" \
+              -e "s|{{base}}|${base}|g" \
+              -e "s|{{sha_osx_arm}}|$(sha wp-osx-arm64.tar.gz)|" \
+              -e "s|{{sha_osx_x64}}|$(sha wp-osx-x64.tar.gz)|" \
+              -e "s|{{sha_linux_x64}}|$(sha wp-linux-x64.tar.gz)|" \
+              -e "s|{{sha_linux_arm}}|$(sha wp-linux-arm64.tar.gz)|" \
+              packaging/homebrew/Formula/winprint.rb > /tmp/winprint.rb
+
+          git clone "https://x-access-token:${TAP_TOKEN}@github.com/kindel/homebrew-winprint.git" tap
+          mkdir -p tap/Formula
+          cp /tmp/winprint.rb tap/Formula/winprint.rb
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/winprint.rb
+          git diff --cached --quiet && { echo "Formula unchanged."; exit 0; }
+          git commit -m "winprint ${version}"
+          git push

--- a/packaging/homebrew/Formula/winprint.rb
+++ b/packaging/homebrew/Formula/winprint.rb
@@ -1,11 +1,33 @@
-# Template for a future Homebrew tap formula.
-# Replace the version, sha256, and URL after publishing a Linux Velopack artifact.
+# Template rendered by the release pipeline (release.yml -> brew job) and pushed to the
+# kindel/homebrew-winprint tap; the placeholders are filled with each stable release's
+# version, download base URL, and per-arch SHA256s. Free TUI (wp) only — GUI ships via stores.
 class Winprint < Formula
   desc "Advanced source code and text file printing terminal UI"
-  homepage "https://github.com/tig/winprint"
-  url "https://github.com/tig/winprint/releases/download/v{{version}}/{{linuxArtifactName}}"
-  sha256 "{{sha256}}"
+  homepage "https://github.com/kindel/winprint"
+  version "{{version}}"
   license "MIT"
+
+  on_macos do
+    on_arm do
+      url "{{base}}/wp-osx-arm64.tar.gz"
+      sha256 "{{sha_osx_arm}}"
+    end
+    on_intel do
+      url "{{base}}/wp-osx-x64.tar.gz"
+      sha256 "{{sha_osx_x64}}"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "{{base}}/wp-linux-arm64.tar.gz"
+      sha256 "{{sha_linux_arm}}"
+    end
+    on_intel do
+      url "{{base}}/wp-linux-x64.tar.gz"
+      sha256 "{{sha_linux_x64}}"
+    end
+  end
 
   def install
     libexec.install Dir["*"]
@@ -13,6 +35,6 @@ class Winprint < Formula
   end
 
   test do
-    system "#{bin}/wp", "--version"
+    system bin/"wp", "--version"
   end
 end


### PR DESCRIPTION
Makes `brew install kindel/winprint/winprint` work and stay current — the free **TUI** (`wp`) for macOS and Linux.

## What
- **`release.yml`**: package a **TUI-only** tarball `wp-<rid>.tar.gz` for `osx-arm64`, `osx-x64`, `linux-x64`, `linux-arm64`. It's captured **right after `Publish TUI`, before the GUI publish writes into the same dir**, so the CLI ships without the (separately distributed, paid) GUI.
- **`release.yml`**: new `brew` job (stable tags only) renders the formula with the version + per-arch SHA256s and pushes it to **kindel/homebrew-winprint**. Gated on `HOMEBREW_TAP_TOKEN` (`HAS_BREW_TAP`) — no-op until the secret is set, like the signing/winget gates.
- **`packaging/homebrew/Formula/winprint.rb`**: real 4-platform formula (`on_macos`/`on_linux` + `on_arm`/`on_intel`), validated to parse as Ruby.

## Already done
- The tap repo **kindel/homebrew-winprint** is created + scaffolded.

## One-time setup (then fully automated)
Add a classic **PAT** (`repo` scope) with push access to the tap as repo secret **`HOMEBREW_TAP_TOKEN`**. After that, every stable release auto-updates the formula.

## Notes
- Homebrew downloads via curl → no Gatekeeper quarantine, so the unsigned `wp` runs (Apple Silicon ad-hoc signing is already applied by `dotnet publish`). No notarization needed for brew.
- This is the **free tier** (TUI), unaffected by the planned 3.0 free/paid split; the GUI **cask** is the one that goes away at 3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)