### PR TITLE
Build linux-arm64 AOT on a native arm64 runner (fix v2.6.10 release)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,12 @@ jobs:
           - os: ubuntu-latest
             runtime: linux-x64
             framework: net10.0
+          # Native arm64 runner — AOT links natively (cross-AOT to aarch64 from an x64 runner
+          # fails: "ld.bfd: unrecognised emulation mode: aarch64linux"). This leg was missing,
+          # so a linux-arm64 AOT break only surfaced at release time; cover it in PR CI now.
+          - os: ubuntu-24.04-arm
+            runtime: linux-arm64
+            framework: net10.0
           - os: macos-26
             runtime: osx-arm64
             framework: net10.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,11 @@ jobs:
             mainExe: wp
             icon: ''
 
-          - os: ubuntu-latest
+          # Build linux-arm64 on a NATIVE arm64 runner. Native AOT links with the target's
+          # binutils, and an x64 runner's ld.bfd can't emit aarch64 ("unrecognised emulation
+          # mode: aarch64linux"), so cross-AOT from ubuntu-latest (x64) fails. ubuntu-24.04-arm
+          # is a free GitHub-hosted arm64 runner (public repos) and AOT-links natively.
+          - os: ubuntu-24.04-arm
             runtime: linux-arm64
             tuiFramework: net10.0
             includeGui: false


### PR DESCRIPTION
## Problem

The **v2.6.10** release failed at `Package linux-arm64` → `Publish TUI`. #156 enabled Native AOT for `wp`, and the `linux-arm64` leg cross-compiles on an **x64 ubuntu runner**, where the AOT link fails:

```
/usr/bin/ld.bfd: unrecognised emulation mode: aarch64linux
clang : error : linker command failed with exit code 1
```

An x64 runner's `ld.bfd` can't emit aarch64. (macOS handles both arches via Xcode's universal toolchain, which is why `osx-x64` cross-AOT passed; Linux's `ld.bfd` is arch-specific.) Because a `Package` job failed, Publish/winget/brew skipped — **v2.6.10 didn't ship; v2.6.9 stays Latest.**

## Fix

- **release.yml** — move the `linux-arm64` package job to **`ubuntu-24.04-arm`** (free GitHub-hosted arm64 runner for public repos) so Native AOT links **natively** instead of cross-compiling.
- **ci.yml** — add `linux-arm64` to the `aot-publish` matrix (also `ubuntu-24.04-arm`). It was **missing** from #156's matrix (only linux-x64/osx-arm64/win-x64), which is exactly why this AOT break reached a release instead of being caught in PR CI.

All other platforms already package fine; this is the only AOT leg that needed a native runner. Once merged I'll re-cut v2.6.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)