### PR TITLE
fix(tui): `wp gui` launch resolution; feat(maui): Config button + unified dialog fonts

### DIFF
--- a/src/WinPrint.Maui/App.xaml
+++ b/src/WinPrint.Maui/App.xaml
@@ -9,6 +9,17 @@
                 <ResourceDictionary Source="Resources/Styles/Colors.xaml" />
                 <ResourceDictionary Source="Resources/Styles/Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
+
+            <!-- One base size for all UI chrome (sidebar + dialogs) so the app is visually consistent.
+                 Controls keep MAUI's default FontAutoScalingEnabled="True", so this base is scaled by the
+                 OS text-size setting automatically on both MacCatalyst and Windows — no per-platform code.
+                 (Print-output fonts — header/footer and content — are rendered by the engine, not these
+                 controls, so they're unaffected and stay at their true point sizes.) Kept app-wide (rather
+                 than per-page) so the code-built dialogs can read the same value via UiFonts.SidebarFontSize. -->
+            <OnPlatform x:Key="SidebarFontSize" x:TypeArguments="x:Double">
+                <On Platform="Default" Value="13" />
+                <On Platform="WinUI" Value="11" />
+            </OnPlatform>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/WinPrint.Maui/MainPage.xaml
+++ b/src/WinPrint.Maui/MainPage.xaml
@@ -23,31 +23,24 @@
         </MenuBarItem>
     </ContentPage.MenuBarItems>
 
-    <!-- One base size for all the UI chrome so the panel is visually consistent. Controls
-         keep MAUI's default FontAutoScalingEnabled="True", so this base is scaled by the
-         OS text-size setting automatically on both MacCatalyst and Windows — no per-platform
-         code. (Print-output fonts — header/footer and content — are rendered by the engine,
-         not these controls, so they're unaffected and stay at their true point sizes.) -->
-    <ContentPage.Resources>
-        <OnPlatform x:Key="SidebarFontSize" x:TypeArguments="x:Double">
-            <On Platform="Default" Value="13" />
-            <On Platform="WinUI" Value="11" />
-        </OnPlatform>
-    </ContentPage.Resources>
+    <!-- The base UI-chrome font size (SidebarFontSize) is defined app-wide in App.xaml so the
+         code-built dialogs can share it via UiFonts.SidebarFontSize. -->
 
     <Grid ColumnDefinitions="Auto,Auto,*">
 
         <!-- LEFT PANEL: Settings (collapsible horizontally). Grid rows so the settings sit
              at the top (row 0) and Help/version pins to the bottom of the panel (row 1). -->
-        <Grid x:Name="LeftPanel" Grid.Column="0" WidthRequest="210" RowDefinitions="*,Auto"
+        <Grid x:Name="LeftPanel" Grid.Column="0" WidthRequest="250" RowDefinitions="*,Auto"
               BackgroundColor="{AppThemeBinding Light=#F0F0F0, Dark=#2D2D2D}">
             <VerticalStackLayout Grid.Row="0" Padding="6,4" Spacing="1">
 
-                <!-- File / Print buttons -->
-                <Grid ColumnDefinitions="*,*" ColumnSpacing="4">
-                    <Button Grid.Column="0" Text="📂 File..." Command="{Binding OpenFileCommand}"
+                <!-- File / Print / Config buttons (Config opens the JSON config in the default editor, issue #165) -->
+                <Grid ColumnDefinitions="*,*,*" ColumnSpacing="4">
+                    <Button Grid.Column="0" Text="📂 File…" Command="{Binding OpenFileCommand}"
                             FontSize="{DynamicResource SidebarFontSize}" Padding="6,2" HeightRequest="{OnPlatform Default=34, WinUI=28}" />
-                    <Button Grid.Column="1" Text="🖨 Print..." Command="{Binding PrintCommand}"
+                    <Button Grid.Column="1" Text="🖨 Print…" Command="{Binding PrintCommand}"
+                            FontSize="{DynamicResource SidebarFontSize}" Padding="6,2" HeightRequest="{OnPlatform Default=34, WinUI=28}" />
+                    <Button Grid.Column="2" Text="⚙ Config…" Command="{Binding OpenConfigCommand}"
                             FontSize="{DynamicResource SidebarFontSize}" Padding="6,2" HeightRequest="{OnPlatform Default=34, WinUI=28}" />
                 </Grid>
 
@@ -203,7 +196,7 @@
 
             <!-- Help / version, pinned to the bottom of the panel (Grid row 1). -->
             <Grid Grid.Row="1" ColumnDefinitions="*,*" Padding="6,4">
-                <Label Grid.Column="0" Text="Help &amp; about..." FontSize="{DynamicResource SidebarFontSize}"
+                <Label Grid.Column="0" Text="Help &amp; about…" FontSize="{DynamicResource SidebarFontSize}"
                        VerticalOptions="End"
                        TextColor="{AppThemeBinding Light=Blue, Dark=LightBlue}" TextDecorations="Underline">
                     <Label.GestureRecognizers>

--- a/src/WinPrint.Maui/UiFonts.cs
+++ b/src/WinPrint.Maui/UiFonts.cs
@@ -1,0 +1,25 @@
+// Copyright Kindel, LLC - http://www.kindel.com
+// Published under the MIT License at https://github.com/tig/winprint
+
+namespace WinPrint.Maui;
+
+/// <summary>
+///     The shared UI-chrome font sizing used across the app. The single source of truth is the
+///     <c>SidebarFontSize</c> resource declared app-wide in <c>App.xaml</c>; XAML (the main window) binds to it
+///     with <c>{DynamicResource SidebarFontSize}</c>, and the code-built dialogs read it here so every surface
+///     uses the same per-platform base size and MAUI's default font auto-scaling.
+/// </summary>
+internal static class UiFonts
+{
+    /// <summary>
+    ///     The base UI-chrome font size, read from the app-wide <c>SidebarFontSize</c> resource. Falls back to
+    ///     the same per-platform constants the resource declares (Windows is denser) if the resource can't be
+    ///     resolved (e.g. before <see cref="Application.Current" /> is set), so callers always get a sane value.
+    /// </summary>
+    public static double SidebarFontSize =>
+        Application.Current?.Resources.TryGetValue("SidebarFontSize", out object? value) == true && value is double size
+            ? size
+            : DeviceInfo.Platform == DevicePlatform.WinUI
+                ? 11
+                : 13;
+}

--- a/src/WinPrint.Maui/ViewModels/MainViewModel.cs
+++ b/src/WinPrint.Maui/ViewModels/MainViewModel.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
+using Serilog;
 using WinPrint.Core;
 using WinPrint.Core.Abstractions;
 using WinPrint.Core.Helpers;
@@ -73,6 +74,7 @@ public sealed class MainViewModel : INotifyPropertyChanged
         {
             /* TODO: Open settings dialog */
         });
+        OpenConfigCommand = new RelayCommand(async () => await OpenConfigAsync());
 
         // Forward AppViewModel state changes so XAML bindings update.
         _app.PropertyChanged += OnAppPropertyChanged;
@@ -536,6 +538,9 @@ public sealed class MainViewModel : INotifyPropertyChanged
     public ICommand ChangeHeaderFooterFontCommand { get; }
     public ICommand SettingsCommand { get; }
 
+    /// <summary>Opens the WinPrint JSON config file in the OS default editor (issue #165).</summary>
+    public ICommand OpenConfigCommand { get; }
+
     public Action? InvalidatePreview { get; set; }
 
     /// <summary>
@@ -648,6 +653,32 @@ public sealed class MainViewModel : INotifyPropertyChanged
 
             OnPropertyChanged(nameof(HeaderFooterFontDescription));
             await _app.ReflowAsync();
+        }
+    }
+
+    // Opens the JSON config file in the OS default editor (issue #165). Unlike the TUI — which edits in a
+    // modal Terminal.Gui editor (issue #166) because it can run headless/over SSH — the GUI always has a
+    // desktop session, so shelling out to the user's default editor is the least-surprising behavior.
+    private async Task OpenConfigAsync()
+    {
+        string path = ServiceLocator.Current.SettingsService.SettingsFileName;
+        try
+        {
+            // The app reads (and creates-with-defaults) the config at startup, so it normally exists; reading
+            // again here makes the button self-healing if the file was deleted while running.
+            if (!File.Exists(path))
+            {
+                ServiceLocator.Current.SettingsService.ReloadAndApplySettings();
+            }
+
+            await Launcher.Default.OpenAsync(new OpenFileRequest
+            {
+                File = new ReadOnlyFile(path)
+            });
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to open config file {path} in the default editor", path);
         }
     }
 

