### PR TITLE
fix(maui): Windows preview engine-pairing + typographic font-name resolution

### DIFF
--- a/src/WinPrint.Core/Abstractions/SystemDrawingGraphicsContext.cs
+++ b/src/WinPrint.Core/Abstractions/SystemDrawingGraphicsContext.cs
@@ -106,7 +106,7 @@ public sealed class SystemDrawingGraphicsContext : IGraphicsContext
         {
             try
             {
-                using SKTypeface? typeface = SKTypeface.FromFamilyName(requested);
+                using var typeface = SKTypeface.FromFamilyName(requested);
                 string? resolved = typeface?.FamilyName;
                 if (!string.IsNullOrEmpty(resolved) &&
                     !string.Equals(resolved, requested, StringComparison.OrdinalIgnoreCase) &&

--- a/src/WinPrint.Core/Abstractions/SystemDrawingGraphicsContext.cs
+++ b/src/WinPrint.Core/Abstractions/SystemDrawingGraphicsContext.cs
@@ -1,5 +1,7 @@
+using System.Collections.Concurrent;
 using System.Drawing;
 using System.Drawing.Text;
+using SkiaSharp;
 
 namespace WinPrint.Core.Abstractions;
 
@@ -84,8 +86,52 @@ public sealed class SystemDrawingGraphicsContext : IGraphicsContext
     {
         GraphicsUnit graphicsUnit = unit == GraphicsFontUnit.Pixel ? GraphicsUnit.Pixel : GraphicsUnit.Point;
         FontStyle nativeStyle = ToSystemFontStyle(style);
-        return new SystemDrawingFont(new Font(family, size, nativeStyle, graphicsUnit));
+        return new SystemDrawingFont(new Font(ResolveGdiFamily(family), size, nativeStyle, graphicsUnit));
     }
+
+    // GDI+ resolves only legacy GDI family names (e.g. "CaskaydiaCove NF"); modern config stores the
+    // typographic family name (e.g. "CaskaydiaCove Nerd Font"), which GDI+ silently swaps for a generic
+    // proportional fallback — corrupting measurement and painting. DirectWrite (via SkiaSharp, already a
+    // dependency) knows both, so when a requested family isn't a GDI-installed family we map it to the
+    // GDI-compatible family name DirectWrite reports, but only if that name is itself installed (so a
+    // genuinely missing font still falls through to GDI+'s own fallback rather than being hijacked).
+    private static string ResolveGdiFamily(string family)
+    {
+        if (string.IsNullOrEmpty(family) || s_installedFamilies.Value.Contains(family))
+        {
+            return family;
+        }
+
+        return s_familyAliases.GetOrAdd(family, static requested =>
+        {
+            try
+            {
+                using SKTypeface? typeface = SKTypeface.FromFamilyName(requested);
+                string? resolved = typeface?.FamilyName;
+                if (!string.IsNullOrEmpty(resolved) &&
+                    !string.Equals(resolved, requested, StringComparison.OrdinalIgnoreCase) &&
+                    s_installedFamilies.Value.Contains(resolved))
+                {
+                    return resolved;
+                }
+            }
+            catch (Exception)
+            {
+                // SkiaSharp unavailable or threw — leave GDI+ to do its own (proportional) fallback.
+            }
+
+            return requested;
+        });
+    }
+
+    private static readonly Lazy<HashSet<string>> s_installedFamilies = new(() =>
+    {
+        using var installed = new InstalledFontCollection();
+        return installed.Families.Select(f => f.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+    });
+
+    private static readonly ConcurrentDictionary<string, string> s_familyAliases =
+        new(StringComparer.OrdinalIgnoreCase);
 
     public IGraphicsBrush CreateSolidBrush(GraphicsColor color)
     {

--- a/src/WinPrint.Maui/Graphics/WindowsPreviewPageRenderer.cs
+++ b/src/WinPrint.Maui/Graphics/WindowsPreviewPageRenderer.cs
@@ -9,6 +9,7 @@ using Microsoft.Maui.Graphics.Platform;
 using WinPrint.Core.Abstractions;
 using WinPrint.Maui.ViewModels;
 using IImage = Microsoft.Maui.Graphics.IImage;
+using PointF = System.Drawing.PointF;
 
 namespace WinPrint.Maui.Graphics;
 
@@ -24,11 +25,14 @@ namespace WinPrint.Maui.Graphics;
 internal static class WindowsPreviewPageRenderer
 {
     /// <summary>
-    ///     Linear oversample factor for the rendered bitmap, applied as a world transform so the page
-    ///     stays crisp at typical zoom without changing the font-size-to-layout relationship the engine
-    ///     reflowed with. 2 ≈ double-resolution.
+    ///     Target preview raster density in pixels per hundredth-of-an-inch (≈200 DPI), independent of the
+    ///     sheet's printer DPI. The shared <c>SheetViewModel</c> can be reflowed for a real 600–1200 DPI
+    ///     printer (e.g. after a print job), and rasterizing the page at that density would allocate
+    ///     hundreds of MB; the preview always renders at this fixed screen density and scales the GDI+
+    ///     world transform to compensate. The layout is DPI-independent (CTEs paint a Point-unit font in
+    ///     Display mode), so this only sets sharpness, not wrapping.
     /// </summary>
-    private const float Oversample = 2f;
+    private const float TargetPixelsPerHundredth = 2f;
 
     /// <summary>
     ///     Renders the view model's current page into an image sized
@@ -42,30 +46,36 @@ internal static class WindowsPreviewPageRenderer
             return null;
         }
 
-        // Paint with the SAME GDI+ unit system the engine reflowed with: PageUnit=Display at the
-        // sheet's reflow DPI (WindowsMeasurementContext uses PrinterResolution). Matching the DPI is
-        // what keeps glyph sizes and wrap/line positions identical to the measurement pass — painting
-        // at a different DPI under-scales the measured positions and crushes the page into the top.
+        // Paint in the SAME GDI+ unit system the engine reflowed with (PageUnit=Display at the sheet's
+        // reflow DPI, as WindowsMeasurementContext uses) so glyph metrics match the measurement pass.
         int dpi = viewModel.SheetViewModel.PrinterResolution?.X ?? 96;
         if (dpi <= 0)
         {
             dpi = 96;
         }
 
-        // Size the bitmap to the page's exact device extent under the paint transform, so the page
-        // fills it precisely regardless of how GraphicsUnit.Display maps units to pixels on this device.
-        var corner = new[] { new System.Drawing.PointF(widthHundredths, heightHundredths) };
+        // GraphicsUnit.Display maps page units (hundredths of an inch) to device pixels by a factor that
+        // depends on the surface, so probe it, then choose a world scale that renders the page at a fixed
+        // TargetPixelsPerHundredth — keeping the bitmap a screen-sized raster even when the sheet was
+        // reflowed for a 600/1200 DPI printer (which would otherwise allocate hundreds of MB).
+        PointF[] probePoint = [new PointF(widthHundredths, heightHundredths)];
         using (var probe = new Bitmap(1, 1))
         {
             probe.SetResolution(dpi, dpi);
             using var pg = System.Drawing.Graphics.FromImage(probe);
             pg.PageUnit = GraphicsUnit.Display;
-            pg.ScaleTransform(Oversample, Oversample);
-            pg.TransformPoints(CoordinateSpace.Device, CoordinateSpace.World, corner);
+            pg.TransformPoints(CoordinateSpace.Device, CoordinateSpace.World, probePoint);
         }
 
-        int pixelWidth = (int)Math.Ceiling(corner[0].X);
-        int pixelHeight = (int)Math.Ceiling(corner[0].Y);
+        float unitToPixel = probePoint[0].X / widthHundredths;
+        if (unitToPixel <= 0)
+        {
+            return null;
+        }
+
+        float oversample = TargetPixelsPerHundredth / unitToPixel;
+        int pixelWidth = (int)Math.Ceiling(widthHundredths * TargetPixelsPerHundredth);
+        int pixelHeight = (int)Math.Ceiling(heightHundredths * TargetPixelsPerHundredth);
         if (pixelWidth <= 0 || pixelHeight <= 0)
         {
             return null;
@@ -77,7 +87,7 @@ internal static class WindowsPreviewPageRenderer
         {
             graphics.Clear(System.Drawing.Color.White);
             graphics.PageUnit = GraphicsUnit.Display; // Display = 1/100" (matches WindowsMeasurementContext)
-            graphics.ScaleTransform(Oversample, Oversample);
+            graphics.ScaleTransform(oversample, oversample);
             var context = new SystemDrawingGraphicsContext(graphics);
             viewModel.PaintCurrentPage(context);
         }

--- a/src/WinPrint.Maui/Graphics/WindowsPreviewPageRenderer.cs
+++ b/src/WinPrint.Maui/Graphics/WindowsPreviewPageRenderer.cs
@@ -1,0 +1,91 @@
+// Copyright Kindel, LLC - http://www.kindel.com
+// Published under the MIT License at https://github.com/tig/winprint
+
+#if WINDOWS
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
+using Microsoft.Maui.Graphics.Platform;
+using WinPrint.Core.Abstractions;
+using WinPrint.Maui.ViewModels;
+using IImage = Microsoft.Maui.Graphics.IImage;
+
+namespace WinPrint.Maui.Graphics;
+
+/// <summary>
+///     Renders a preview page into a bitmap with <see cref="SystemDrawingGraphicsContext" /> — the
+///     same GDI+ engine that measured the document during reflow (<c>WindowsMeasurementContext</c>)
+///     and that draws each page on the printer device context (<c>WindowsPrintJob</c>). MAUI's
+///     CoreGraphics-backed <c>ICanvas</c> measures text wider than it draws it, so painting the
+///     preview through it wraps and spaces runs differently than the printed output; rendering with
+///     System.Drawing keeps the preview metric-identical to what prints (the engine-pairing
+///     invariant — the Windows counterpart to <see cref="SkiaPreviewPageRenderer" /> on macOS).
+/// </summary>
+internal static class WindowsPreviewPageRenderer
+{
+    /// <summary>
+    ///     Linear oversample factor for the rendered bitmap, applied as a world transform so the page
+    ///     stays crisp at typical zoom without changing the font-size-to-layout relationship the engine
+    ///     reflowed with. 2 ≈ double-resolution.
+    /// </summary>
+    private const float Oversample = 2f;
+
+    /// <summary>
+    ///     Renders the view model's current page into an image sized
+    ///     <paramref name="widthHundredths" /> × <paramref name="heightHundredths" /> (page space,
+    ///     hundredths of an inch). Returns null when the bitmap could not be created.
+    /// </summary>
+    public static IImage? Render(MainViewModel viewModel, int widthHundredths, int heightHundredths)
+    {
+        if (widthHundredths <= 0 || heightHundredths <= 0)
+        {
+            return null;
+        }
+
+        // Paint with the SAME GDI+ unit system the engine reflowed with: PageUnit=Display at the
+        // sheet's reflow DPI (WindowsMeasurementContext uses PrinterResolution). Matching the DPI is
+        // what keeps glyph sizes and wrap/line positions identical to the measurement pass — painting
+        // at a different DPI under-scales the measured positions and crushes the page into the top.
+        int dpi = viewModel.SheetViewModel.PrinterResolution?.X ?? 96;
+        if (dpi <= 0)
+        {
+            dpi = 96;
+        }
+
+        // Size the bitmap to the page's exact device extent under the paint transform, so the page
+        // fills it precisely regardless of how GraphicsUnit.Display maps units to pixels on this device.
+        var corner = new[] { new System.Drawing.PointF(widthHundredths, heightHundredths) };
+        using (var probe = new Bitmap(1, 1))
+        {
+            probe.SetResolution(dpi, dpi);
+            using var pg = System.Drawing.Graphics.FromImage(probe);
+            pg.PageUnit = GraphicsUnit.Display;
+            pg.ScaleTransform(Oversample, Oversample);
+            pg.TransformPoints(CoordinateSpace.Device, CoordinateSpace.World, corner);
+        }
+
+        int pixelWidth = (int)Math.Ceiling(corner[0].X);
+        int pixelHeight = (int)Math.Ceiling(corner[0].Y);
+        if (pixelWidth <= 0 || pixelHeight <= 0)
+        {
+            return null;
+        }
+
+        using var bitmap = new Bitmap(pixelWidth, pixelHeight, PixelFormat.Format32bppArgb);
+        bitmap.SetResolution(dpi, dpi);
+        using (var graphics = System.Drawing.Graphics.FromImage(bitmap))
+        {
+            graphics.Clear(System.Drawing.Color.White);
+            graphics.PageUnit = GraphicsUnit.Display; // Display = 1/100" (matches WindowsMeasurementContext)
+            graphics.ScaleTransform(Oversample, Oversample);
+            var context = new SystemDrawingGraphicsContext(graphics);
+            viewModel.PaintCurrentPage(context);
+        }
+
+        var stream = new MemoryStream();
+        bitmap.Save(stream, System.Drawing.Imaging.ImageFormat.Png);
+        stream.Position = 0;
+        return PlatformImage.FromStream(stream);
+    }
+}
+#endif

--- a/src/WinPrint.Maui/Views/PrintPreviewDrawable.cs
+++ b/src/WinPrint.Maui/Views/PrintPreviewDrawable.cs
@@ -13,16 +13,17 @@ public sealed class PrintPreviewDrawable : IDrawable
 {
     private readonly MainViewModel _viewModel;
 
-#if MACCATALYST
-    // Page rendered via Skia (see SkiaPreviewPageRenderer), cached until the page,
-    // content generation, or sheet geometry changes. Zoom only rescales the cached image.
+#if MACCATALYST || WINDOWS
+    // Page rendered through the engine that measured it — Skia on macOS (SkiaPreviewPageRenderer),
+    // GDI+ on Windows (WindowsPreviewPageRenderer) — cached until the page, content generation, or
+    // sheet geometry changes. Zoom only rescales the cached image.
     private Microsoft.Maui.Graphics.IImage? _pageImage;
     private (string File, int Page, int Generation, int Width, int Height) _pageImageKey;
 
-    // Downsampled copy of _pageImage near the current on-screen size. CoreGraphics
-    // rescaling the full-resolution page on every frame makes pinch-zoom crawl; drawing
-    // a near-1:1 bitmap is cheap. Regenerated only when the needed size crosses a
-    // bucket boundary, so a pinch triggers a handful of downsamples, not one per tick.
+    // Downsampled copy of _pageImage near the current on-screen size. Rescaling the full-resolution
+    // page on every frame makes pinch-zoom crawl; drawing a near-1:1 bitmap is cheap. Regenerated
+    // only when the needed size crosses a bucket boundary, so a pinch triggers a handful of
+    // downsamples, not one per tick.
     private Microsoft.Maui.Graphics.IImage? _displayImage;
     private float _displayImageWidth;
     private const float DisplayBucketPx = 256f;
@@ -118,16 +119,21 @@ public sealed class PrintPreviewDrawable : IDrawable
         canvas.DrawRectangle(x, y, pageWidth, pageHeight);
 
         // Render content via SheetViewModel
-#if MACCATALYST
-        // Paint with Skia — the engine that measured the document and renders the printed
-        // PDF — instead of MAUI's CoreGraphics canvas, whose text measurement is wider than
-        // its drawing and spreads runs apart. See SkiaPreviewPageRenderer.
+#if MACCATALYST || WINDOWS
+        // Paint with the engine that measured the document and renders the printed output — Skia on
+        // macOS (PDF), GDI+ on Windows (printer DC) — instead of MAUI's CoreGraphics canvas, whose
+        // text measurement is wider than its drawing and spreads runs apart. See
+        // SkiaPreviewPageRenderer / WindowsPreviewPageRenderer (the engine-pairing invariant).
         (string, int, int, int, int) key = (_viewModel.ActiveFile, _viewModel.CurrentPage,
             _viewModel.PreviewContentGeneration, bounds.Width, bounds.Height);
         if (_pageImage is null || key != _pageImageKey)
         {
             _pageImage?.Dispose();
+#if MACCATALYST
             _pageImage = SkiaPreviewPageRenderer.Render(_viewModel, (int)boundsW, (int)boundsH);
+#else
+            _pageImage = WindowsPreviewPageRenderer.Render(_viewModel, (int)boundsW, (int)boundsH);
+#endif
             _pageImageKey = key;
             _displayImage?.Dispose();
             _displayImage = null;


### PR DESCRIPTION
Follow-up to #171 (TUI preview engine-pairing), applying the same fix to the **MAUI Windows** app. (#171 was merged with only the TUI half.)

## Problem
On Windows, MAUI reflowed with the GDI+ measurement context but **painted the preview through MAUI''s CoreGraphics canvas**, which measures text wider than it draws it — wrapping/spacing diverged from the printed output. Separately, GDI+ resolves only **legacy GDI family names**, so typographic names config stores (e.g. `CaskaydiaCove Nerd Font`, `JetBrainsMono Nerd Font`) silently fell back to a proportional font — corrupting measurement, preview, and print.

## Fix
1. **Engine pairing** — `WindowsPreviewPageRenderer` rasterizes the page through `SystemDrawingGraphicsContext` (GDI+, the engine that also measures and prints on Windows) at the reflow DPI, oversampled via a world transform; `PrintPreviewDrawable` shares its cached-image path with Windows. Mirrors macOS''s `SkiaPreviewPageRenderer`.
2. **Font-name resolution** — in the Windows GDI+ font path, map an unresolvable family to the GDI-compatible name DirectWrite reports (via SkiaSharp, already a dependency), but only when that name is installed, so genuinely missing fonts still fall through. Also fixes the GDI+ print path.

## Verification (Windows ARM64)
- `CaskaydiaCove Nerd Font` and `JetBrainsMono Nerd Font` now render as the real monospace faces with correct wrapping (previously proportional fallback).
- `Cascadia Code` / `FiraCode Nerd Font` unchanged (already-installed names short-circuit the shim).
- Preview verified visually; the font shim also routes through the print path (`CreateFont`) by construction.

See #174 for the longer-term option of unifying MAUI Windows on Skia (font resolution is no longer a driver for that, now that GDI+ handles these names).

🤖 Generated with [Claude Code](https://claude.com/claude-code)