### PR TITLE
Fix paper size preview reflow

### DIFF
--- a/src/WinPrint.Core/Abstractions/PrinterChoices.cs
+++ b/src/WinPrint.Core/Abstractions/PrinterChoices.cs
@@ -9,6 +9,20 @@ namespace WinPrint.Core.Abstractions;
 /// </summary>
 public static class PrinterChoices
 {
+    private static readonly Dictionary<string, (int Width, int Height)> PaperDimensions =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Letter"] = (850, 1100),
+            ["Legal"] = (850, 1400),
+            ["Tabloid"] = (1100, 1700),
+            ["Executive"] = (725, 1050),
+            ["A3"] = (1169, 1654),
+            ["A4"] = (827, 1169),
+            ["A5"] = (583, 827),
+            ["B4"] = (984, 1390),
+            ["B5"] = (693, 984)
+        };
+
     /// <summary>Generic printer entries used when no real printers can be enumerated.</summary>
     public static IReadOnlyList<string> DefaultPrinters { get; } =
     [
@@ -29,4 +43,55 @@ public static class PrinterChoices
         "B4",
         "B5"
     ];
+
+    /// <summary>Applies a selected paper name and, when known, its dimensions.</summary>
+    public static bool ApplyPaperSize(PrintPageSetup pageSetup, string? paperSizeName)
+    {
+        ArgumentNullException.ThrowIfNull(pageSetup);
+
+        pageSetup.PaperSizeName = paperSizeName ?? string.Empty;
+        if (!TryGetPaperDimensions(paperSizeName, out int width, out int height))
+        {
+            return false;
+        }
+
+        pageSetup.PaperWidth = width;
+        pageSetup.PaperHeight = height;
+        return true;
+    }
+
+    /// <summary>Looks up common paper dimensions in hundredths of an inch.</summary>
+    public static bool TryGetPaperDimensions(string? paperSizeName, out int width, out int height)
+    {
+        width = 0;
+        height = 0;
+        if (string.IsNullOrWhiteSpace(paperSizeName))
+        {
+            return false;
+        }
+
+        foreach (KeyValuePair<string, (int Width, int Height)> paper in PaperDimensions)
+        {
+            if (IsPaperNameMatch(paperSizeName, paper.Key))
+            {
+                width = paper.Value.Width;
+                height = paper.Value.Height;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsPaperNameMatch(string paperSizeName, string knownName)
+    {
+        if (string.Equals(paperSizeName, knownName, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return paperSizeName.Length > knownName.Length &&
+               paperSizeName.StartsWith(knownName, StringComparison.OrdinalIgnoreCase) &&
+               !char.IsLetterOrDigit(paperSizeName[knownName.Length]);
+    }
 }

--- a/src/WinPrint.Core/Models/Font.cs
+++ b/src/WinPrint.Core/Models/Font.cs
@@ -26,11 +26,8 @@ public class Font : ICloneable
     public FontStyle Style
     {
         get => _style;
-        set
-        {
-            _style = value & AllStyles;
-            //                SetField(ref style, value);
-        }
+        set => _style = value & AllStyles;
+        //                SetField(ref style, value);
     }
 
     /// <summary>

--- a/src/WinPrint.Core/ViewModels/AppViewModel.cs
+++ b/src/WinPrint.Core/ViewModels/AppViewModel.cs
@@ -154,6 +154,39 @@ public sealed class AppViewModel : INotifyPropertyChanged
         set => SetField(ref _selectedPaperSize, value);
     }
 
+    public void SetPrinterSetup(string? printerName, string? paperSizeName, int fromSheet, int toSheet)
+    {
+        SetPrinterName(printerName);
+        _pageSetup.FromSheet = fromSheet;
+        _pageSetup.ToSheet = toSheet;
+        SetPaperSize(paperSizeName);
+    }
+
+    public void SetPrinterName(string? printerName)
+    {
+        string value = printerName ?? string.Empty;
+        SelectedPrinter = value;
+        _pageSetup.PrinterName = value;
+    }
+
+    public void SetPaperSize(string? paperSizeName)
+    {
+        string value = paperSizeName ?? string.Empty;
+        int oldWidth = _pageSetup.PaperWidth;
+        int oldHeight = _pageSetup.PaperHeight;
+        bool changed = !string.Equals(_pageSetup.PaperSizeName, value, StringComparison.Ordinal) ||
+                       SelectedPaperSize != value;
+
+        SelectedPaperSize = value;
+        PrinterChoices.ApplyPaperSize(_pageSetup, value);
+        changed = changed || _pageSetup.PaperWidth != oldWidth || _pageSetup.PaperHeight != oldHeight;
+
+        if (changed)
+        {
+            _ = ReflowAsync();
+        }
+    }
+
     // ----- Sheet enumeration / selection -----
 
     /// <summary>
@@ -762,8 +795,8 @@ public sealed class AppViewModel : INotifyPropertyChanged
     /// </summary>
     public void RestorePrinterSelection(IList<string> availablePrinters, string? systemDefault)
     {
-        SelectedPrinter = PrinterSelection.ResolvePrinter(Settings.LastPrinter, systemDefault,
-            availablePrinters as IReadOnlyList<string> ?? availablePrinters?.ToList());
+        SetPrinterName(PrinterSelection.ResolvePrinter(Settings.LastPrinter, systemDefault,
+            availablePrinters as IReadOnlyList<string> ?? availablePrinters?.ToList()));
     }
 
     /// <summary>
@@ -776,7 +809,7 @@ public sealed class AppViewModel : INotifyPropertyChanged
         string? saved = Settings.LastPaperSize;
         if (!string.IsNullOrEmpty(saved) && availablePaperSizes != null && availablePaperSizes.Contains(saved))
         {
-            SelectedPaperSize = saved;
+            SetPaperSize(saved);
         }
     }
 
@@ -897,15 +930,13 @@ public sealed class AppViewModel : INotifyPropertyChanged
             if (!string.IsNullOrEmpty(options.Printer) &&
                 (availablePrinters == null || availablePrinters.Contains(options.Printer)))
             {
-                SelectedPrinter = options.Printer;
-                _pageSetup.PrinterName = options.Printer;
+                SetPrinterName(options.Printer);
             }
 
             if (!string.IsNullOrEmpty(options.PaperSize) &&
                 (availablePaperSizes == null || availablePaperSizes.Contains(options.PaperSize)))
             {
-                SelectedPaperSize = options.PaperSize;
-                _pageSetup.PaperSizeName = options.PaperSize;
+                SetPaperSize(options.PaperSize);
             }
 
             // --from-sheet / --to-sheet print range (0 = default/all).

--- a/src/WinPrint.Maui/ViewModels/MainViewModel.cs
+++ b/src/WinPrint.Maui/ViewModels/MainViewModel.cs
@@ -484,13 +484,7 @@ public sealed class MainViewModel : INotifyPropertyChanged
         {
             if (_app.SelectedPaperSize != value)
             {
-                _app.SelectedPaperSize = value;
-                if (value != null)
-                {
-                    UpdatePageSetupForPaper(value);
-                    _ = _app.ReflowAsync();
-                }
-
+                _app.SetPaperSize(value);
                 OnPropertyChanged();
             }
         }
@@ -837,25 +831,6 @@ public sealed class MainViewModel : INotifyPropertyChanged
                 (int)(top * 100),
                 (int)(bottom * 100));
             _app.SetMargins(margins);
-        }
-    }
-
-    private void UpdatePageSetupForPaper(string paperName)
-    {
-        if (paperName.StartsWith("Letter"))
-        {
-            _currentPageSetup.PaperWidth = 850;
-            _currentPageSetup.PaperHeight = 1100;
-        }
-        else if (paperName.StartsWith("Legal"))
-        {
-            _currentPageSetup.PaperWidth = 850;
-            _currentPageSetup.PaperHeight = 1400;
-        }
-        else if (paperName.StartsWith("A4"))
-        {
-            _currentPageSetup.PaperWidth = 827;
-            _currentPageSetup.PaperHeight = 1169;
         }
     }
 

