### PR TITLE
Document why the macOS x64 cask ships JIT, not AOT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,6 +198,19 @@ jobs:
       # Velopack's mac packer rebuilds its own .app from loose files and can't wrap a MacCatalyst
       # bundle, which is what shipped a broken, TUI-launching app in v2.6.2). `dotnet build` (not
       # publish) assembles a complete, runnable WinPrint.app; we sign + notarize + zip it below.
+      #
+      # Expected per-arch size/AOT asymmetry (do NOT mistake the x64 cask for a broken build):
+      #   - WinPrint-osx-arm64.app.zip is Mono-AOT-compiled (~132 MB unzipped: a ~100 MB native
+      #     apphost + *.aotdata.arm64 files).
+      #   - WinPrint-osx-x64.app.zip is Mono-JIT (~35 MB: ~6 MB apphost, no aotdata). This is a
+      #     strict subset of arm64 — same 149 assemblies in MonoBundle — and is fully functional;
+      #     JIT is the normal, performant execution mode on Intel Macs.
+      # This is dictated by the MacCatalyst SDK, not our config: Xamarin.Shared.Sdk.targets gates
+      # `_RunAotCompiler` to `RuntimeIdentifier == maccatalyst-arm64` only (MacCatalyst is
+      # SdkIsDesktop, so the device-AOT default is skipped). The `RunAOTCompilation` MSBuild
+      # property is an Android/WASM lever and is IGNORED here, so it cannot turn on x64 AOT. The
+      # only switch that flips x64 (`MtouchInterpreter`) selects the *interpreter*, which is slower
+      # than the current JIT — so do not "fix" the size gap that way. See PR discussion for v2.6.4.
       - name: Build macOS GUI (.app)
         if: ${{ matrix.includeGui && runner.os == 'macOS' }}
         shell: bash

--- a/src/WinPrint.Maui/WinPrint.Maui.csproj
+++ b/src/WinPrint.Maui/WinPrint.Maui.csproj
@@ -17,6 +17,12 @@
 		The Mac App Store will NOT accept apps with ONLY maccatalyst-arm64 indicated;
 		either BOTH runtimes must be indicated or ONLY macatalyst-x64. -->
 		<!-- For example: <RuntimeIdentifiers>maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers> -->
+		<!-- AOT is per-arch and decided by the MacCatalyst SDK, not by us: the release pipeline
+		     builds each arch into its own cask, and only maccatalyst-arm64 is AOT-compiled
+		     (Xamarin.Shared.Sdk.targets gates `_RunAotCompiler` to maccatalyst-arm64). maccatalyst-x64
+		     ships as Mono JIT — smaller bundle, normal Intel-Mac execution mode, NOT a broken build.
+		     The `RunAOTCompilation` property is Android/WASM-only and ignored here; the only x64 lever
+		     (`MtouchInterpreter`) selects the slower interpreter, so don't use it to "match" arm64. -->
 
 		<OutputType>Exe</OutputType>
 		<RootNamespace>WinPrint.Maui</RootNamespace>


### PR DESCRIPTION
## Background

v2.6.4 artifact validation flagged the `WinPrint-osx-x64.app.zip` cask as suspicious:

| | arm64 cask | x64 cask |
|---|---|---|
| Unzipped size | ~132 MB | ~35 MB |
| `winprint` apphost | ~100 MB (AOT native) | ~6 MB |
| `*.aotdata.*` files | 116 | 0 |
| Execution | Mono **AOT** | Mono **JIT** |
| Assemblies in MonoBundle | 149 | 149 (identical set) |

The x64 bundle is a **strict subset** of arm64 (0 files unique to x64) and is **fully functional** — it just isn't AOT-compiled.

## Root cause (expected SDK behavior, not a bug)

`Xamarin.Shared.Sdk.targets` gates the AOT compiler by RID:

```xml
<_RunAotCompiler Condition="'$(RuntimeIdentifier)' == 'maccatalyst-arm64'">true</_RunAotCompiler>
```

MacCatalyst is `SdkIsDesktop`, so the device-AOT default (line ~1259) is skipped, and **only `maccatalyst-arm64` enables AOT**. `maccatalyst-x64` therefore runs Mono **JIT** — the normal, performant execution mode on Intel Macs.

Two things were verified locally to rule out a config fix:
- **`RunAOTCompilation` is an Android/WASM property** — it is *not referenced anywhere* in the MacCatalyst SDK pack, so setting it on the x64 build is a no-op (confirmed: a local `dotnet build … -r maccatalyst-x64 /p:RunAOTCompilation=true` produced **zero** aotdata files).
- The gate is **RID-based, not host-based**, so building on an Intel runner would not change it either.
- The only switch that flips x64 (`MtouchInterpreter`) selects the **interpreter**, which is *slower* than the current JIT — so "matching" arm64 that way would regress x64.

## Change

**Comments only — no behavior change.** Documents the asymmetry in `release.yml` (next to the GUI build step) and `WinPrint.Maui.csproj` (next to the runtime-identifier note) so the size/AOT gap isn't mistaken for a broken x64 build and re-investigated or "fixed" into a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)