### PR TITLE
reflow preview with the engine it paints with (non-default content fonts render wrong)

### DIFF
--- a/src/WinPrint.TUI/SettingsContext.cs
+++ b/src/WinPrint.TUI/SettingsContext.cs
@@ -72,11 +72,21 @@ public sealed class SettingsContext
         // Create a real SheetViewModel so the TUI participates in the shared print path
         var sheetVM = new SheetViewModel();
 
-        // Give it a cross-platform measurement context (MAUI sets this on the SheetViewModel too).
-        // SheetViewModel.LoadFileAsync copies it onto each ContentEngine it creates; without it the
-        // engine fails to load and AppViewModel resets ActiveFile back to "<no file>". Prefer the print
-        // backend context (Skia on Unix); fall back to ImageSharp when the backend returns null (Windows GDI).
-        sheetVM.MeasurementContext = svc.CreateMeasurementContext() ?? renderer.CreateMeasurementContext();
+        // Give it a cross-platform measurement context. SheetViewModel.LoadFileAsync copies it onto
+        // each ContentEngine it creates; without it the engine fails to load and AppViewModel resets
+        // ActiveFile back to "<no file>".
+        //
+        // ENGINE-PAIRING INVARIANT: reflow must measure with the SAME engine the preview paints with.
+        // The live preview is rasterized by PageRenderer through ImageSharp, so reflow must measure
+        // through ImageSharp too — otherwise wrap points and line height are computed for a different
+        // font than the one drawn. The two engines agree for installed families but diverge for ones
+        // that aren't installed (Skia's SKTypeface.FromFamilyName silently substitutes a wide platform
+        // fallback, while ImageSharp falls back to the embedded CaskaydiaCove NFM), which made every
+        // non-installed content font wrap early and render wrong. Do NOT swap in the print service's
+        // Skia context here: the print path reflows separately (PrintPlanner) with its own Skia context,
+        // keeping print self-consistent. (See SkiaPreviewPageRenderer in WinPrint.Maui — the MAUI
+        // preview honours the same invariant by painting with Skia, the engine that measured it.)
+        sheetVM.MeasurementContext = renderer.CreateMeasurementContext();
 
         var app = new AppViewModel(pageSetup, sheetVM);
         app.LoadSheets();


### PR DESCRIPTION
## Problem

When the content font is changed from the default, the preview renders incorrectly — text wraps far too early, leaving the rest of the line blank. The default font looks fine.

## Root cause

The TUI broke the **engine-pairing invariant** the codebase already documents (see `SkiaPreviewPageRenderer` in `WinPrint.Maui`): *reflow must measure with the same engine the preview paints with.*

`SettingsContext.Create` reflowed the preview's `SheetViewModel` using the **print service's Skia** measurement context, but the live preview is rasterized by `PageRenderer` through **ImageSharp**. Two different font engines decided wrapping/line-height vs. painting.

The engines agree for an *installed* family but diverge for one that **isn't installed**:
- Skia's `SKTypeface.FromFamilyName` silently substitutes a **wide platform fallback**.
- ImageSharp falls back to the embedded **CaskaydiaCove NFM**.

So reflow measured a different (wider) font than was painted → early wrapping and wrong line height for every non-installed content font, while the default (installed) font looked correct.

Measured proof — `'W'` advance at 8pt:

| Font | Skia (reflow) | ImageSharp (paint) |
|---|---|---|
| Menlo / Courier New *(installed)* | 6.69 / 6.67 | 6.69 / 6.67 ✓ |
| Consolas / Cascadia Mono / Source Code Pro *(not installed)* | **10.49** | **6.51** ✗ |

## Fix

`src/WinPrint.TUI/SettingsContext.cs` — reflow the preview with `renderer.CreateMeasurementContext()` (ImageSharp), matching the engine that paints it.

- The **print path is unaffected**: it reflows separately in `PrintPlanner` with its own Skia context, so print stays self-consistent (Skia/Skia).
- **No-op on Windows**, where `svc.CreateMeasurementContext()` was already null and ImageSharp was already used — which is why this only manifested on macOS/Linux.

## Verification

- Rendered `testfiles/MainFrm.cpp` through the production path before/after: "Consolas" (not installed here) goes from wrapping early with a right-hand gap → filling each column like the default does. Menlo (installed) is unchanged.
- TUI tests pass: 11 binding/command-line + 14 preview/main **golden** tests green (golden snapshots use installed fonts, so they're unaffected).

## Scope

MAUI on MacCatalyst already honors the invariant (reflows with Skia, paints its preview with Skia via `SkiaPreviewPageRenderer`); the actual print/PDF path (Skia/Skia) was also already consistent. This defect was specific to the TUI live preview. The MAUI Windows `ICanvas` paint path was not testable in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)