--- a/src/WinPrint.Maui/ViewModels/MainViewModel.cs
+++ b/src/WinPrint.Maui/ViewModels/MainViewModel.cs
@@ -664,11 +664,12 @@ public sealed class MainViewModel : INotifyPropertyChanged
         string path = ServiceLocator.Current.SettingsService.SettingsFileName;
         try
         {
-            // The app reads (and creates-with-defaults) the config at startup, so it normally exists; reading
-            // again here makes the button self-healing if the file was deleted while running.
+            // The app reads (and creates-with-defaults) the config at startup, so it normally exists; if it
+            // was deleted while running, ReadSettings recreates it on disk with defaults so there is always
+            // a file to open. (ReloadAndApplySettings only *reads* — it throws when the file is missing.)
             if (!File.Exists(path))
             {
-                ServiceLocator.Current.SettingsService.ReloadAndApplySettings();
+                ServiceLocator.Current.SettingsService.ReadSettings();
             }
 
             await Launcher.Default.OpenAsync(new OpenFileRequest

--- a/src/WinPrint.Maui/Views/FontChooserPage.cs
+++ b/src/WinPrint.Maui/Views/FontChooserPage.cs
@@ -100,6 +100,7 @@ internal sealed class FontChooserPage : ContentPage
         _preview = new Label
         {
             TextColor = InkColor,
+            FontSize = UiFonts.SidebarFontSize,
             LineBreakMode = LineBreakMode.TailTruncation,
             VerticalOptions = LayoutOptions.Center
         };
@@ -246,7 +247,7 @@ internal sealed class FontChooserPage : ContentPage
         var title = new Label
         {
             Text = "Choose Font",
-            FontSize = 18,
+            FontSize = UiFonts.SidebarFontSize,
             FontAttributes = FontAttributes.Bold,
             TextColor = InkColor
         };
@@ -290,7 +291,14 @@ internal sealed class FontChooserPage : ContentPage
                 new RowDefinition { Height = GridLength.Star }
             }
         };
-        sizePanel.Add(new Label { Text = "Size", TextColor = InkColor, FontAttributes = FontAttributes.Bold }, 0);
+        sizePanel.Add(
+            new Label
+            {
+                Text = "Size",
+                TextColor = InkColor,
+                FontSize = UiFonts.SidebarFontSize,
+                FontAttributes = FontAttributes.Bold
+            }, 0);
         sizePanel.Add(_size, 0, 1);
         sizePanel.Add(Framed(_sizeList), 0, 2);
         listsRow.Add(sizePanel, 1);
@@ -364,7 +372,8 @@ internal sealed class FontChooserPage : ContentPage
         {
             BackgroundColor = FieldColor,
             TextColor = InkColor,
-            PlaceholderColor = HintColor
+            PlaceholderColor = HintColor,
+            FontSize = UiFonts.SidebarFontSize
         };
     }
 
@@ -375,7 +384,12 @@ internal sealed class FontChooserPage : ContentPage
             SelectionMode = SelectionMode.Single,
             ItemTemplate = new DataTemplate(() =>
             {
-                var label = new Label { Padding = new Thickness(10, 6), TextColor = InkColor };
+                var label = new Label
+                {
+                    Padding = new Thickness(10, 6),
+                    TextColor = InkColor,
+                    FontSize = UiFonts.SidebarFontSize
+                };
                 label.SetBinding(Label.TextProperty, ".");
                 return label;
             })
