### PR TITLE
Bundle wp into the macOS GUI cask (one brew install = GUI + TUI)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,6 +229,35 @@ jobs:
           fi
           echo "GUI_APP=$APP" >> "$GITHUB_ENV"
 
+      # Embed the TUI (`wp`) inside the GUI bundle so the Homebrew *cask* delivers BOTH the GUI and
+      # the `wp` CLI from a single artifact (the cask's `binary` stanza symlinks the embedded wp onto
+      # PATH). `wp` is a self-contained CoreCLR publish — its own apphost + ~150 dylibs/assemblies, a
+      # different runtime from the GUI's Mono `MonoBundle` — so the WHOLE payload rides along, not a
+      # lone binary. It goes under Contents/Helpers, the Apple-blessed home for auxiliary executables
+      # (notarization rejects code in Resources). This runs BEFORE the sign/notarize step so the
+      # embedded wp is covered by `codesign --deep` + notarization. The wp-*.tar.gz formula still
+      # ships for Linux and CLI-only installs.
+      - name: Embed wp (TUI) into the macOS GUI bundle
+        if: ${{ matrix.includeGui && runner.os == 'macOS' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          SRC="artifacts/publish/${{ matrix.runtime }}"
+          DEST="$GUI_APP/Contents/Helpers/wp"
+          if [ ! -x "$SRC/wp" ]; then
+            echo "::error::wp payload missing at $SRC/wp (TUI publish must precede this step)."
+            exit 1
+          fi
+          rm -rf "$DEST"
+          mkdir -p "$DEST"
+          cp -R "$SRC"/. "$DEST"/
+          chmod +x "$DEST/wp"
+          if [ ! -x "$DEST/wp" ]; then
+            echo "::error::Failed to embed wp into $DEST"
+            exit 1
+          fi
+          echo "Embedded wp ($(find "$DEST" -type f | wc -l | tr -d ' ') files) into Contents/Helpers/wp"
+
       - name: Azure login for Trusted Signing
         if: ${{ runner.os == 'Windows' && env.HAS_AZURE_SIGNING == 'true' }}
         uses: azure/login@v2

--- a/packaging/homebrew/Casks/winprint.rb
+++ b/packaging/homebrew/Casks/winprint.rb
@@ -1,8 +1,13 @@
 # Template rendered by the release pipeline (release.yml -> brew job) and pushed to the
 # kindel/homebrew-winprint tap. Placeholders are filled with each stable release's version,
 # download base URL, and per-arch SHA256s. This is the free MAUI GUI (WinPrint.app), a
-# notarized Developer ID build distributed directly (NOT the App Store). The TUI (`wp`) ships
-# separately as the Homebrew *formula*; `brew upgrade` handles updates for both.
+# notarized Developer ID build distributed directly (NOT the App Store).
+#
+# The GUI bundle ALSO embeds the `wp` TUI (release.yml copies the self-contained CLI payload into
+# WinPrint.app/Contents/Helpers/wp), so this single cask install delivers BOTH the GUI and the `wp`
+# command — the `binary` stanza below symlinks the embedded wp onto PATH. The standalone Homebrew
+# *formula* still ships `wp` for Linux and CLI-only installs; the cask therefore conflicts with the
+# formula (both would provide `wp`).
 cask "winprint" do
   version "{{version}}"
 
@@ -16,10 +21,13 @@ cask "winprint" do
   end
 
   name "WinPrint"
-  desc "Advanced source code and text file printing GUI"
+  desc "Advanced source code and text file printing GUI (bundles the wp TUI)"
   homepage "https://github.com/kindel/winprint"
 
+  conflicts_with formula: "winprint"
+
   app "WinPrint.app"
+  binary "#{appdir}/WinPrint.app/Contents/Helpers/wp/wp"
 
   zap trash: [
     "~/Library/Application Support/WinPrint",

--- a/packaging/homebrew/Formula/winprint.rb
+++ b/packaging/homebrew/Formula/winprint.rb
@@ -1,7 +1,9 @@
 # Template rendered by the release pipeline (release.yml -> brew job) and pushed to the
 # kindel/homebrew-winprint tap; the placeholders are filled with each stable release's
-# version, download base URL, and per-arch SHA256s. This is the free TUI (`wp`); the free MAUI
-# GUI ships alongside it as the tap's *cask* (packaging/homebrew/Casks/winprint.rb).
+# version, download base URL, and per-arch SHA256s. This is the standalone free TUI (`wp`) — used
+# on Linux and for CLI-only macOS installs. The free MAUI GUI ships as the tap's *cask*
+# (packaging/homebrew/Casks/winprint.rb), which on macOS also embeds `wp`; the cask therefore
+# conflicts with this formula (both provide `wp`).
 class Winprint < Formula
   desc "Advanced source code and text file printing terminal UI"
   homepage "https://github.com/kindel/winprint"


### PR DESCRIPTION
## Problem

The Homebrew tap ships the GUI and the `wp` TUI as **two independent packages** with nothing linking them, so a single `brew install` gives only one:

| Package | Command | Gets |
|---|---|---|
| Formula | `brew install kindel/winprint/winprint` | `wp` only |
| Cask | `brew install --cask kindel/winprint/winprint` | `WinPrint.app` only |

A Mac user expects one install to give **both**. (Reported: "the zip file only has the GUI version in it.")

## Fix

Embed the `wp` TUI **inside** the GUI cask so one install delivers both:

1. **release.yml** — new *Embed wp into the macOS GUI bundle* step copies the self-contained wp payload into `WinPrint.app/Contents/Helpers/wp/` **before** the sign/notarize step, so the nested wp is covered by `codesign --deep` + notarization.
2. **Cask** — adds `binary "#{appdir}/WinPrint.app/Contents/Helpers/wp/wp"` to symlink the embedded wp onto PATH, plus `conflicts_with formula: "winprint"`.

Result: `brew install --cask kindel/winprint/winprint` → **GUI + `wp`** from one artifact.

## Why the whole payload, not one file

`wp` is a **self-contained CoreCLR** publish — its own apphost + ~150 assemblies/dylibs, a *different* runtime from the GUI's Mono `MonoBundle`. Copying just the `wp` binary would yield a CLI that can't find its runtime. So the entire payload is embedded. Verified locally that an embedded `wp` launches from `Contents/Helpers/wp/wp` (exit 0, reports version). `Contents/Helpers` is the Apple-blessed location for auxiliary executables (notarization rejects code under `Resources`).

## Notes / tradeoffs

- **Size:** the cask `.app.zip` grows by the wp payload (~117 MB uncompressed; compresses in the zip). The standalone formula is unchanged.
- **Formula stays** for Linux and CLI-only macOS installs; cask now conflicts with it (both provide `wp`).
- **Validation:** the full sign/notarize path only runs on the release runner (and Apple signing secrets aren't set yet), so end-to-end cask validation lands with the next release. Local de-risk confirmed the embed + launch model.
- **Hardened-runtime caveat (future):** once Apple signing is enabled, the nested CoreCLR `wp` may need the same JIT/library-validation entitlements as the GUI — worth checking when notarization goes live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)