### PR TITLE
fix(tui): reflow preview when content/header-footer font face or size changes

### DIFF
--- a/src/WinPrint.TUI/Views/Editors/FontEditor.cs
+++ b/src/WinPrint.TUI/Views/Editors/FontEditor.cs
@@ -67,16 +67,23 @@ public sealed class FontEditor : EditorBase<Font>
             return;
         }
 
-        // Font is mutable; mutate the bound instance directly.
+        // Build a NEW Font and assign it through Value (rather than mutating the bound instance in place).
+        // Font is not a ModelBase and raises no PropertyChanged, so an in-place mutation left Value
+        // reference-identical: EditorBase never raised ValueChanged, so the SettingsPanel handler never ran
+        // and the preview never reflowed. Font has value equality, so an unchanged selection is a no-op.
+        var updated = (Font)Value.Clone();
+
         if (!string.IsNullOrEmpty(_family.Value))
         {
-            Value.Family = _family.Value;
+            updated.Family = _family.Value;
         }
 
         if (float.TryParse(_size.Value, NumberStyles.Float, CultureInfo.InvariantCulture, out float size))
         {
-            Value.Size = size;
+            updated.Size = size;
         }
+
+        Value = updated;
     }
 
     // The model's family/size are free-form, so a bound value may not be in the curated list; add it

--- a/tests/WinPrint.TUI.UITests/FontEditorGoldenTests.cs
+++ b/tests/WinPrint.TUI.UITests/FontEditorGoldenTests.cs
@@ -49,4 +49,45 @@ public class FontEditorGoldenTests
 
         DriverAssert.ContainsText(fixture.Screen, "Wingdings Deluxe");
     }
+
+    [Fact]
+    public void ChangingFamily_RaisesValueChanged_SoPreviewCanReflow()
+    {
+        // Regression: picking a different family in the dropdown must raise ValueChanged so the
+        // SettingsPanel handler writes the new font and reflows. (Mutating the bound Font in place left
+        // Value reference-identical, so EditorBase never raised ValueChanged and the preview never reflowed.)
+        var editor = new FontEditor
+        {
+            Value = new Font { Family = "Source Code Pro", Size = 10f, Style = FontStyle.Regular }
+        };
+        _ = new AppFixture(editor, 60, 6);
+
+        Font? changedTo = null;
+        editor.ValueChanged += (_, e) => changedTo = e.NewValue;
+
+        editor.SelectInDropDown("_family", "Courier New");
+
+        Assert.NotNull(changedTo);
+        Assert.Equal("Courier New", changedTo!.Family);
+        Assert.Equal(10f, changedTo.Size); // size preserved
+    }
+
+    [Fact]
+    public void ChangingSize_RaisesValueChanged_SoPreviewCanReflow()
+    {
+        var editor = new FontEditor
+        {
+            Value = new Font { Family = "Source Code Pro", Size = 10f, Style = FontStyle.Regular }
+        };
+        _ = new AppFixture(editor, 60, 6);
+
+        Font? changedTo = null;
+        editor.ValueChanged += (_, e) => changedTo = e.NewValue;
+
+        editor.SelectInDropDown("_size", "12");
+
+        Assert.NotNull(changedTo);
+        Assert.Equal(12f, changedTo!.Size);
+        Assert.Equal("Source Code Pro", changedTo.Family); // family preserved
+    }
 }

--- a/tests/WinPrint.TUI.UITests/SettingsBindingTests.cs
+++ b/tests/WinPrint.TUI.UITests/SettingsBindingTests.cs
@@ -112,6 +112,36 @@ public class SettingsBindingTests
     }
 
     [Fact]