@@ -400,7 +414,12 @@ internal sealed class FontChooserPage : ContentPage
     /// </summary>
     private View MakeToggle(string text, Func<bool> get, Action<bool> set)
     {
-        var label = new Label { TextColor = InkColor, VerticalOptions = LayoutOptions.Center };
+        var label = new Label
+        {
+            TextColor = InkColor,
+            FontSize = UiFonts.SidebarFontSize,
+            VerticalOptions = LayoutOptions.Center
+        };
         var border = new Border
         {
             StrokeThickness = 1,
@@ -437,6 +456,7 @@ internal sealed class FontChooserPage : ContentPage
         {
             Text = text,
             TextColor = foreground,
+            FontSize = UiFonts.SidebarFontSize,
             FontAttributes = FontAttributes.Bold,
             HorizontalTextAlignment = TextAlignment.Center,
             VerticalTextAlignment = TextAlignment.Center

--- a/src/WinPrint.Maui/Views/SaveSheetDialogPage.cs
+++ b/src/WinPrint.Maui/Views/SaveSheetDialogPage.cs
@@ -37,7 +37,12 @@ internal sealed class SaveSheetDialogPage : ContentPage
             ItemsSource = _names,
             ItemTemplate = new DataTemplate(() =>
             {
-                Label label = new() { Padding = new Thickness(8, 6), TextColor = InkColor };
+                Label label = new()
+                {
+                    Padding = new Thickness(8, 6),
+                    TextColor = InkColor,
+                    FontSize = UiFonts.SidebarFontSize
+                };
                 label.SetBinding(Label.TextProperty, ".");
                 return label;
             })
@@ -53,19 +58,19 @@ internal sealed class SaveSheetDialogPage : ContentPage
             UpdateButtons();
         };
 
-        _newName = new Entry { Placeholder = "New definition name" };
+        _newName = new Entry { Placeholder = "New definition name", FontSize = UiFonts.SidebarFontSize };
         _newName.TextChanged += (_, _) => UpdateButtons();
 
-        _createButton = new Button { Text = "Create" };
+        _createButton = new Button { Text = "Create", FontSize = UiFonts.SidebarFontSize };
         _createButton.Clicked += (_, _) => Complete(SaveSheetChoice.Create);
 
-        Button cancelButton = new() { Text = "Cancel" };
+        Button cancelButton = new() { Text = "Cancel", FontSize = UiFonts.SidebarFontSize };
         cancelButton.Clicked += (_, _) => Complete(SaveSheetChoice.Cancel);
 
-        Button dontSaveButton = new() { Text = "Don't Save" };
+        Button dontSaveButton = new() { Text = "Don't Save", FontSize = UiFonts.SidebarFontSize };
         dontSaveButton.Clicked += (_, _) => Complete(SaveSheetChoice.DontSave);
 
-        _saveButton = new Button { Text = "Save" };
+        _saveButton = new Button { Text = "Save", FontSize = UiFonts.SidebarFontSize };
         _saveButton.Clicked += (_, _) => Complete(SaveSheetChoice.Save);
 
         Grid newNameRow = new()
@@ -99,6 +104,7 @@ internal sealed class SaveSheetDialogPage : ContentPage
         Label titleLabel = new()
         {
             Text = "Sheet Definition has changed. Select definition to update.",
+            FontSize = UiFonts.SidebarFontSize,
             FontAttributes = FontAttributes.Bold,
             TextColor = InkColor
         };

--- a/src/WinPrint.TUI/GuiLauncher.cs
+++ b/src/WinPrint.TUI/GuiLauncher.cs
@@ -11,6 +11,10 @@ internal static class GuiLauncher
     private const string MacGuiExecutable = "winprint";
     private const string WindowsGuiExecutable = "winprint.exe";
 
+    // `open <bundle>` launches a .app on macOS. Absolute path + UseShellExecute=false so the bundle path is
+    // passed as a single argv entry (ArgumentList) and survives spaces.
+    private const string MacOpenCommand = "/usr/bin/open";
+
     // In a source tree the GUI builds to a sibling project's output (src/WinPrint.Maui/bin/...), not next to
     // wp (src/WinPrint.TUI/bin/...), so the dev fallback looks under this project's bin.
     private const string MauiProjectName = "WinPrint.Maui";
@@ -39,7 +43,13 @@ internal static class GuiLauncher
             case GuiPlatform.Windows:
                 // The Velopack package co-locates winprint.exe (GUI) with wp.exe (TUI), so the GUI that
                 // ships/builds alongside this wp is its sibling — never a global lookup.
-                Start(Path.Combine(baseDirectory, WindowsGuiExecutable), "", startProcess, directoryExists);
+                Run(
+                    new ProcessStartInfo
+                    {
+                        FileName = Path.Combine(baseDirectory, WindowsGuiExecutable),
+                        UseShellExecute = true
+                    },
+                    startProcess);
                 return;
 
             case GuiPlatform.MacOS:
@@ -82,7 +92,14 @@ internal static class GuiLauncher
                 "`brew install --cask kindel/winprint/winprint`, or build/run wp from the packaged bundle.");
         }
 
-        Start("open", appPath, startProcess, directoryExists);
+        // ArgumentList (not Arguments) so a bundle path with spaces reaches `open` as one argument.
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = MacOpenCommand,
+            UseShellExecute = false
+        };
+        startInfo.ArgumentList.Add(appPath);
+        Run(startInfo, startProcess);
     }
 
     private static string? FindMacGuiBundle(
@@ -121,7 +138,7 @@ internal static class GuiLauncher
         Func<string, bool> fileExists,
         Func<string, IEnumerable<string>> enumerateBundles)
     {
-        string? config = ExtractBuildConfig(baseDirectory);
+        string? config = BuildConfigOf(baseDirectory);
 
         for (string? dir = baseDirectory; dir is not null; dir = Path.GetDirectoryName(dir))
         {
@@ -138,7 +155,8 @@ internal static class GuiLauncher
             // so `wp gui` from a Debug build doesn't open a stale Release one (or vice versa).
             string? sameConfig = config is null
                 ? null
-                : bundles.FirstOrDefault(bundle => ContainsPathSegment(bundle, config));
+                : bundles.FirstOrDefault(bundle =>
+                    string.Equals(BuildConfigOf(bundle), config, StringComparison.OrdinalIgnoreCase));
 
             return sameConfig ?? bundles.FirstOrDefault();
         }
@@ -146,21 +164,16 @@ internal static class GuiLauncher
         return null;
     }
 