--- a/src/WinPrint.TUI/SettingsContext.cs
+++ b/src/WinPrint.TUI/SettingsContext.cs
@@ -110,12 +110,12 @@ public sealed class SettingsContext
             PrinterSelection.ResolvePrinter(settings.LastPrinter, pageSetup.PrinterName, printerNames);
         if (!string.IsNullOrEmpty(chosenPrinter))
         {
-            pageSetup.PrinterName = chosenPrinter;
+            app.SetPrinterName(chosenPrinter);
         }
 
         if (!string.IsNullOrEmpty(settings.LastPaperSize))
         {
-            pageSetup.PaperSizeName = settings.LastPaperSize;
+            app.SetPaperSize(settings.LastPaperSize);
         }
     }
 

--- a/src/WinPrint.TUI/Views/Editors/PrinterEditor.cs
+++ b/src/WinPrint.TUI/Views/Editors/PrinterEditor.cs
@@ -82,6 +82,8 @@ public sealed class PrinterEditor : EditorBase<PrintPageSetup>
         Add(_printer, paperLabel, _paper, pagesLabel, _from, toLabel, _to);
     }
 
+    public event EventHandler? Edited;
+
     /// <summary>The sheet range (From/To) being edited. Editing From/To mutates this instance.</summary>
     public PageRange Range { get; private set; } = new();
 
