### PR TITLE
Fix invalid cask DSL (conflicts_with formula:) + validate cask loads in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -507,6 +507,11 @@ jobs:
           # `ruby -c` only checks syntax and misses invalid DSL — e.g. a cask using the formula-only
           # `conflicts_with formula:` key, which once shipped a cask the tap couldn't even parse.
           # Load them by name from a throwaway local tap so an invalid stanza fails this job instead.
+          # On ubuntu-latest Homebrew is pre-installed but NOT on PATH — load its shellenv first, or
+          # every `brew` call below fails with "command not found" and breaks the tap publish.
+          if ! command -v brew >/dev/null 2>&1; then
+            eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          fi
           export HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1
           VTAP="$(brew --repository)/Library/Taps/kindel/homebrew-winprint"
           rm -rf "$VTAP"; mkdir -p "$VTAP/Casks" "$VTAP/Formula"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -503,6 +503,23 @@ jobs:
               -e "s|{{sha_cask_x64}}|$(sha WinPrint-osx-x64.app.zip)|" \
               packaging/homebrew/Casks/winprint.rb > /tmp/winprint-cask.rb
 
+          # Validate the rendered cask + formula actually LOAD under Homebrew before publishing.
+          # `ruby -c` only checks syntax and misses invalid DSL — e.g. a cask using the formula-only
+          # `conflicts_with formula:` key, which once shipped a cask the tap couldn't even parse.
+          # Load them by name from a throwaway local tap so an invalid stanza fails this job instead.
+          export HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1
+          VTAP="$(brew --repository)/Library/Taps/kindel/homebrew-winprint"
+          rm -rf "$VTAP"; mkdir -p "$VTAP/Casks" "$VTAP/Formula"
+          git -C "$VTAP" init -q
+          cp /tmp/winprint-cask.rb "$VTAP/Casks/winprint.rb"
+          cp /tmp/winprint.rb "$VTAP/Formula/winprint.rb"
+          git -C "$VTAP" add -A
+          git -C "$VTAP" -c user.email=ci@example.com -c user.name=ci commit -qm validate
+          echo "Validating rendered cask + formula load under Homebrew…"
+          brew info --cask kindel/winprint/winprint > /dev/null
+          brew info --formula kindel/winprint/winprint > /dev/null
+          rm -rf "$VTAP"
+
           git clone "https://x-access-token:${TAP_TOKEN}@github.com/kindel/homebrew-winprint.git" tap
           mkdir -p tap/Formula tap/Casks
           cp /tmp/winprint.rb tap/Formula/winprint.rb

--- a/packaging/homebrew/Casks/winprint.rb
+++ b/packaging/homebrew/Casks/winprint.rb
@@ -6,8 +6,10 @@
 # The GUI bundle ALSO embeds the `wp` TUI (release.yml copies the self-contained CLI payload into
 # WinPrint.app/Contents/Helpers/wp), so this single cask install delivers BOTH the GUI and the `wp`
 # command — the `binary` stanza below symlinks the embedded wp onto PATH. The standalone Homebrew
-# *formula* still ships `wp` for Linux and CLI-only installs; the cask therefore conflicts with the
-# formula (both would provide `wp`).
+# *formula* still ships `wp` for Linux and CLI-only installs. Both provide `wp`, so installing the
+# cask and the formula together collides on the `wp` symlink (Homebrew errors at link time) — pick
+# one on macOS. (Casks can't declare a `conflicts_with formula:`; that key is cask-only, so we just
+# document it here instead of encoding an invalid stanza.)
 cask "winprint" do
   version "{{version}}"
 
@@ -23,8 +25,6 @@ cask "winprint" do
   name "WinPrint"
   desc "Advanced source code and text file printing GUI (bundles the wp TUI)"
   homepage "https://github.com/kindel/winprint"
-
-  conflicts_with formula: "winprint"
 
   app "WinPrint.app"
   binary "#{appdir}/WinPrint.app/Contents/Helpers/wp/wp"


### PR DESCRIPTION
## Bug

#158 added `conflicts_with formula: "winprint"` to the Homebrew **cask**, but `conflicts_with` in a cask only accepts `cask:` — Homebrew rejects the entire cask at load time:

```
Error: Cask 'winprint' definition is invalid: 'conflicts_with' stanza failed with: Unknown key: :formula
```

My #158 review check ran `ruby -c` (Ruby *syntax* only), which passed — so a cask the tap couldn't parse shipped in **v2.6.7**, and `brew install --cask kindel/winprint/winprint` broke for all macOS GUI users. (The `wp`-embedding *packaging* from #158 was fine — verified `Contents/Helpers/wp/wp` in the shipped bytes; only the DSL was wrong.)

The **published tap was hotfixed out-of-band** so users are unblocked now; this PR fixes the **template** so releases stop regenerating the break.

## Changes

- **Remove the invalid stanza.** Casks can't declare a formula conflict, so the formula/cask `wp`-symlink collision is documented in a comment instead (Homebrew errors at link time if you install both; pick one on macOS).
- **Add a Homebrew load-validation to the release `brew` job:** render the cask + formula into a throwaway local tap and `brew info --cask/--formula` them *by name* before publishing. An unloadable cask now **fails the job** instead of reaching the tap. Verified locally this catches the bad stanza and passes the fixed template.

## Note

`ruby -c` is insufficient for cask DSL — only loading the cask by name surfaces invalid stanzas (`brew audit [path]` is disabled; `brew info --cask <name>` is the reliable check). That's exactly the gap this CI step closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)