-    // The build configuration ("Debug"/"Release") is the path segment two levels above wp's bin output
-    // (bin/<config>/<tfm>); pick it out so the dev GUI lookup can prefer a matching configuration.
-    private static string? ExtractBuildConfig(string path)
+    // The build configuration is the path segment immediately after `bin` (bin/<config>/<tfm>...). Reading
+    // it structurally — rather than scanning for the first "Debug"/"Release" anywhere — avoids mis-detecting
+    // a configuration when an unrelated ancestor directory happens to be named "Debug"/"Release".
+    private static string? BuildConfigOf(string path)
     {
-        return Array.Find(
-            path.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
-            segment => string.Equals(segment, "Debug", StringComparison.OrdinalIgnoreCase) ||
-                       string.Equals(segment, "Release", StringComparison.OrdinalIgnoreCase));
-    }
-
-    private static bool ContainsPathSegment(string path, string segment)
-    {
-        return path
-            .Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
-            .Any(part => string.Equals(part, segment, StringComparison.OrdinalIgnoreCase));
+        string[] segments = path.Split(
+            [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+            StringSplitOptions.RemoveEmptyEntries);
+        int binIndex = Array.LastIndexOf(segments, "bin");
+        return binIndex >= 0 && binIndex + 1 < segments.Length ? segments[binIndex + 1] : null;
     }
 
     private static bool IsMacGuiBundle(
@@ -179,27 +192,11 @@ internal static class GuiLauncher
             : [];
     }
 
-    private static void Start(
-        string fileName,
-        string arguments,
-        Func<ProcessStartInfo, bool> startProcess,
-        Func<string, bool> directoryExists)
+    private static void Run(ProcessStartInfo startInfo, Func<ProcessStartInfo, bool> startProcess)
     {
-        string resolvedFileName =
-            File.Exists(fileName) || directoryExists(fileName) || Path.IsPathFullyQualified(fileName)
-                ? fileName
-                : Path.GetFileName(fileName);
-
-        var startInfo = new ProcessStartInfo
-        {
-            FileName = resolvedFileName,
-            Arguments = arguments,
-            UseShellExecute = true
-        };
-
         if (!startProcess(startInfo))
         {
-            throw new InvalidOperationException($"Could not launch {resolvedFileName}.");
+            throw new InvalidOperationException($"Could not launch {startInfo.FileName}.");
         }
     }
 

--- a/src/WinPrint.TUI/GuiLauncher.cs
+++ b/src/WinPrint.TUI/GuiLauncher.cs
@@ -4,31 +4,46 @@ namespace WinPrint.TUI;
 
 internal static class GuiLauncher
 {
+    // The macOS GUI bundle and the real GUI executable inside it (Contents/MacOS/winprint). The embedded
+    // TUI lives at Contents/Helpers/wp, so checking for the winprint executable distinguishes the real GUI
+    // bundle from a stale/look-alike WinPrint.app whose executable is something else.
+    private const string MacGuiBundleName = "WinPrint.app";
+    private const string MacGuiExecutable = "winprint";
+    private const string WindowsGuiExecutable = "winprint.exe";
+
+    // In a source tree the GUI builds to a sibling project's output (src/WinPrint.Maui/bin/...), not next to
+    // wp (src/WinPrint.TUI/bin/...), so the dev fallback looks under this project's bin.
+    private const string MauiProjectName = "WinPrint.Maui";
+
     public static void Launch()
     {
         Launch(
             GetCurrentPlatform(),
             AppContext.BaseDirectory,
-            Directory.GetCurrentDirectory(),
             Directory.Exists,
+            File.Exists,
+            EnumerateBundles,
             StartProcess);
     }
 
     internal static void Launch(
         GuiPlatform platform,
         string baseDirectory,
-        string currentDirectory,
         Func<string, bool> directoryExists,
+        Func<string, bool> fileExists,
+        Func<string, IEnumerable<string>> enumerateBundles,
         Func<ProcessStartInfo, bool> startProcess)
     {
         switch (platform)
         {
             case GuiPlatform.Windows:
-                Start(Path.Combine(baseDirectory, "winprint.exe"), "", startProcess, directoryExists);
+                // The Velopack package co-locates winprint.exe (GUI) with wp.exe (TUI), so the GUI that
+                // ships/builds alongside this wp is its sibling — never a global lookup.
+                Start(Path.Combine(baseDirectory, WindowsGuiExecutable), "", startProcess, directoryExists);
                 return;
 
             case GuiPlatform.MacOS:
-                StartMacGui(baseDirectory, currentDirectory, directoryExists, startProcess);
+                StartMacGui(baseDirectory, directoryExists, fileExists, enumerateBundles, startProcess);
                 return;
 
             default:
@@ -50,42 +65,118 @@ internal static class GuiLauncher
 
     private static void StartMacGui(
         string baseDirectory,
-        string currentDirectory,
         Func<string, bool> directoryExists,
+        Func<string, bool> fileExists,
+        Func<string, IEnumerable<string>> enumerateBundles,
         Func<ProcessStartInfo, bool> startProcess)
     {
-        string? appPath = FindMacAppBundle(baseDirectory, currentDirectory, directoryExists);
-        if (appPath is not null)
+        // Resolve the GUI relative to where *this* wp lives — never via /Applications or `open -a WinPrint`,
+        // which match any (possibly stale/legacy) bundle by name and silently launch the wrong app.
+        string? appPath = FindMacGuiBundle(baseDirectory, directoryExists, fileExists, enumerateBundles);
+        if (appPath is null)
         {
-            Start("open", appPath, startProcess, directoryExists);
-            return;
+            throw new InvalidOperationException(
+                "Could not find the WinPrint GUI. The wp CLI launches the WinPrint.app it ships inside " +
+                "(the Homebrew cask embeds wp at WinPrint.app/Contents/Helpers/wp), is built next to, or " +
+                "builds to the sibling WinPrint.Maui project. Install the GUI with " +
+                "`brew install --cask kindel/winprint/winprint`, or build/run wp from the packaged bundle.");
         }
 
-        Start("open", "-a WinPrint", startProcess, directoryExists);
+        Start("open", appPath, startProcess, directoryExists);
     }
 
-    private static string? FindMacAppBundle(
+    private static string? FindMacGuiBundle(
         string baseDirectory,
-        string currentDirectory,
-        Func<string, bool> directoryExists)
+        Func<string, bool> directoryExists,
+        Func<string, bool> fileExists,
+        Func<string, IEnumerable<string>> enumerateBundles)
     {
-        string[] roots =
-        [
-            baseDirectory,
-            currentDirectory,
-            "/Applications"
-        ];
-
-        foreach (string root in roots)
+        // 1) wp embedded inside the GUI bundle (Homebrew cask / packaged build):
+        //    .../WinPrint.app/Contents/Helpers/wp → walk up to the enclosing WinPrint.app.
+        for (string? dir = baseDirectory; dir is not null; dir = Path.GetDirectoryName(dir))
         {
-            string candidate = Path.Combine(root, "WinPrint.app");
-            if (directoryExists(candidate))
+            if (string.Equals(Path.GetFileName(dir), MacGuiBundleName, StringComparison.Ordinal) &&
+                IsMacGuiBundle(dir, directoryExists, fileExists))
             {
-                return candidate;
+                return dir;
             }
         }
 
+        // 2) GUI bundle sitting next to wp (side-by-side publish layout).
+        string sibling = Path.Combine(baseDirectory, MacGuiBundleName);
+        if (IsMacGuiBundle(sibling, directoryExists, fileExists))
+        {
+            return sibling;
+        }
+
+        // 3) Source-tree build: wp runs from src/WinPrint.TUI/bin/<config>/<tfm>, while the GUI builds to
+        //    the sibling src/WinPrint.Maui/bin/<config>/<tfm>/<rid>/WinPrint.app. Find that build output
+        //    relative to wp, preferring a bundle built with the same configuration.
+        return FindDevGuiBundle(baseDirectory, directoryExists, fileExists, enumerateBundles);
+    }
+
+    private static string? FindDevGuiBundle(
+        string baseDirectory,
+        Func<string, bool> directoryExists,
+        Func<string, bool> fileExists,
+        Func<string, IEnumerable<string>> enumerateBundles)
+    {
+        string? config = ExtractBuildConfig(baseDirectory);
+
+        for (string? dir = baseDirectory; dir is not null; dir = Path.GetDirectoryName(dir))
+        {
+            string mauiBin = Path.Combine(dir, MauiProjectName, "bin");
+            if (!directoryExists(mauiBin))
+            {
+                continue;
+            }
+
+            List<string> bundles =
+                [.. enumerateBundles(mauiBin).Where(bundle => IsMacGuiBundle(bundle, directoryExists, fileExists))];
+
+            // Prefer a bundle built with the same configuration as this wp (Debug↔Debug, Release↔Release)
+            // so `wp gui` from a Debug build doesn't open a stale Release one (or vice versa).
+            string? sameConfig = config is null
+                ? null
+                : bundles.FirstOrDefault(bundle => ContainsPathSegment(bundle, config));
+
+            return sameConfig ?? bundles.FirstOrDefault();
+        }
+
         return null;
+    }
+
+    // The build configuration ("Debug"/"Release") is the path segment two levels above wp's bin output
+    // (bin/<config>/<tfm>); pick it out so the dev GUI lookup can prefer a matching configuration.
+    private static string? ExtractBuildConfig(string path)
+    {
+        return Array.Find(
+            path.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+            segment => string.Equals(segment, "Debug", StringComparison.OrdinalIgnoreCase) ||
+                       string.Equals(segment, "Release", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool ContainsPathSegment(string path, string segment)
+    {
+        return path
+            .Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            .Any(part => string.Equals(part, segment, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool IsMacGuiBundle(
+        string bundlePath,
+        Func<string, bool> directoryExists,
+        Func<string, bool> fileExists)
+    {
+        return directoryExists(bundlePath) &&
+               fileExists(Path.Combine(bundlePath, "Contents", "MacOS", MacGuiExecutable));
+    }
+
+    private static IEnumerable<string> EnumerateBundles(string root)
+    {
+        return Directory.Exists(root)
+            ? Directory.EnumerateDirectories(root, MacGuiBundleName, SearchOption.AllDirectories)
+            : [];
     }
 
     private static void Start(

--- a/tests/WinPrint.Core.UnitTests/Services/SettingsServiceTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Services/SettingsServiceTests.cs
@@ -75,6 +75,51 @@ public class SettingsServiceTests : TestServicesBase
     }
 
     [Fact]
+    public void ReadSettings_RecreatesFileOnDisk_WhenMissing()
+    {
+        // The MAUI "open config" button self-heals a deleted config by calling ReadSettings (NOT
+        // ReloadAndApplySettings, which only reads). ReadSettings must write defaults back to disk so the
+        // editor has a file to open.
+        var settingsService = new SettingsService
+        {
+            SettingsFileName = $"WinPrint.{Guid.NewGuid():N}.json"
+        };
+        if (File.Exists(settingsService.SettingsFileName))
+        {
+            File.Delete(settingsService.SettingsFileName);
+        }
+
+        try
+        {
+            Settings? settings = settingsService.ReadSettings();
+
+            Assert.NotNull(settings);
+            Assert.True(File.Exists(settingsService.SettingsFileName));
+        }
+        finally
+        {
+            File.Delete(settingsService.SettingsFileName);
+        }
+    }
+
+    [Fact]
+    public void ReloadAndApplySettings_Throws_WhenFileMissing()
+    {
+        // Documents why the open-config button cannot use ReloadAndApplySettings to recreate a deleted
+        // config: it reads via File.ReadAllText and throws when the file is absent.
+        var settingsService = new SettingsService
+        {
+            SettingsFileName = $"WinPrint.{Guid.NewGuid():N}.json"
+        };
+        if (File.Exists(settingsService.SettingsFileName))
+        {
+            File.Delete(settingsService.SettingsFileName);
+        }
+
+        Assert.Throws<FileNotFoundException>(() => settingsService.ReloadAndApplySettings());
+    }
+
+    [Fact]
     public void TestReadMicrosoftExtensionsConfigurationSchema()
     {
         string settingsFileName = $"WinPrint.{GetType().Name}.Mec.json";

--- a/tests/WinPrint.TUI.UnitTests/GuiLauncherTests.cs
+++ b/tests/WinPrint.TUI.UnitTests/GuiLauncherTests.cs
@@ -7,6 +7,8 @@ namespace WinPrint.TUI.UnitTests;
 
 public class GuiLauncherTests
 {
+    private const string MacOpen = "/usr/bin/open";
+
     private static readonly Func<string, IEnumerable<string>> NoBundles = _ => [];
 
     [Fact]
@@ -46,7 +48,7 @@ public class GuiLauncherTests
 
         ProcessStartInfo start = Assert.Single(starts);
         Assert.Equal(@"C:\Apps\WinPrint\winprint.exe", start.FileName);
-        Assert.Equal("", start.Arguments);
+        Assert.Empty(start.ArgumentList);
         Assert.True(start.UseShellExecute);
     }
 
@@ -72,9 +74,8 @@ public class GuiLauncherTests
             });
 
         ProcessStartInfo start = Assert.Single(starts);
-        Assert.Equal("open", start.FileName);
-        Assert.Equal(bundle, start.Arguments);
-        Assert.True(start.UseShellExecute);
+        Assert.Equal(MacOpen, start.FileName);
+        Assert.Equal(bundle, Assert.Single(start.ArgumentList));
     }
 
     [Fact]
@@ -100,8 +101,37 @@ public class GuiLauncherTests
             });
 
         ProcessStartInfo start = Assert.Single(starts);
-        Assert.Equal("open", start.FileName);
-        Assert.Equal(bundle, start.Arguments);
+        Assert.Equal(MacOpen, start.FileName);
+        Assert.Equal(bundle, Assert.Single(start.ArgumentList));
+    }
+
+    [Fact]
+    public void MacOS_PassesBundlePathAsSingleArgument_EvenWithSpaces()
+    {
+        // A bundle path containing spaces must reach `open` as ONE argument (via ArgumentList), not a
+        // space-split Arguments string that `open` would treat as several (non-existent) paths.
+        List<ProcessStartInfo> starts = [];
+        const string baseDirectory = "/Users/jane doe/My Apps";
+        string bundle = Path.Combine(baseDirectory, "WinPrint.app");
+        string guiExecutable = Path.Combine(bundle, "Contents", "MacOS", "winprint");
+
+        GuiLauncher.Launch(
+            GuiPlatform.MacOS,
+            baseDirectory,
+            dir => dir == bundle,
+            file => file == guiExecutable,
+            NoBundles,
+            startInfo =>
+            {
+                starts.Add(startInfo);
+                return true;
+            });
+
+        ProcessStartInfo start = Assert.Single(starts);
+        Assert.Equal(bundle, Assert.Single(start.ArgumentList));
+        Assert.Empty(start.Arguments);
+        // ArgumentList is only honored without shell-execute; otherwise the path is re-parsed as a string.
+        Assert.False(start.UseShellExecute);
     }
 
     [Fact]
@@ -128,8 +158,8 @@ public class GuiLauncherTests
             });
 
         ProcessStartInfo start = Assert.Single(starts);
-        Assert.Equal("open", start.FileName);
-        Assert.Equal(bundle, start.Arguments);
+        Assert.Equal(MacOpen, start.FileName);
+        Assert.Equal(bundle, Assert.Single(start.ArgumentList));
     }
 
     [Fact]
@@ -158,7 +188,37 @@ public class GuiLauncherTests
             });
 
         ProcessStartInfo start = Assert.Single(starts);