@@ -155,6 +157,7 @@ public sealed class PrinterEditor : EditorBase<PrintPageSetup>
         Range.From = _from.Value;
         Range.To = _to.Value;
         SyncRangeToValue();
+        Edited?.Invoke(this, EventArgs.Empty);
     }
 
     // A bound printer/paper may not be in the offered list (e.g. set from a saved profile); add it so

--- a/src/WinPrint.TUI/Views/SettingsPanel.cs
+++ b/src/WinPrint.TUI/Views/SettingsPanel.cs
@@ -189,6 +189,13 @@ public sealed class SettingsPanel : View
                 app.SetLineNumbers(LineNumbers.Value == CheckState.Checked);
             }
         };
+        Printer.Edited += (_, _) =>
+        {
+            if (!_seeding && Printer.Value is { } setup)
+            {
+                app.SetPrinterSetup(setup.PrinterName, setup.PaperSizeName, setup.FromSheet, setup.ToSheet);
+            }
+        };
 
         FileButton.Accepting += (_, _) => OpenFile();
 

--- a/tests/WinPrint.Core.UnitTests/ViewModels/AppViewModelTests.cs
+++ b/tests/WinPrint.Core.UnitTests/ViewModels/AppViewModelTests.cs
@@ -5,6 +5,7 @@ using WinPrint.Core.Abstractions;
 using WinPrint.Core.Models;
 using WinPrint.Core.Services;
 using WinPrint.Core.UnitTests.Services;
+using WinPrint.Core.UnitTests.TestSupport;
 using WinPrint.Core.ViewModels;
 using Xunit;
 using Xunit.Abstractions;
@@ -63,6 +64,93 @@ public class AppViewModelTests : TestServicesBase
         Assert.Equal(
             ModelLocator.Current.Settings.DefaultSheet.ToString(),
             vm.SheetKeys[vm.SelectedSheetIndex]);
