### PR TITLE
Give each release runtime its own Velopack channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
             includeGui: true
             mauiFramework: net10.0-windows10.0.19041.0
             mauiRuntime: win-x64
-            channel: win
+            channel: win-x64
             mainExe: winprint.exe
             icon: src/WinPrint.cli/winprint.ico
 
@@ -44,7 +44,7 @@ jobs:
             includeGui: true
             mauiFramework: net10.0-maccatalyst
             mauiRuntime: maccatalyst-x64
-            channel: osx
+            channel: osx-x64
             mainExe: wp
             icon: ''
 
@@ -54,7 +54,7 @@ jobs:
             includeGui: true
             mauiFramework: net10.0-maccatalyst
             mauiRuntime: maccatalyst-arm64
-            channel: osx
+            channel: osx-arm64
             mainExe: wp
             icon: ''
 
@@ -62,7 +62,7 @@ jobs:
             runtime: linux-x64
             tuiFramework: net10.0
             includeGui: false
-            channel: linux
+            channel: linux-x64
             mainExe: wp
             icon: ''
 
@@ -70,7 +70,7 @@ jobs:
             runtime: linux-arm64
             tuiFramework: net10.0
             includeGui: false
-            channel: linux
+            channel: linux-arm64
             mainExe: wp
             icon: ''
 
@@ -348,7 +348,7 @@ jobs:
           identifier: Kindel.WinPrint
           version: ${{ steps.ver.outputs.version }}
           release-tag: ${{ github.ref_name }}
-          installers-regex: 'win-Setup\.exe$'
+          installers-regex: 'win-x64-Setup\.exe$'
           token: ${{ secrets.WINGET_TOKEN }}
 
   # Update the Homebrew tap (kindel/homebrew-winprint) with the new TUI on every STABLE

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -27,7 +27,7 @@ which smooths winget validation.
      ```bash
      komac update Kindel.WinPrint \
        --version 2.6.0 \
-       --urls https://github.com/tig/winprint/releases/download/v2.6.0/Kindel.WinPrint-win-Setup.exe \
+       --urls https://github.com/tig/winprint/releases/download/v2.6.0/Kindel.WinPrint-win-x64-Setup.exe \
        --token <PAT> --submit
      ```
      (For a brand-new package use `komac new Kindel.WinPrint`.)
@@ -44,7 +44,7 @@ are needed** — each stable release auto-submits its update.
 
 ```
 PackageVersion:  2.6.0
-InstallerUrl:    https://github.com/tig/winprint/releases/download/v2.6.0/Kindel.WinPrint-win-Setup.exe
+InstallerUrl:    https://github.com/tig/winprint/releases/download/v2.6.0/Kindel.WinPrint-win-x64-Setup.exe
 InstallerSha256: F19CCCE38A0AE67059343648E11C3898614507817893FD01FD3D62D875AD3CE1
 ReleaseDate:     2026-06-20
 ```

--- a/src/WinPrint.Core/Services/UpdateService.cs
+++ b/src/WinPrint.Core/Services/UpdateService.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using Serilog;
 using Velopack;
 using Velopack.Sources;
@@ -138,7 +139,33 @@ public class UpdateService
     private static UpdateManager CreateUpdateManager()
     {
         var source = new GithubSource(RepositoryUrl, string.Empty, IncludePrerelease, new HttpClientFileDownloader());
-        return new UpdateManager(source);
+        // The release workflow packs a separate Velopack channel per runtime (win-x64, osx-x64,
+        // osx-arm64, linux-x64, linux-arm64), so each install must ask for its own arch's channel.
+        // Without this, Velopack falls back to the per-OS default channel (win/osx/linux) and would
+        // miss the release feed entirely on macOS/Linux.
+        var options = new UpdateOptions { ExplicitChannel = GetUpdateChannel() };
+        return new UpdateManager(source, options);
+    }
+
+    /// <summary>
+    ///     Builds the Velopack channel name for the running process, matching the per-runtime
+    ///     channels produced by the release workflow (e.g. <c>osx-arm64</c>).
+    /// </summary>
+    private static string GetUpdateChannel()
+    {
+        string os = OperatingSystem.IsWindows() ? "win"
+            : OperatingSystem.IsMacOS() ? "osx"
+            : OperatingSystem.IsLinux() ? "linux"
+            : throw new PlatformNotSupportedException("WinPrint updates are not supported on this OS.");
+
+        string arch = RuntimeInformation.ProcessArchitecture switch
+        {
+            Architecture.X64 => "x64",
+            Architecture.Arm64 => "arm64",
+            var other => throw new PlatformNotSupportedException($"WinPrint updates are not supported on {other}.")
+        };
+
+        return $"{os}-{arch}";
     }
 
     private static bool IncludePrerelease

--- a/src/WinPrint.Core/Services/UpdateService.cs
+++ b/src/WinPrint.Core/Services/UpdateService.cs
@@ -153,8 +153,10 @@ public class UpdateService
     /// </summary>
     private static string GetUpdateChannel()
     {
+        // The macOS GUI ships as a MAUI Mac Catalyst build, which reports as MacCatalyst (not
+        // macOS), so map it to the same "osx" channel as the plain-net10.0 TUI.
         string os = OperatingSystem.IsWindows() ? "win"
-            : OperatingSystem.IsMacOS() ? "osx"
+            : OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst() ? "osx"
             : OperatingSystem.IsLinux() ? "linux"
             : throw new PlatformNotSupportedException("WinPrint updates are not supported on this OS.");
 


### PR DESCRIPTION
## Why

The release workflow packed **two architectures onto one Velopack channel** for both macOS (`osx`) and Linux (`linux`). Each arch then produced identically-named `*-Setup.*` / `releases.<channel>.json` / `*.nupkg` artifacts that **overwrote each other** when the `publish` job flattens every matrix job's output into a single GitHub Release (`files: release-artifacts/**/*`). Only `win` was safe because it's single-arch.

This wasn't just cosmetic — it was a latent **auto-update bug**: the in-app updater (`UpdateService.CreateUpdateManager`) used Velopack's default per-OS channel (`win`/`osx`/`linux`), so on macOS/Linux it would fetch the surviving feed and could pull the **wrong architecture**.

## What changed

- **`release.yml` — one Velopack channel per runtime:** `win` → `win-x64`, `osx` → `osx-x64`/`osx-arm64`, `linux` → `linux-x64`/`linux-arm64`. Every artifact name is now unique *and* self-describing (e.g. `Kindel.WinPrint-osx-arm64-Setup.pkg`, `releases.linux-x64.json`) — no collisions when merged into one release.
- **`UpdateService.cs` — match the new channels at runtime:** added `GetUpdateChannel()` (OS + `ProcessArchitecture`) passed as `UpdateOptions.ExplicitChannel`. Without this, splitting channels would have broken auto-update on *every* platform.
- **winget plumbing kept in sync:** regex `win-Setup\.exe$` → `win-x64-Setup\.exe$`, plus the bootstrap URLs in `packaging/winget/README.md`.

## Migration note

Moving `win` → `win-x64` means any *existing* `win`-channel install won't auto-update to the new channel (they'd reinstall). Safe to do now since 2.6.0 is throwaway testing. macOS/Linux auto-update was already broken by the collision, so for them this is a pure fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)