-        Assert.Equal(debugBundle, start.Arguments);
+        Assert.Equal(debugBundle, Assert.Single(start.ArgumentList));
+    }
+
+    [Fact]
+    public void MacOS_DetectsBuildConfigStructurally_IgnoringUnrelatedDebugSegments()
+    {
+        // A parent directory literally named "Debug" must not fool config detection: the build config is
+        // the segment right after wp's `bin`, so a Release wp opens the Release bundle — not the Debug one
+        // a naive "first Debug/Release anywhere in the path" scan would prefer.
+        List<ProcessStartInfo> starts = [];
+        const string baseDirectory = "/Users/Debug/proj/src/WinPrint.TUI/bin/Release/net10.0";
+        const string mauiBin = "/Users/Debug/proj/src/WinPrint.Maui/bin";
+        const string debugBundle =
+            "/Users/Debug/proj/src/WinPrint.Maui/bin/Debug/net10.0-maccatalyst/maccatalyst-arm64/WinPrint.app";
+        const string releaseBundle =
+            "/Users/Debug/proj/src/WinPrint.Maui/bin/Release/net10.0-maccatalyst/maccatalyst-arm64/WinPrint.app";
+
+        GuiLauncher.Launch(
+            GuiPlatform.MacOS,
+            baseDirectory,
+            dir => dir is mauiBin or debugBundle or releaseBundle,
+            file => file.EndsWith(Path.Combine("Contents", "MacOS", "winprint"), StringComparison.Ordinal),
+            root => root == mauiBin ? [debugBundle, releaseBundle] : [],
+            startInfo =>
+            {
+                starts.Add(startInfo);
+                return true;
+            });
+
+        ProcessStartInfo start = Assert.Single(starts);
+        Assert.Equal(releaseBundle, Assert.Single(start.ArgumentList));
     }
 
     [Fact]

