### PR TITLE
cask: quarantine caveat until the macOS .app is notarized (#162)

### DIFF
--- a/packaging/homebrew/Casks/winprint.rb
+++ b/packaging/homebrew/Casks/winprint.rb
@@ -29,6 +29,14 @@ cask "winprint" do
   app "WinPrint.app"
   binary "#{appdir}/WinPrint.app/Contents/Helpers/wp/wp"
 
+  # WinPrint.app is not yet Apple-notarized (tracked in tig/winprint#162), so Gatekeeper may
+  # report it as "damaged". Remove this caveat once notarization ships.
+  caveats <<~EOS
+    WinPrint.app is not yet notarized by Apple. If macOS says it "is damaged and can't be
+    opened", clear the download quarantine and reopen it:
+      xattr -dr com.apple.quarantine "#{appdir}/WinPrint.app"
+  EOS
+
   zap trash: [
     "~/Library/Application Support/WinPrint",
     "~/Library/Preferences/com.kindel.winprint.plist",


### PR DESCRIPTION
Until the macOS `.app` is Apple-notarized (**#162**), Gatekeeper reports it as **"damaged and can't be opened"** on first launch (it's only ad-hoc signed). Add a cask `caveats` block so `brew install --cask` users see the one-line fix instead of a dead end:

```
xattr -dr com.apple.quarantine "/Applications/WinPrint.app"
```

Verified the cask still loads under `brew info --cask` (the new release-job guard checks this too). **Remove this caveat once notarization (#162) ships.**

Note: this helps brew-cask users; users who download the `.app.zip` directly won't see cask caveats — #162's notarization is the real fix for everyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)