+    public void BoundPanel_ChangingContentFontWritesThroughToModel()
+    {
+        // Regression: picking a different content font family/size in the dropdown must route through the
+        // ContentFont.ValueChanged handler into the live sheet model (the same handler calls ReflowAsync,
+        // so this also proves the preview relayouts). Previously the in-place Font mutation raised no
+        // ValueChanged, so the handler never ran and nothing relayouted.
+        var context = SettingsContext.Create();
+        var panel = new SettingsPanel();
+        panel.Bind(context);
+        _ = new AppFixture(panel, 40, 30);
+
+        SheetSettings sheet = context.CurrentSheet!;
+        ContentSettings content = sheet.ContentSettings!;
+        var original = (Font)content.Font.Clone();
+        try
+        {
+            panel.ContentFont.SelectInDropDown("_family", "Courier New");
+            panel.ContentFont.SelectInDropDown("_size", "16");
+
+            Assert.Equal("Courier New", content.Font.Family);
+            Assert.Equal(16f, content.Font.Size);
+        }
+        finally
+        {
+            // Settings is a process-global singleton (ModelLocator); restore so the edit doesn't bleed.
+            content.Font = original;
+        }
+    }
+
+    [Fact]
     public void ModelMutation_FiresSettingsChanged_TriggersPreviewRefresh()
     {
         // Arrange: create a SettingsContext with a real SheetViewModel.

--- a/tests/WinPrint.TUI.UITests/Testing/EditorTesting.cs
+++ b/tests/WinPrint.TUI.UITests/Testing/EditorTesting.cs
@@ -1,0 +1,22 @@
+using System.Reflection;
+using Terminal.Gui.Views;
+using WinPrint.TUI.Views.Editors;
+
+namespace WinPrint.TUI.UnitTests.Testing;
+
+/// <summary>Test helpers for driving composed editor controls the way a user would.</summary>
+internal static class EditorTesting
+{
+    /// <summary>
+    ///     Selects <paramref name="value" /> in one of a <see cref="FontEditor" />'s composed dropdowns
+    ///     (referenced by private field name, e.g. <c>_family</c> / <c>_size</c>), simulating a user pick
+    ///     without the brittleness of sending key sequences through the driver.
+    /// </summary>
+    public static void SelectInDropDown(this FontEditor editor, string fieldName, string value)
+    {
+        FieldInfo field = typeof(FontEditor).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)
+                          ?? throw new InvalidOperationException($"FontEditor has no field '{fieldName}'.");
+        var dropDown = (DropDownList)field.GetValue(editor)!;
+        dropDown.Value = value;
+    }
+}


### PR DESCRIPTION
## Problem
In the TUI, changing the **content font** (or header/footer font) **face or size** did not relayout/reflow the preview, while margins, landscape, rows/cols did.

## Root cause
`FontEditor.PushFromChildren()` mutated the bound `Font` **in place**. `Font` is not a `ModelBase` and raises no `PropertyChanged`, so the editor's `Value` reference never changed — `EditorBase.SetValue` short-circuits on equal references and **never raised `ValueChanged`**. As a result the `SettingsPanel` `ContentFont`/`HeaderFooterFont` handlers (which write the font to the model and call `app.ReflowAsync()`) never ran. The working editors (margins/pages) assign a **new** value object, which is why they reflow.

## Fix
`FontEditor.PushFromChildren()` now builds a **new** `Font` (clone + apply family/size) and assigns it through `Value` — the same pattern `MarginEditor` uses. `ValueChanged` fires → the `SettingsPanel` handler writes the font through and reflows. `Font` has value equality, so an unchanged selection stays a no-op. One change fixes both the content and header/footer font editors.

## Tests (test-first — added failing, then fixed)
- `FontEditorGoldenTests.ChangingFamily_RaisesValueChanged_SoPreviewCanReflow` / `ChangingSize_…` — driving the family/size dropdown raises `ValueChanged` with the updated `Font` (other field preserved).
- `SettingsBindingTests.BoundPanel_ChangingContentFontWritesThroughToModel` — a dropdown change routes through to the live `ContentSettings.Font` (the same handler that calls `ReflowAsync`).
- New `Testing/EditorTesting.SelectInDropDown` drives the editor's composed dropdown like a user (no brittle key sequences).

Both new behavior tests fail on the old code (`ValueChanged` never fires) and pass on the fix. Full TUI UITests suite: **58/58**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)