### PR TITLE
Add scripts/build.ps1 for reliable local builds (analyzer lock)

### DIFF
--- a/scripts/build.cmd
+++ b/scripts/build.cmd
@@ -1,0 +1,10 @@
+@echo off
+rem Thin wrapper so `scripts\build` works from cmd. Prefers pwsh, falls back to Windows
+rem PowerShell. See build.ps1 for what it does (avoids the WinPrint.Analyzers lock race).
+where pwsh >nul 2>nul
+if %errorlevel%==0 (
+    pwsh -NoProfile -ExecutionPolicy Bypass -File "%~dp0build.ps1" %*
+) else (
+    powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0build.ps1" %*
+)
+exit /b %errorlevel%

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,0 +1,48 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+  Reliable local build that avoids the WinPrint.Analyzers file-lock race.
+
+.DESCRIPTION
+  WinPrint.Analyzers (a Roslyn analyzer) is ProjectReference'd by every project
+  (Directory.Build.props). The persistent C# build server (VBCSCompiler) loads it to run
+  the WPA rules and holds a Windows file lock on the DLL *across* builds, so a plain
+  `dotnet build` intermittently fails with MSB3026 / CS2012
+  ("WinPrint.Analyzers.dll ... is being used by another process") whenever the analyzer
+  gets rebuilt while a previous build's server still holds it.
+
+  This script makes a local build reliable by doing what CI does, in order:
+    1. Shut down the build/compiler servers, releasing any lingering lock on the analyzer.
+    2. Pre-build the analyzer on its own (so the solution build never rebuilds it mid-flight).
+    3. Build the requested target (default: WinPrint.slnx), forwarding any extra arguments.
+
+.EXAMPLE
+  ./scripts/build.ps1
+  ./scripts/build.ps1 -c Release
+  ./scripts/build.ps1 src/WinPrint.Core/WinPrint.Core.csproj -c Debug
+#>
+
+$ErrorActionPreference = 'Stop'
+$repo = Split-Path -Parent $PSScriptRoot
+$exitCode = 0
+
+Push-Location $repo
+try {
+    Write-Host '==> dotnet build-server shutdown (release the analyzer lock)' -ForegroundColor Cyan
+    dotnet build-server shutdown
+
+    Write-Host '==> Pre-building WinPrint.Analyzers (mirrors CI; avoids the rebuild race)' -ForegroundColor Cyan
+    dotnet build tools/WinPrint.Analyzers/WinPrint.Analyzers.csproj
+    if ($LASTEXITCODE -ne 0) { $exitCode = $LASTEXITCODE; return }
+
+    # Forward whatever the caller passed; default to the solution when nothing was given.
+    $forward = if ($args.Count -gt 0) { $args } else { @('WinPrint.slnx') }
+    Write-Host "==> dotnet build $($forward -join ' ')" -ForegroundColor Cyan
+    dotnet build @forward
+    $exitCode = $LASTEXITCODE
+}
+finally {
+    Pop-Location
+}
+
+exit $exitCode


### PR DESCRIPTION
Plain `dotnet build` intermittently fails on Windows with:

```
MSB3026 / CS2012: 'WinPrint.Analyzers.dll' ... is being used by another process
```

**Why:** `WinPrint.Analyzers` (a Roslyn analyzer) is ProjectReference'd by every project. The persistent C# build server (`VBCSCompiler`) loads it to run the WPA rules and holds a Windows file lock on the DLL *across* builds; when a later build rebuilds the analyzer while a prior build's server still holds it, the overwrite fails. CI avoids this by pre-building the analyzer in its own step — local plain builds don't.

**This PR** adds `scripts/build.ps1` (+ `build.cmd` wrapper) that makes local builds reliable, in order:
1. `dotnet build-server shutdown` — releases any lingering lock.
2. Pre-build `WinPrint.Analyzers` on its own (mirrors CI).
3. `dotnet build <target>` (default `WinPrint.slnx`), forwarding extra args.

```
./scripts/build.ps1
./scripts/build.ps1 -c Release
scripts\build.cmd src\WinPrint.Core\WinPrint.Core.csproj -c Debug
```

Verified on macOS (shutdown → analyzer pre-build → forwarded build, exit 0; passthrough args work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)