### PR TITLE
Fix Windows release installer entrypoints

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
             mauiFramework: net10.0-windows10.0.19041.0
             mauiRuntime: win-x64
             channel: win
-            mainExe: wp.exe
+            mainExe: winprint.exe
             icon: src/WinPrint.cli/winprint.ico
 
           - os: macos-26
@@ -160,6 +160,23 @@ jobs:
             -o $publishDir `
             /p:WindowsPackageType=None `
             /p:WinPrintWindowsOnly=true
+
+      - name: Validate Windows package inputs
+        if: ${{ matrix.includeGui && runner.os == 'Windows' }}
+        shell: pwsh
+        run: |
+          $publishDir = "artifacts/publish/${{ matrix.runtime }}"
+          $requiredFiles = @(
+            "winprint.exe", # MAUI GUI; this must be the Start Menu entrypoint.
+            "wp.exe"        # Terminal UI; exposed through the installed folder on PATH.
+          )
+
+          foreach ($file in $requiredFiles) {
+            $path = Join-Path $publishDir $file
+            if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+              throw "Windows package input is missing required executable: $path"
+            }
+          }
 
       - name: Publish macOS GUI
         if: ${{ matrix.includeGui && runner.os == 'macOS' }}

--- a/src/WinPrint.Maui/MauiProgram.cs
+++ b/src/WinPrint.Maui/MauiProgram.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.Logging;
 using CommandLine;
 using Serilog;
-using Velopack;
 using WinPrint.Core.Models;
 #if WINDOWS
 using WinPrint.Core.Services;