--- a/tests/WinPrint.TUI.UnitTests/GuiLauncherTests.cs
+++ b/tests/WinPrint.TUI.UnitTests/GuiLauncherTests.cs
@@ -7,6 +7,8 @@ namespace WinPrint.TUI.UnitTests;
 
 public class GuiLauncherTests
 {
+    private static readonly Func<string, IEnumerable<string>> NoBundles = _ => [];
+
     [Fact]
     public void GuiCommand_AdvertisesGuiSubcommand()
     {
@@ -33,8 +35,9 @@ public class GuiLauncherTests
         GuiLauncher.Launch(
             GuiPlatform.Windows,
             @"C:\Apps\WinPrint",
-            @"C:\Work",
             _ => false,
+            _ => false,
+            NoBundles,
             startInfo =>
             {
                 starts.Add(startInfo);
@@ -48,50 +51,20 @@ public class GuiLauncherTests
     }
 
     [Fact]
-    public void MacOS_LaunchesNearbyAppBundle()
+    public void MacOS_LaunchesSiblingGuiBundle()
     {
+        // wp published next to the GUI: WinPrint.app sits beside wp in the same directory.
         List<ProcessStartInfo> starts = [];
-        string baseDirectory = Path.Combine(Path.GetTempPath(), $"winprint-gui-test-{Guid.NewGuid():N}");
+        const string baseDirectory = "/opt/winprint";
         string bundle = Path.Combine(baseDirectory, "WinPrint.app");
-        try
-        {
-            Directory.CreateDirectory(bundle);
-
-            GuiLauncher.Launch(
-                GuiPlatform.MacOS,
-                baseDirectory,
-                "/tmp",
-                Directory.Exists,
-                startInfo =>
-                {
-                    starts.Add(startInfo);
-                    return true;
-                });
-
-            ProcessStartInfo start = Assert.Single(starts);
-            Assert.Equal("open", start.FileName);
-            Assert.Equal(bundle, start.Arguments);
-            Assert.True(start.UseShellExecute);
-        }
-        finally
-        {
-            if (Directory.Exists(baseDirectory))
-            {
-                Directory.Delete(baseDirectory, true);
-            }
-        }
-    }
-
-    [Fact]
-    public void MacOS_FallsBackToApplicationName()
-    {
-        List<ProcessStartInfo> starts = [];
+        string guiExecutable = Path.Combine(bundle, "Contents", "MacOS", "winprint");
 
         GuiLauncher.Launch(
             GuiPlatform.MacOS,
-            "/opt/winprint",
-            "/tmp",
-            _ => false,
+            baseDirectory,
+            dir => dir == bundle,
+            file => file == guiExecutable,
+            NoBundles,
             startInfo =>
             {
                 starts.Add(startInfo);
@@ -100,7 +73,137 @@ public class GuiLauncherTests
 
         ProcessStartInfo start = Assert.Single(starts);
         Assert.Equal("open", start.FileName);
-        Assert.Equal("-a WinPrint", start.Arguments);
+        Assert.Equal(bundle, start.Arguments);
+        Assert.True(start.UseShellExecute);
+    }
+
+    [Fact]
+    public void MacOS_LaunchesEnclosingGuiBundleWhenWpIsEmbedded()
+    {
+        // Homebrew cask / packaged build: wp runs from WinPrint.app/Contents/Helpers, so the GUI is the
+        // enclosing bundle — found by walking up, not by any global lookup.
+        List<ProcessStartInfo> starts = [];
+        const string bundle = "/Applications/WinPrint.app";
+        string baseDirectory = Path.Combine(bundle, "Contents", "Helpers");
+        string guiExecutable = Path.Combine(bundle, "Contents", "MacOS", "winprint");
+
+        GuiLauncher.Launch(
+            GuiPlatform.MacOS,
+            baseDirectory,
+            dir => dir == bundle,
+            file => file == guiExecutable,
+            NoBundles,
+            startInfo =>
+            {
+                starts.Add(startInfo);
+                return true;
+            });
+
+        ProcessStartInfo start = Assert.Single(starts);
+        Assert.Equal("open", start.FileName);
+        Assert.Equal(bundle, start.Arguments);
+    }
+
+    [Fact]
+    public void MacOS_LaunchesSiblingMauiProjectBuildOutput()
+    {
+        // Source-tree `dotnet build`: wp builds to src/WinPrint.TUI/bin/<config>/<tfm> while the GUI
+        // builds to the sibling src/WinPrint.Maui/bin/<config>/<tfm>/<rid>/WinPrint.app.
+        List<ProcessStartInfo> starts = [];
+        const string baseDirectory = "/repo/src/WinPrint.TUI/bin/Debug/net10.0";
+        const string mauiBin = "/repo/src/WinPrint.Maui/bin";
+        const string bundle = "/repo/src/WinPrint.Maui/bin/Debug/net10.0-maccatalyst/maccatalyst-arm64/WinPrint.app";
+        string guiExecutable = Path.Combine(bundle, "Contents", "MacOS", "winprint");
+
+        GuiLauncher.Launch(
+            GuiPlatform.MacOS,
+            baseDirectory,
+            dir => dir is mauiBin or bundle,
+            file => file == guiExecutable,
+            root => root == mauiBin ? [bundle] : [],
+            startInfo =>
+            {
+                starts.Add(startInfo);
+                return true;
+            });
+
+        ProcessStartInfo start = Assert.Single(starts);
+        Assert.Equal("open", start.FileName);
+        Assert.Equal(bundle, start.Arguments);
+    }
+
+    [Fact]
+    public void MacOS_PrefersDevGuiBundleMatchingBuildConfig()
+    {
+        // When both Debug and Release GUI builds exist, a Debug wp must open the Debug bundle (and not a
+        // stale Release one), regardless of enumeration order.
+        List<ProcessStartInfo> starts = [];
+        const string baseDirectory = "/repo/src/WinPrint.TUI/bin/Debug/net10.0";
+        const string mauiBin = "/repo/src/WinPrint.Maui/bin";
+        const string debugBundle =
+            "/repo/src/WinPrint.Maui/bin/Debug/net10.0-maccatalyst/maccatalyst-arm64/WinPrint.app";
+        const string releaseBundle =
+            "/repo/src/WinPrint.Maui/bin/Release/net10.0-maccatalyst/maccatalyst-arm64/WinPrint.app";
+
+        GuiLauncher.Launch(
+            GuiPlatform.MacOS,
+            baseDirectory,
+            dir => dir is mauiBin or debugBundle or releaseBundle,
+            file => file.EndsWith(Path.Combine("Contents", "MacOS", "winprint"), StringComparison.Ordinal),
+            root => root == mauiBin ? [releaseBundle, debugBundle] : [],
+            startInfo =>
+            {
+                starts.Add(startInfo);
+                return true;
+            });
+
+        ProcessStartInfo start = Assert.Single(starts);
+        Assert.Equal(debugBundle, start.Arguments);
+    }
+
+    [Fact]
+    public void MacOS_IgnoresLookAlikeBundleWithoutGuiExecutable()
+    {
+        // A WinPrint.app whose Contents/MacOS lacks the `winprint` GUI executable (e.g. a stale/legacy
+        // bundle that only contains the TUI) must NOT be launched — wp gui should report the GUI missing
+        // rather than silently opening the wrong app.
+        const string bundle = "/Applications/WinPrint.app";
+        string baseDirectory = Path.Combine(bundle, "Contents", "Helpers");
+
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() =>
+            GuiLauncher.Launch(
+                GuiPlatform.MacOS,
+                baseDirectory,
+                dir => dir == bundle, // the bundle dir exists…
+                _ => false, // …but Contents/MacOS/winprint does not.
+                NoBundles,
+                _ => true));
+
+        Assert.Contains("Could not find the WinPrint GUI", ex.Message);
+    }
+
+    [Fact]
+    public void MacOS_ReportsMissingGuiWhenNoBundleNearby()
+    {
+        // Formula-only install (TUI without the GUI cask): no WinPrint.app near wp → helpful error,
+        // never a fallback to /Applications or `open -a WinPrint`.
+        List<ProcessStartInfo> starts = [];
+
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() =>
+            GuiLauncher.Launch(
+                GuiPlatform.MacOS,
+                "/opt/homebrew/Cellar/winprint/2.6.15/bin",
+                _ => false,
+                _ => false,
+                NoBundles,
+                startInfo =>
+                {
+                    starts.Add(startInfo);
+                    return true;
+                }));
+
+        Assert.Contains("Could not find the WinPrint GUI", ex.Message);
+        Assert.Empty(starts);
     }
 
     [Fact]
@@ -110,8 +213,9 @@ public class GuiLauncherTests
             GuiLauncher.Launch(
                 GuiPlatform.Unsupported,
                 "/opt/winprint",
-                "/tmp",
                 _ => false,
+                _ => false,
+                NoBundles,
                 _ => true));
 
         Assert.Equal("WinPrint GUI is not available on Linux yet.", ex.Message);


### PR DESCRIPTION
Two changes folded into one PR.

---

## 1. `wp gui` launches the right GUI bundle (TUI)

### Problem
`wp gui` on macOS searched `baseDir` → cwd → **`/Applications`** for any `WinPrint.app` and `open`ed the first match (with an `open -a WinPrint` fallback). That matches unrelated/stale bundles **by name** — e.g. a legacy `/Applications/WinPrint.app` whose `CFBundleExecutable` is `wp` (not the GUI) — so it silently launched the wrong app (or the headless TUI) and still reported success.

### Fix
Resolve the GUI **strictly relative to where this `wp` lives**, in order:
1. **Enclosing bundle** — Homebrew cask / packaged build, where `wp` runs from `WinPrint.app/Contents/Helpers/wp`: walk up to the enclosing `WinPrint.app`.
2. **Sibling bundle** — side-by-side publish layout (`WinPrint.app` next to `wp`).
3. **Source-tree build** — `wp` builds to `src/WinPrint.TUI/bin/<config>/<tfm>` while the GUI builds to the sibling `src/WinPrint.Maui/bin/<config>/<tfm>/<rid>/WinPrint.app`: find that build output and **prefer the bundle matching `wp`'s build config** (Debug↔Debug / Release↔Release).

Every candidate is validated as the real GUI by requiring `Contents/MacOS/winprint` (the legacy bundle's executable is `wp`, so it's correctly rejected). The global `/Applications` scan and `open -a WinPrint` fallback are **removed**; when no GUI is found next to `wp` (e.g. a formula-only install), `wp gui` reports a helpful error instead of opening the wrong app. Windows behavior (co-located `winprint.exe`) is unchanged.

### Verification
- **Live (dev build):** `./src/WinPrint.TUI/bin/Debug/net10.0/wp gui` launches `…/src/WinPrint.Maui/bin/Debug/net10.0-maccatalyst/maccatalyst-arm64/WinPrint.app/Contents/MacOS/winprint`.
- **Live (formula-only install):** prints the helpful "Could not find the WinPrint GUI…" message instead of hijacking the stale `/Applications/WinPrint.app`.
- `GuiLauncherTests` 9/9; full TUI suite 45/45.

---

## 2. Config button + unified dialog fonts (MAUI, issue #165)

- Add a **⚙ Config…** button to the settings pane, in the top button row to the right of Print, opening the JSON config in the OS default editor (self-healing if the file was deleted). The GUI always has a desktop session, so the default editor is the least-surprising behavior (vs the TUI's modal editor, issue #166).
- Widen the settings pane (210→250) so File / Print / Config fit without truncation; use a single ellipsis glyph (…) on button/link labels.
- **Unify dialog fonts** with the main window: move `SidebarFontSize` to `App.xaml` as one app-wide source of truth, add `UiFonts.SidebarFontSize` to read it from code, and apply it across the code-built `FontChooserPage` and `SaveSheetDialogPage` so every surface shares the same per-platform base size and font auto-scaling.

### Verification
- MacCatalyst build clean; MAUI unit tests 30/30.
- Visually confirmed: three-button row with single ellipses, and the Font Chooser rendering at the compact sidebar size.

---

Style gate (`jb cleanupcode WinPrintCleanup` + `dotnet format`) clean for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)