### PR TITLE
Make Velopack shortcut validator robust (unblock v2.6.3 release)

### DIFF
--- a/scripts/Test-WindowsVelopackShortcut.ps1
+++ b/scripts/Test-WindowsVelopackShortcut.ps1
@@ -13,6 +13,11 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
+# Velopack's Update.exe is a GUI-subsystem binary, so `& $updateExe` may return without
+# setting $LASTEXITCODE. Under StrictMode -Latest, reading an unset $LASTEXITCODE throws.
+# Seed it so the exit-code checks never fault on the cleanup path.
+$global:LASTEXITCODE = 0
+
 if ([string]::IsNullOrWhiteSpace($PackId)) {
     throw "PackId must be provided either as -PackId or PACK_ID."
 }
@@ -253,5 +258,12 @@ try {
     Write-Host "Validated Start Menu shortcut target: $($startMenuShortcuts[0].TargetPath)"
 }
 finally {
-    Remove-InstallArtifacts -InstallRoot $installRoot -ShortcutRoots $shortcutRoots
+    # Cleanup is best-effort — a teardown hiccup must not fail the release after the
+    # shortcut validation above has already passed.
+    try {
+        Remove-InstallArtifacts -InstallRoot $installRoot -ShortcutRoots $shortcutRoots
+    }
+    catch {
+        Write-Warning "Install-artifact cleanup failed (non-fatal): $_"
+    }
 }


### PR DESCRIPTION
The new `Test-WindowsVelopackShortcut.ps1` failed the **win-x64** job in the v2.6.3 release (so publish/winget/brew were skipped), even though the shortcut validation itself passed.

**Cause:** under `Set-StrictMode -Latest`, the `finally` cleanup reads `$LASTEXITCODE` right after `& Update.exe --uninstall` — a GUI-subsystem exe that can return without setting it → `"the variable '$LASTEXITCODE' ... has not been set"` → job fails.

**Fix:**
- Seed `$global:LASTEXITCODE = 0` so the exit-code checks never fault.
- Wrap the `finally` cleanup in try/catch — teardown is best-effort and must not fail the release once validation has passed.

Release-only script (not exercised by `build-and-test`/`maui-ui-tests`); PowerShell parse verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)