### PR TITLE
Fix #163: bump Terminal.Gui to 2.4.8 (flash-free Kitty pan/zoom)

### DIFF
--- a/src/WinPrint.TUI/WinPrint.TUI.csproj
+++ b/src/WinPrint.TUI/WinPrint.TUI.csproj
@@ -21,7 +21,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Terminal.Gui" Version="2.4.7" />
+        <PackageReference Include="Terminal.Gui" Version="2.4.8" />
         <PackageReference Include="Terminal.Gui.Cli" Version="0.2.1" />
         <PackageReference Include="Terminal.Gui.Editor" Version="2.5.0" />
         <PackageReference Include="Velopack" Version="1.1.1" />

--- a/tests/WinPrint.TUI.UITests/PreviewRasterGraphicsTests.cs
+++ b/tests/WinPrint.TUI.UITests/PreviewRasterGraphicsTests.cs
@@ -2,10 +2,12 @@ using System.Drawing;
 using Terminal.Gui.App;
 using Terminal.Gui.Drawing;
 using Terminal.Gui.Drivers;
+using Terminal.Gui.Input;
 using Terminal.Gui.ViewBase;
 using Terminal.Gui.Views;
 using WinPrint.TUI.Views;
 using Xunit;
+using TgColor = Terminal.Gui.Drawing.Color;
 
 namespace WinPrint.TUI.UnitTests;
 
@@ -77,5 +79,75 @@ public class PreviewRasterGraphicsTests
             "ImageView should report raster graphics in use (Kitty support forced on)");
 
         app.End(token!);
+    }
+
+    /// <summary>
+    ///     Regression guard for issue #163: panning the Kitty/Ghostty preview must not re-transmit the
+    ///     image every step. Terminal.Gui transmits the page once (<c>a=t</c>) and pans it with tiny
+    ///     placement crops (<c>a=p</c>); the regressed behavior deleted the placement (<c>a=d</c>) and
+    ///     re-sent the whole image each frame, which read as a per-step flash on macOS Kitty/Ghostty
+    ///     (Windows Terminal Sixel was unaffected). Fixed upstream in Terminal.Gui 2.4.8
+    ///     (gui-cs/Terminal.Gui#5514); this fails if winprint is ever pinned back to a flickering build.
+    /// </summary>
+    [Fact]
+    public void KittyPreview_Pan_DoesNotRetransmitImage()
+    {
+        using IApplication app = Application.Create();
+        app.AppModel = AppModel.FullScreen;
+        app.Init(DriverRegistry.Names.ANSI);
+        app.Driver!.SetScreenSize(60, 20);
+
+        var preview = new PreviewPane { Width = Dim.Fill(), Height = Dim.Fill() };
+        var window = new Window { Width = Dim.Fill(), Height = Dim.Fill(), BorderStyle = LineStyle.None };
+        window.Add(preview);
+
+        SessionToken? token = app.Begin(window);
+
+        // Force Kitty support after Begin (the async detection has already run) and turn on Kitty output.
+        app.Driver!.SetKittyGraphicsSupport(new KittyGraphicsSupportResult
+        {
+            IsSupported = true,
+            Resolution = new Size(10, 20)
+        });
+        app.Driver!.GetOutput().UseKittyGraphics = true;
+
+        // Put a zoomed-in image in the preview directly (no async page render needed) so it is pannable.
+        preview.Image.Image = CreateGradient(64, 64);
+        preview.Image.ZoomLevel = 2d;
+
+        app.LayoutAndDraw();
+        app.LayoutAndDraw(); // second pass ensures encoding completes
+        string firstFrame = app.Driver!.GetOutput().GetLastOutput();
+
+        Assert.Contains("a=t,", firstFrame); // the image is transmitted once...
+        Assert.Contains("a=p,", firstFrame); // ...and displayed via a placement.
+
+        // Pan one cell — same image, different crop. This is the gesture that used to flash.
+        preview.Image.NewKeyDownEvent(Key.CursorRight);
+        app.LayoutAndDraw();
+        string panFrame = app.Driver!.GetOutput().GetLastOutput();
+
+        Assert.Contains("a=p,", panFrame); // the crop moves with a tiny placement update...
+        Assert.DoesNotContain("a=t,", panFrame); // ...with no pixel re-transmit (the flash fix)...
+        Assert.DoesNotContain("a=d", panFrame); // ...and no delete.
+
+        app.End(token!);
+    }
+
+    private static TgColor[,] CreateGradient(int width, int height)
+    {
+        var image = new TgColor[width, height];
+
+        for (int x = 0; x < width; x++)
+        {
+            for (int y = 0; y < height; y++)
+            {
+                byte r = (byte)(x * 255 / Math.Max(1, width - 1));
+                byte g = (byte)(y * 255 / Math.Max(1, height - 1));
+                image[x, y] = new TgColor(r, g, 128);
+            }
+        }
+
+        return image;
     }
 }


### PR DESCRIPTION
Fixes #163.

## Problem
The `wp` TUI page preview flickered on pan/zoom under macOS Kitty/Ghostty (Windows Terminal Sixel was fine). Root cause was in **Terminal.Gui's released Kitty raster path**: it deleted the prior placement (`a=d`) and re-transmitted the whole re-encoded image (`a=T`) on every pan/zoom step, so Kitty briefly showed the background = a per-step flash. Sixel just overwrites cells (no delete), hence Windows was unaffected.

## Fix
Bump `Terminal.Gui` 2.4.7 → **2.4.8**, which carries the upstream fix (gui-cs/Terminal.Gui#5514): the image is transmitted once (`a=t`) and panned/zoomed with tiny placement crops (`a=p`), double-buffering on a real pixel change.

- Transitive Markdig is still 1.3.2 (matches `WinPrint.Core`'s pin — no lockstep change needed).

## Regression guard
`KittyPreview_Pan_DoesNotRetransmitImage` drives a `PreviewPane` pan with forced Kitty support and asserts the frame moves the crop (`a=p`) with **no** `a=t` re-transmit and **no** `a=d` delete. Verified it **fails on 2.4.7** (which emits the monolithic `a=T`) and **passes on 2.4.8** — so winprint can't silently regress to a flickering Terminal.Gui.

Local TUI UITests: 56 pass + the new guard; the one failure (`BoundMainView_RendersRealDefaultSheetData`, macOS "Menlo" font assertion) is a pre-existing Mac-only env failure that also fails on 2.4.7 — unrelated to this change (CI runs on windows-latest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)