### PR TITLE
Validate Windows installer shortcut target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,6 +301,16 @@ jobs:
 
           vpk @vpkArgs
 
+      - name: Validate Windows Start Menu shortcut
+        if: ${{ matrix.includeGui && runner.os == 'Windows' }}
+        shell: pwsh
+        run: |
+          scripts\Test-WindowsVelopackShortcut.ps1 `
+            -ReleaseDir "artifacts/velopack/${{ matrix.runtime }}" `
+            -PackId $env:PACK_ID `
+            -PackTitle $env:PACK_TITLE `
+            -ExpectedMainExe "${{ matrix.mainExe }}"
+
       - name: Upload package artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -56,5 +56,8 @@ ReleaseDate:     2026-06-20
 - **`AppsAndFeaturesEntries.ProductCode`** is set to the Velopack PackId (`Kindel.WinPrint`),
   which is the Add/Remove Programs registry key Velopack creates. If `winget upgrade` ever
   fails to detect an installed copy, confirm the actual ARP key on a real install and adjust.
+- The release workflow installs the generated Windows Velopack setup on the GitHub runner and
+  asserts the Start Menu shortcut points to the MAUI GUI (`winprint.exe`), not the bundled TUI
+  (`wp.exe`).
 - Only the **x64** Windows installer is published; add more `Installers` entries if other
   arches ship later.

--- a/scripts/Test-WindowsVelopackShortcut.ps1
+++ b/scripts/Test-WindowsVelopackShortcut.ps1
@@ -74,6 +74,21 @@ function Remove-InstallArtifacts {
         [string[]] $ShortcutRoots
     )
 