+    }
+
+    [Fact]
+    public void SetPaperSize_KnownPaper_UpdatesSelectionNameAndDimensions()
+    {
+        AppViewModel vm = CreateVm();
+
+        vm.SetPaperSize("Legal");
+
+        Assert.Equal("Legal", vm.SelectedPaperSize);
+        Assert.Equal("Legal", vm.CurrentPageSetup.PaperSizeName);
+        Assert.Equal(850, vm.CurrentPageSetup.PaperWidth);
+        Assert.Equal(1400, vm.CurrentPageSetup.PaperHeight);
+    }
+
+    [Fact]
+    public void SetPaperSize_DisplayPaperName_UpdatesDimensions()
+    {
+        AppViewModel vm = CreateVm();
+
+        vm.SetPaperSize("A4 (210 x 297mm)");
+
+        Assert.Equal("A4 (210 x 297mm)", vm.CurrentPageSetup.PaperSizeName);
+        Assert.Equal(827, vm.CurrentPageSetup.PaperWidth);
+        Assert.Equal(1169, vm.CurrentPageSetup.PaperHeight);
+    }
+
+    [Fact]
+    public void SetPaperSize_UnknownPaper_PreservesExistingDimensions()
+    {
+        AppViewModel vm = CreateVm();
+        vm.SetPaperSize("Legal");
+
+        vm.SetPaperSize("Letterhead");
+
+        Assert.Equal("Letterhead", vm.CurrentPageSetup.PaperSizeName);
+        Assert.Equal(850, vm.CurrentPageSetup.PaperWidth);
+        Assert.Equal(1400, vm.CurrentPageSetup.PaperHeight);
+    }
+
+    [Fact]
+    public void SetPrinterSetup_AfterDirectPaperNameMutation_UpdatesDimensions()
+    {
+        AppViewModel vm = CreateVm();
+        vm.SetPaperSize("Letter");
+
+        vm.CurrentPageSetup.PaperSizeName = "Legal";
+        vm.SetPrinterSetup("Printer", "Legal", 2, 3);
+
+        Assert.Equal("Printer", vm.CurrentPageSetup.PrinterName);
+        Assert.Equal("Legal", vm.SelectedPaperSize);
+        Assert.Equal(850, vm.CurrentPageSetup.PaperWidth);
+        Assert.Equal(1400, vm.CurrentPageSetup.PaperHeight);
+        Assert.Equal(2, vm.CurrentPageSetup.FromSheet);
+        Assert.Equal(3, vm.CurrentPageSetup.ToSheet);
+    }
+
+    [Fact]
+    public async Task SetPaperSize_LoadedFile_ReflowsPreviewBounds()
+    {
+        string file = Path.Combine(Path.GetTempPath(), $"wp_paper_reflow_{Guid.NewGuid():N}.txt");
+        await File.WriteAllTextAsync(file, "hello\nworld\n");
+
+        try
+        {
+            AppViewModel vm = CreateVm();
+            vm.LoadSheets();
+            vm.SetLandscape(false);
+            vm.SheetViewModel!.MeasurementContext = new RecordingGraphicsContext();
+
+            Assert.True(await vm.LoadFileAsync(file));
+            Assert.Equal(850, vm.SheetViewModel.Bounds.Width);
+            Assert.Equal(1100, vm.SheetViewModel.Bounds.Height);
+
+            var reflowed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            vm.ReflowCompleted += (_, _) => reflowed.TrySetResult();
+
+            vm.SetPaperSize("Legal");
+
+            await reflowed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal(850, vm.SheetViewModel.Bounds.Width);
+            Assert.Equal(1400, vm.SheetViewModel.Bounds.Height);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
     }
 
     [Fact]
@@ -522,6 +610,8 @@ public class AppViewModelTests : TestServicesBase
         ModelLocator.Current.Settings.LastPaperSize = "A4";
         vm.RestorePaperSize(new[] { "Letter", "A4" });
         Assert.Equal("A4", vm.SelectedPaperSize);
+        Assert.Equal(827, vm.CurrentPageSetup.PaperWidth);
+        Assert.Equal(1169, vm.CurrentPageSetup.PaperHeight);
 
         ModelLocator.Current.Settings.LastPaperSize = "Foolscap";
         vm.RestorePaperSize(new[] { "Letter", "A4" });

--- a/tests/WinPrint.TUI.UnitTests/StickyPrinterRestoreTests.cs
+++ b/tests/WinPrint.TUI.UnitTests/StickyPrinterRestoreTests.cs
@@ -30,6 +30,8 @@ public class StickyPrinterRestoreTests
 
             Assert.Equal("SavedPrinter", context.App.CurrentPageSetup.PrinterName);
             Assert.Equal("A4", context.App.CurrentPageSetup.PaperSizeName);
+            Assert.Equal(827, context.App.CurrentPageSetup.PaperWidth);
+            Assert.Equal(1169, context.App.CurrentPageSetup.PaperHeight);
         }
         finally
         {
@@ -76,6 +78,29 @@ public class StickyPrinterRestoreTests
         finally
         {
             settings.LastPrinter = prevPrinter;
+        }
+    }
+
+    [Fact]
+    public void SettingsContext_CommandLinePaperOverridesSavedAndUpdatesDimensions()
+    {
+        Settings settings = ModelLocator.Current.Settings;
+        string? prevPaper = settings.LastPaperSize;
+        try
+        {
+            settings.LastPaperSize = "A4";
+            var svc = new ConfigurablePrintService(["Other"], "Other");
+
+            var context = SettingsContext.Create(
+                new Options { Files = ["x.cs"], PaperSize = "Legal" }, svc);
+
+            Assert.Equal("Legal", context.App.CurrentPageSetup.PaperSizeName);
+            Assert.Equal(850, context.App.CurrentPageSetup.PaperWidth);
+            Assert.Equal(1400, context.App.CurrentPageSetup.PaperHeight);
+        }
+        finally
+        {
+            settings.LastPaperSize = prevPaper;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add a shared Core paper-size apply path that updates paper name and dimensions together.
- Route TUI, MAUI, sticky restore, and CLI/options paper-size updates through that shared path so preview reflow sees the new page size.
- Add regression coverage for known/display/custom paper dimensions, TUI-style direct paper-name mutation, sticky/CLI restore, and loaded-document preview bounds reflow.

## Validation
- `dotnet test tests\WinPrint.Core.UnitTests\WinPrint.Core.UnitTests.csproj`
- `dotnet test tests\WinPrint.TUI.UnitTests\WinPrint.TUI.UnitTests.csproj`
- `dotnet build src\WinPrint.Maui\WinPrint.Maui.csproj`
- `dotnet build src\WinPrint.WinForms\WinPrint.WinForms.csproj`
- `dotnet build src\WinPrint.cli\WinPrint.cli.csproj`

Fixes: #135