@@ -21,13 +20,6 @@ public static class MauiProgram
 
     public static MauiApp CreateMauiApp()
     {
-#if !MACCATALYST
-        // Velopack's locator throws PlatformNotSupportedException on MacCatalyst (it
-        // doesn't recognize the platform). The Mac app is installed/updated via the
-        // Homebrew cask instead, so only hook Velopack up elsewhere (Windows).
-        VelopackApp.Build().Run();
-#endif
-
         // Capture the *invocation* CWD before we change it below, so relative file
         // arguments passed on the command line can be resolved against the directory
         // the user launched the app from rather than the install directory. Prefer

--- a/src/WinPrint.Maui/Packaging/WindowsUserPath.cs
+++ b/src/WinPrint.Maui/Packaging/WindowsUserPath.cs
@@ -1,0 +1,86 @@
+namespace WinPrint.Maui.Packaging;
+
+internal static class WindowsUserPath
+{
+    private const char PathSeparator = ';';
+
+    public static void AddCurrentDirectory()
+    {
+        UpdateUserPath(AddPathEntry);
+    }
+
+    public static void RemoveCurrentDirectory()
+    {
+        UpdateUserPath(RemovePathEntry);
+    }
+
+    internal static string AddPathEntry(string? currentPath, string entry)
+    {
+        if (ContainsPathEntry(currentPath, entry))
+        {
+            return currentPath ?? string.Empty;
+        }
+
+        if (string.IsNullOrWhiteSpace(currentPath))
+        {
+            return entry;
+        }
+
+        return currentPath.TrimEnd(PathSeparator) + PathSeparator + entry;
+    }
+
+    internal static string RemovePathEntry(string? currentPath, string entry)
+    {
+        if (string.IsNullOrEmpty(currentPath))
+        {
+            return string.Empty;
+        }
+
+        string[] remainingEntries =
+        [
+            .. currentPath
+            .Split(PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Where(pathEntry => !PathEntriesMatch(pathEntry, entry))
+        ];
+
+        return string.Join(PathSeparator, remainingEntries);
+    }
+
+    private static bool ContainsPathEntry(string? currentPath, string entry)
+    {
+        return !string.IsNullOrEmpty(currentPath)
+               && currentPath
+                   .Split(PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+                   .Any(pathEntry => PathEntriesMatch(pathEntry, entry));
+    }
+
+    private static bool PathEntriesMatch(string left, string right)
+    {
+        return string.Equals(NormalizePathEntry(left), NormalizePathEntry(right), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string NormalizePathEntry(string entry)
+    {
+        entry = entry.Trim().Trim('"');
+        return Path.TrimEndingDirectorySeparator(entry);
+    }
+
+    private static string GetCurrentDirectoryPathEntry()
+    {
+        return Path.TrimEndingDirectorySeparator(AppContext.BaseDirectory);
+    }
+
+    private static void UpdateUserPath(Func<string?, string, string> update)
+    {
+        string pathEntry = GetCurrentDirectoryPathEntry();
+        string? currentPath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User);
+        string updatedPath = update(currentPath, pathEntry);
+
+        if (string.Equals(currentPath, updatedPath, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        Environment.SetEnvironmentVariable("PATH", updatedPath, EnvironmentVariableTarget.User);
+    }
+}

--- a/src/WinPrint.Maui/Platforms/Windows/App.xaml.cs
+++ b/src/WinPrint.Maui/Platforms/Windows/App.xaml.cs
@@ -1,6 +1,9 @@
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
 
+using Velopack;
+using WinPrint.Maui.Packaging;
+
 namespace WinPrint.Maui.WinUI;
 
 /// <summary>
@@ -14,6 +17,12 @@ public partial class App : MauiWinUIApplication
     /// </summary>
     public App()
     {
+        VelopackApp.Build()
+            .OnAfterInstallFastCallback(_ => WindowsUserPath.AddCurrentDirectory())
+            .OnAfterUpdateFastCallback(_ => WindowsUserPath.AddCurrentDirectory())
+            .OnBeforeUninstallFastCallback(_ => WindowsUserPath.RemoveCurrentDirectory())
+            .Run();
+
         InitializeComponent();
     }
 

--- a/tests/WinPrint.Maui.UnitTests/WinPrint.Maui.UnitTests.csproj
+++ b/tests/WinPrint.Maui.UnitTests/WinPrint.Maui.UnitTests.csproj
@@ -22,6 +22,7 @@
     <ItemGroup>
         <Compile Include="..\..\src\WinPrint.Maui\Views\PreviewGeometry.cs" Link="Linked\PreviewGeometry.cs" />
         <Compile Include="..\..\src\WinPrint.Maui\FontSizeParser.cs" Link="Linked\FontSizeParser.cs" />
+        <Compile Include="..\..\src\WinPrint.Maui\Packaging\WindowsUserPath.cs" Link="Linked\WindowsUserPath.cs" />
     </ItemGroup>
 
 </Project>

--- a/tests/WinPrint.Maui.UnitTests/WindowsUserPathTests.cs
+++ b/tests/WinPrint.Maui.UnitTests/WindowsUserPathTests.cs
@@ -1,0 +1,35 @@
+using WinPrint.Maui.Packaging;
+using Xunit;
+
+namespace WinPrint.Maui.UnitTests;
+
+public class WindowsUserPathTests
+{
+    [Fact]
+    public void AddPathEntryAppendsMissingEntry()
+    {
+        string updatedPath = WindowsUserPath.AddPathEntry(@"C:\Tools;C:\Windows", @"C:\Users\Tig\AppData\Local\Kindel.WinPrint\current");
+
+        Assert.Equal(@"C:\Tools;C:\Windows;C:\Users\Tig\AppData\Local\Kindel.WinPrint\current", updatedPath);
+    }
+
+    [Fact]
+    public void AddPathEntryDoesNotDuplicateEquivalentEntry()
+    {
+        string currentPath = @"C:\Tools;C:\Users\Tig\AppData\Local\Kindel.WinPrint\current\";
+
+        string updatedPath = WindowsUserPath.AddPathEntry(currentPath, @"c:\users\tig\appdata\local\kindel.winprint\current");
+
+        Assert.Equal(currentPath, updatedPath);
+    }
+
+    [Fact]
+    public void RemovePathEntryRemovesEquivalentEntry()
+    {
+        string currentPath = @"C:\Tools;C:\Users\Tig\AppData\Local\Kindel.WinPrint\current\;C:\Windows";
+
+        string updatedPath = WindowsUserPath.RemovePathEntry(currentPath, @"c:\users\tig\appdata\local\kindel.winprint\current");
+
+        Assert.Equal(@"C:\Tools;C:\Windows", updatedPath);
+    }
+}


### PR DESCRIPTION
## Summary
- Point the Windows Velopack package at winprint.exe so the Start Menu launches the MAUI GUI instead of the console TUI.
- Add Windows Velopack install/update/uninstall hooks to add/remove the installed current folder from the user PATH so wp.exe is available after install.
- Add a release workflow guard that fails Windows packaging if either winprint.exe or wp.exe is missing.

## Validation
- dotnet test tests\WinPrint.Maui.UnitTests\WinPrint.Maui.UnitTests.csproj --configuration Debug --verbosity minimal
- dotnet build src\WinPrint.Maui\WinPrint.Maui.csproj --configuration Debug -f net10.0-windows10.0.19041.0 /p:WinPrintWindowsOnly=true --verbosity minimal
- Release-style publish check for TUI + MAUI into a temp folder, verifying both winprint.exe and wp.exe exist.