+    $currentDir = Join-Path $InstallRoot "current"
+    $updateExe = Join-Path $InstallRoot "Update.exe"
+    if (Test-Path -LiteralPath $updateExe -PathType Leaf) {
+        Wait-ForInstallProcessesToExit -InstallRoot $InstallRoot -TimeoutSeconds 60
+
+        & $updateExe --uninstall --silent
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "Velopack uninstall failed with exit code $LASTEXITCODE; falling back to direct artifact cleanup."
+        }
+
+        Start-Sleep -Seconds 2
+    }
+
+    Remove-UserPathEntry -Entry $currentDir
+
     foreach ($shortcutRoot in $ShortcutRoots) {
         Get-ShortcutDetails -Root $shortcutRoot -InstallRoot $InstallRoot |
             Where-Object { $_.PointsAtInstall } |
@@ -119,6 +134,64 @@ function Wait-ForCondition {
     throw $FailureMessage
 }
 
+function Get-InstallProcesses {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $InstallRoot
+    )
+
+    @(Get-CimInstance Win32_Process |
+        Where-Object {
+            $_.ExecutablePath -and $_.ExecutablePath.StartsWith($InstallRoot, [StringComparison]::OrdinalIgnoreCase)
+        })
+}
+
+function Wait-ForInstallProcessesToExit {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $InstallRoot,
+
+        [int] $TimeoutSeconds = 60
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    do {
+        if (@(Get-InstallProcesses -InstallRoot $InstallRoot).Count -eq 0) {
+            return
+        }
+
+        Start-Sleep -Seconds 1
+    } while ((Get-Date) -lt $deadline)
+
+    $processes = Get-InstallProcesses -InstallRoot $InstallRoot
+    $details = ($processes | ForEach-Object { "$($_.ProcessId): $($_.ExecutablePath)" }) -join [Environment]::NewLine
+    Write-Warning "Timed out waiting for validation install processes to exit before uninstall:$([Environment]::NewLine)$details"
+}
+
+function Remove-UserPathEntry {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Entry
+    )
+
+    $currentPath = [Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::User)
+    if ([string]::IsNullOrEmpty($currentPath)) {
+        return
+    }
+
+    $normalizedEntry = [IO.Path]::TrimEndingDirectorySeparator($Entry.Trim().Trim('"'))
+    $remainingEntries = @($currentPath.Split(";", [StringSplitOptions]::RemoveEmptyEntries) |
+        Where-Object {
+            $normalizedPathEntry = [IO.Path]::TrimEndingDirectorySeparator($_.Trim().Trim('"'))
+            -not $normalizedPathEntry.Equals($normalizedEntry, [StringComparison]::OrdinalIgnoreCase)
+        })
+    $updatedPath = $remainingEntries -join ";"
+
+    if (-not $updatedPath.Equals($currentPath, [StringComparison]::Ordinal)) {
+        [Environment]::SetEnvironmentVariable("PATH", $updatedPath, [EnvironmentVariableTarget]::User)
+    }
+}
+
 $shortcutRoots = @(
     (Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs"),
     ([Environment]::GetFolderPath("DesktopDirectory"))
@@ -146,22 +219,24 @@ try {
         throw "Expected bundled TUI executable was not installed: $tuiExe"
     }
 
+    $startMenuRoot = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs"
     $packageShortcuts = @()
+    $startMenuShortcuts = @()
     Wait-ForCondition `
         -Condition {
             $script:packageShortcuts = @($shortcutRoots |
                     ForEach-Object { Get-ShortcutDetails -Root $_ -InstallRoot $installRoot } |
                     Where-Object { $_.PointsAtInstall })
-            $script:packageShortcuts.Count -gt 0
+            $script:startMenuShortcuts = @($script:packageShortcuts |
+                    Where-Object { $_.FullName.StartsWith($startMenuRoot, [StringComparison]::OrdinalIgnoreCase) })
+            $script:startMenuShortcuts.Count -gt 0
         } `
-        -FailureMessage "Timed out waiting for shortcuts to be created for install root '$installRoot'."
+        -FailureMessage "Timed out waiting for a Start Menu shortcut to be created for install root '$installRoot'."
 
     if ($packageShortcuts.Count -eq 0) {
         throw "No shortcuts were created for install root '$installRoot'."
     }
 
-    $startMenuRoot = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs"
-    $startMenuShortcuts = @($packageShortcuts | Where-Object { $_.FullName.StartsWith($startMenuRoot, [StringComparison]::OrdinalIgnoreCase) })
     if ($startMenuShortcuts.Count -eq 0) {
         throw "No Start Menu shortcut was created for '$PackTitle'."
     }

--- a/scripts/Test-WindowsVelopackShortcut.ps1
+++ b/scripts/Test-WindowsVelopackShortcut.ps1
@@ -1,0 +1,182 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $ReleaseDir,
+
+    [string] $PackId = $env:PACK_ID,
+
+    [string] $PackTitle = $env:PACK_TITLE,
+
+    [string] $ExpectedMainExe = "winprint.exe"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrWhiteSpace($PackId)) {
+    throw "PackId must be provided either as -PackId or PACK_ID."
+}
+
+if ([string]::IsNullOrWhiteSpace($PackTitle)) {
+    throw "PackTitle must be provided either as -PackTitle or PACK_TITLE."
+}
+
+if (-not (Test-Path -LiteralPath $ReleaseDir -PathType Container)) {
+    throw "ReleaseDir does not exist: $ReleaseDir"
+}
+
+$setupFiles = @(Get-ChildItem -LiteralPath $ReleaseDir -Filter "*-Setup.exe" -File)
+if ($setupFiles.Count -ne 1) {
+    $found = ($setupFiles | Select-Object -ExpandProperty FullName) -join [Environment]::NewLine
+    throw "Expected exactly one Velopack Setup.exe in '$ReleaseDir', found $($setupFiles.Count):$([Environment]::NewLine)$found"
+}
+
+$installRoot = Join-Path $env:LOCALAPPDATA $PackId
+if (Test-Path -LiteralPath $installRoot) {
+    throw "Refusing to validate over an existing install: $installRoot"
+}
+
+function Get-ShortcutDetails {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Root,
+
+        [Parameter(Mandatory = $true)]
+        [string] $InstallRoot
+    )
+
+    if (-not (Test-Path -LiteralPath $Root -PathType Container)) {
+        return
+    }
+
+    $shell = New-Object -ComObject WScript.Shell
+    Get-ChildItem -LiteralPath $Root -Recurse -Filter "*.lnk" -File |
+        ForEach-Object {
+            $shortcut = $shell.CreateShortcut($_.FullName)
+            [pscustomobject]@{
+                Name = $_.Name
+                FullName = $_.FullName
+                TargetPath = $shortcut.TargetPath
+                Arguments = $shortcut.Arguments
+                WorkingDirectory = $shortcut.WorkingDirectory
+                PointsAtInstall = $shortcut.TargetPath.StartsWith($InstallRoot, [StringComparison]::OrdinalIgnoreCase) -or
+                    $shortcut.Arguments.Contains($InstallRoot, [StringComparison]::OrdinalIgnoreCase)
+            }
+        }
+}
+
+function Remove-InstallArtifacts {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $InstallRoot,
+
+        [Parameter(Mandatory = $true)]
+        [string[]] $ShortcutRoots
+    )
+
+    foreach ($shortcutRoot in $ShortcutRoots) {
+        Get-ShortcutDetails -Root $shortcutRoot -InstallRoot $InstallRoot |
+            Where-Object { $_.PointsAtInstall } |
+            ForEach-Object { Remove-Item -LiteralPath $_.FullName -Force -ErrorAction SilentlyContinue }
+    }
+
+    for ($attempt = 1; $attempt -le 5; $attempt++) {
+        if (-not (Test-Path -LiteralPath $InstallRoot)) {
+            return
+        }
+
+        Remove-Item -LiteralPath $InstallRoot -Recurse -Force -ErrorAction SilentlyContinue
+        if (-not (Test-Path -LiteralPath $InstallRoot)) {
+            return
+        }
+
+        Start-Sleep -Seconds 2
+    }
+
+    Write-Warning "Could not remove temporary install directory: $InstallRoot"
+}
+
+function Wait-ForCondition {
+    param(
+        [Parameter(Mandatory = $true)]
+        [scriptblock] $Condition,
+
+        [Parameter(Mandatory = $true)]
+        [string] $FailureMessage,
+
+        [int] $TimeoutSeconds = 60
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    do {
+        if (& $Condition) {
+            return
+        }
+
+        Start-Sleep -Seconds 1
+    } while ((Get-Date) -lt $deadline)
+
+    throw $FailureMessage
+}
+
+$shortcutRoots = @(
+    (Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs"),
+    ([Environment]::GetFolderPath("DesktopDirectory"))
+)
+
+try {
+    $currentDir = Join-Path $installRoot "current"
+    $expectedTarget = Join-Path $currentDir $ExpectedMainExe
+    $tuiExe = Join-Path $currentDir "wp.exe"
+
+    & $setupFiles[0].FullName --silent
+    if ($LASTEXITCODE -ne 0) {
+        throw "Velopack setup failed with exit code $LASTEXITCODE."
+    }
+
+    Wait-ForCondition `
+        -Condition { (Test-Path -LiteralPath $expectedTarget -PathType Leaf) -and (Test-Path -LiteralPath $tuiExe -PathType Leaf) } `
+        -FailureMessage "Timed out waiting for Velopack to install '$ExpectedMainExe' and 'wp.exe' under '$currentDir'."
+
+    if (-not (Test-Path -LiteralPath $expectedTarget -PathType Leaf)) {
+        throw "Expected main executable was not installed: $expectedTarget"
+    }
+
+    if (-not (Test-Path -LiteralPath $tuiExe -PathType Leaf)) {
+        throw "Expected bundled TUI executable was not installed: $tuiExe"
+    }
+
+    $packageShortcuts = @()
+    Wait-ForCondition `
+        -Condition {
+            $script:packageShortcuts = @($shortcutRoots |
+                    ForEach-Object { Get-ShortcutDetails -Root $_ -InstallRoot $installRoot } |
+                    Where-Object { $_.PointsAtInstall })
+            $script:packageShortcuts.Count -gt 0
+        } `
+        -FailureMessage "Timed out waiting for shortcuts to be created for install root '$installRoot'."
+
+    if ($packageShortcuts.Count -eq 0) {
+        throw "No shortcuts were created for install root '$installRoot'."
+    }
+
+    $startMenuRoot = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs"
+    $startMenuShortcuts = @($packageShortcuts | Where-Object { $_.FullName.StartsWith($startMenuRoot, [StringComparison]::OrdinalIgnoreCase) })
+    if ($startMenuShortcuts.Count -eq 0) {
+        throw "No Start Menu shortcut was created for '$PackTitle'."
+    }
+
+    $wrongTargets = @($startMenuShortcuts | Where-Object {
+            -not $_.TargetPath.Equals($expectedTarget, [StringComparison]::OrdinalIgnoreCase)
+        })
+
+    if ($wrongTargets.Count -gt 0) {
+        $details = ($wrongTargets | ForEach-Object { "$($_.FullName) -> $($_.TargetPath)" }) -join [Environment]::NewLine
+        throw "Start Menu shortcut target mismatch. Expected '$expectedTarget':$([Environment]::NewLine)$details"
+    }
+
+    Write-Host "Validated Start Menu shortcut target: $($startMenuShortcuts[0].TargetPath)"
+}
+finally {
+    Remove-InstallArtifacts -InstallRoot $installRoot -ShortcutRoots $shortcutRoots
+}


### PR DESCRIPTION
## Summary
- add a Windows Velopack install-time validation script for the generated Start Menu shortcut
- wire the release workflow to assert the shortcut targets `winprint.exe` while `wp.exe` remains bundled
- document the release-time shortcut validation in winget packaging notes

Fixes #144.

## Validation
- `dotnet publish src\WinPrint.TUI\WinPrint.TUI.csproj -c Release -f net10.0-windows -r win-x64 --self-contained true -o artifacts\issue-144\publish\win-x64 /p:PublishSingleFile=false`
- `dotnet publish src\WinPrint.Maui\WinPrint.Maui.csproj -c Release -f net10.0-windows10.0.19041.0 -r win-x64 --self-contained true -o artifacts\issue-144\publish\win-x64 /p:WindowsPackageType=None /p:WinPrintWindowsOnly=true`
- `vpk pack --yes --packId Kindel.WinPrint.Issue144 --packTitle 'WinPrint Issue 144' --packAuthors Kindel --packVersion 9.9.9 --packDir artifacts\issue-144\publish\win-x64 --outputDir artifacts\issue-144\velopack\win-x64 --channel win-x64 --runtime win-x64 --mainExe winprint.exe --icon src\WinPrint.cli\winprint.ico`
- `scripts\Test-WindowsVelopackShortcut.ps1 -ReleaseDir artifacts\issue-144\velopack\win-x64 -PackId Kindel.WinPrint.Issue144 -PackTitle 'WinPrint Issue 144' -ExpectedMainExe winprint.exe`
- `git diff --check`