### PR TITLE
Fail brew/winget release jobs loudly when their token is missing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,6 @@ env:
   VPK_VERSION: 1.1.1
   HAS_AZURE_SIGNING: ${{ secrets.AZURE_CLIENT_ID != '' && secrets.AZURE_TENANT_ID != '' && secrets.AZURE_SUBSCRIPTION_ID != '' && secrets.AZURE_SIGNING_ACCOUNT != '' && secrets.AZURE_SIGNING_PROFILE != '' && secrets.AZURE_SIGNING_ENDPOINT != '' }}
   HAS_APPLE_SIGNING: ${{ secrets.APPLE_CERTIFICATE_BASE64 != '' && secrets.APPLE_CERTIFICATE_PASSWORD != '' && secrets.APPLE_ID != '' && secrets.APPLE_APP_SPECIFIC_PASSWORD != '' && secrets.APPLE_TEAM_ID != '' && secrets.APPLE_SIGNING_IDENTITY != '' }}
-  HAS_WINGET: ${{ secrets.WINGET_TOKEN != '' }}
-  HAS_BREW_TAP: ${{ secrets.HOMEBREW_TAP_TOKEN != '' }}
 
 jobs:
   package:
@@ -386,12 +384,23 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.ref_name, '-') }}
     steps:
+      # A missing token must FAIL this job, never silently skip into a green check.
+      # A skipped publish that reports success hides the fact the package was never shipped.
+      - name: Require WINGET_TOKEN
+        shell: bash
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: |
+          if [ -z "${WINGET_TOKEN}" ]; then
+            echo "::error title=winget not submitted::WINGET_TOKEN is not set, so this stable release was NOT submitted to winget-pkgs. Set the secret and re-run this job."
+            exit 1
+          fi
+
       - name: Derive winget version (strip leading v)
         id: ver
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Submit to winget-pkgs
-        if: ${{ env.HAS_WINGET == 'true' }}
         uses: vedantmgoyal9/winget-releaser@v2
         with:
           identifier: Kindel.WinPrint
@@ -410,12 +419,23 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.ref_name, '-') }}
     steps:
+      # A missing token must FAIL this job, never silently skip into a green check.
+      # Until #153 set HOMEBREW_TAP_TOKEN, this job no-opped yet reported success, so the
+      # tap shipped only a README and `brew install` 404'd while releases looked healthy.
+      - name: Require HOMEBREW_TAP_TOKEN
+        shell: bash
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if [ -z "${TAP_TOKEN}" ]; then
+            echo "::error title=Homebrew tap not published::HOMEBREW_TAP_TOKEN is not set, so the Homebrew tap was NOT updated for this release. See https://github.com/tig/winprint/issues/153 to set the secret, then re-run this job."
+            exit 1
+          fi
+
       - name: Checkout source
-        if: ${{ env.HAS_BREW_TAP == 'true' }}
         uses: actions/checkout@v5
 
       - name: Render formula and push to tap
-        if: ${{ env.HAS_BREW_TAP == 'true' }}
         shell: bash
         env:
           TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}


### PR DESCRIPTION
## Why

The release pipeline's **Update Homebrew tap** job has reported green on every stable release while **publishing nothing**. As of v2.6.3, `kindel/homebrew-winprint` contains only `README.md` — no `Formula/winprint.rb`, no `Casks/winprint.rb` — so `brew install kindel/winprint/winprint` 404s.

**Root cause:** both steps of the `brew` job were gated on `if: env.HAS_BREW_TAP == 'true'` (`= secrets.HOMEBREW_TAP_TOKEN != ''`). With the secret unset, every step skips, and a job whose steps all skip is counted **success** — a false-green no-op. The `winget` job had the identical latent pattern (`HAS_WINGET`).

## What

- Replace the silent per-step `if:` guards with a leading **`Require <TOKEN>`** step that emits a `::error::` annotation and `exit 1` when the secret is missing. A skipped publish is now a **red, actionable failure** instead of a fake success.
- Applied symmetrically to **both** `brew` (HOMEBREW_TAP_TOKEN) and `winget` (WINGET_TOKEN) — same bug class.
- Drop the now-unused `HAS_WINGET` / `HAS_BREW_TAP` env vars.

## Scope / follow-up

This makes the failure **visible**; it does not make the tap publish on its own. Actually setting `HOMEBREW_TAP_TOKEN` is a manual owner step tracked in **#153**. After this merges, the next stable release (or a re-run of the brew job) will go **red** until that secret exists — which is the intended signal.

Closes nothing on its own; unblocks the diagnosis in #153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)