### PR TITLE
feat(tui): real wp help, headless wp print, wp gui <file>, drop wp tui

### DIFF
--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -28,7 +28,9 @@ wp [options] [file...]
 |---------|-------------|
 | `wp file.cs` | Open a file in the TUI |
 | `wp` | Launch the TUI (terminal user interface) |
+| `wp print file.cs` | Print one or more files without opening the UI |
 | `wp gui` | Launch the graphical user interface on Windows/macOS |
+| `wp gui file.cs` | Launch the GUI with a file (and options) loaded |
 
 ### Examples
 
@@ -50,10 +52,24 @@ Pass print preview options:
 wp Program.cs --printer "Microsoft Print to PDF" --sheet "Default 2-Up"
 ```
 
+Print without opening the UI (use `--what-if` to count sheets without printing):
+
+```bash
+wp print Program.cs --printer "Microsoft Print to PDF" --sheet "Default 2-Up"
+wp print *.cs --landscape
+wp print Program.cs --what-if
+```
+
 Launch the GUI:
 
 ```bash
 wp gui
+```
+
+Launch the GUI with a file (and options) loaded:
+
+```bash
+wp gui ./testfiles/Program.cs --sheet "Default 2-Up"
 ```
 
 Get help:
@@ -79,9 +95,9 @@ apply everywhere:
 | `--to-sheet` | `-t` | Last sheet to print (use with `--from-sheet`). |
 | `--content-type` | `-e` | Content type engine / language override (e.g. `text/plain`, `text/html`, or a `<language>`). |
 
-Front ends add their own *appropriate* extras: the TUI adds `--view`, `--width`, `--height`; the `wp`
-print command adds `--line-numbers`, `--what-if` (`-w`, count sheets without printing), and
-`--config`; and the GUI launches through the separate `wp gui` command. The Terminal.Gui.Cli framework
+Front ends add their own *appropriate* extras: the interactive TUI adds `--view`, `--width`,
+`--height`; the `wp print` command adds `--what-if` (`-w`, count sheets without printing); and the
+GUI launches through the separate `wp gui` command. The Terminal.Gui.Cli framework
 — which the `wp` CLI/TUI uses for command-line handling — also provides `--help`, `--version`,
 `--opencli`, `--json`, `--output`, `--initial`, `--timeout`, and `--cat`.
 

--- a/src/WinPrint.TUI/CommandOptionsBinder.cs
+++ b/src/WinPrint.TUI/CommandOptionsBinder.cs
@@ -1,0 +1,47 @@
+using Terminal.Gui.Cli;
+using WinPrint.Core.Models;
+
+namespace WinPrint.TUI;
+
+/// <summary>
+///     Maps a parsed <see cref="CommandRunOptions" /> onto the shared <see cref="Options" /> model so
+///     every <c>wp</c> command (tui, print) applies the same canonical print options through the same
+///     <c>AppViewModel.ApplyOptions</c> path MAUI uses. Keeps the option names in exactly one place.
+/// </summary>
+internal static class CommandOptionsBinder
+{
+    public static Options ToOptions(CommandRunOptions options, IEnumerable<string>? files)
+    {
+        var fileList = files?.Where(f => !string.IsNullOrEmpty(f)).ToList();
+        return new Options
+        {
+            Files = fileList is { Count: > 0 } ? fileList : null,
+            Sheet = GetString(options, "sheet"),
+            Landscape = GetFlag(options, "landscape"),
+            Portrait = GetFlag(options, "portrait"),
+            Printer = GetString(options, "printer"),
+            PaperSize = GetString(options, "paper-size"),
+            FromPage = GetInt(options, "from-sheet"),
+            ToPage = GetInt(options, "to-sheet"),
+            ContentType = GetString(options, "content-type")
+        };
+    }
+
+    public static string? GetString(CommandRunOptions options, string name)
+    {
+        return options.CommandOptions.TryGetValue(name, out string? value) ? value : null;
+    }
+
+    public static bool GetFlag(CommandRunOptions options, string name)
+    {
+        return options.CommandOptions.TryGetValue(name, out string? value)
+               && value.Equals("true", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static int GetInt(CommandRunOptions options, string name)
+    {
+        return options.CommandOptions.TryGetValue(name, out string? value) && int.TryParse(value, out int result)
+            ? result
+            : 0;
+    }
+}

--- a/src/WinPrint.TUI/GuiCommand.cs
+++ b/src/WinPrint.TUI/GuiCommand.cs
@@ -1,11 +1,14 @@
 using System.ComponentModel;
 using Terminal.Gui.App;
 using Terminal.Gui.Cli;
+using WinPrint.Core;
 
 namespace WinPrint.TUI;
 
 /// <summary>
-///     Launches the packaged MAUI GUI from the <c>wp gui</c> command.
+///     Launches the packaged MAUI GUI from the <c>wp gui</c> command, forwarding any file arguments
+///     and shared print options to <c>winprint.exe</c> (which parses them with the same canonical
+///     option names). So <c>wp gui ./testfiles/Program.cs</c> opens the GUI with that file loaded.
 /// </summary>
 public sealed class GuiCommand : ICliCommand
 {
@@ -16,7 +19,7 @@ public sealed class GuiCommand : ICliCommand
     public IReadOnlyList<string> Aliases { get; } = ["gui"];
 
     /// <inheritdoc />
-    public string Description => "Open the WinPrint GUI.";
+    public string Description => "Open the WinPrint GUI (optionally on one or more files).";
 
     /// <inheritdoc />
     public CommandKind Kind => CommandKind.Input;
@@ -25,7 +28,16 @@ public sealed class GuiCommand : ICliCommand
     public Type ResultType => typeof(void);
 
     /// <inheritdoc />
-    public IReadOnlyList<CommandOptionDescriptor> Options { get; } = [];
+    public bool AcceptsPositionalArgs => true;
+
+    /// <inheritdoc />
+    // The same canonical print options the TUI exposes, so `wp gui --sheet … file` parses identically
+    // and shows up in `wp help gui`. They are forwarded to the GUI by their shared long names.
+    public IReadOnlyList<CommandOptionDescriptor> Options { get; } =
+    [
+        .. WinPrintOptions.Shared.Select(o =>
+            new CommandOptionDescriptor(o.Name, o.Short?.ToString(), o.ValueType, o.Help, false, null))
+    ];
 
     /// <inheritdoc />
     public Task<CommandResult> RunAsync(
@@ -34,9 +46,11 @@ public sealed class GuiCommand : ICliCommand
         CommandRunOptions options,
         CancellationToken cancellationToken)
     {
+        ArgumentNullException.ThrowIfNull(options);
+
         try
         {
-            GuiLauncher.Launch();
+            GuiLauncher.Launch(BuildArguments(options));
             return Task.FromResult(new CommandResult(CommandStatus.Ok, "Opened WinPrint GUI.", null, null));
         }
         catch (InvalidOperationException ex)
@@ -47,5 +61,36 @@ public sealed class GuiCommand : ICliCommand
         {
             return Task.FromResult(new CommandResult(CommandStatus.Error, null, ex.GetType().Name, ex.Message));
         }
+    }
+
+    // Reconstruct a command line for winprint.exe: positional files first, then any set print options
+    // by their canonical long names (winprint.exe parses these via CommandLineParser). Flags are
+    // emitted bare; valued options as `--name value`.
+    private static IReadOnlyList<string> BuildArguments(CommandRunOptions options)
+    {
+        List<string> args = [.. options.Arguments];
+
+        foreach (WinPrintOption option in WinPrintOptions.Shared)
+        {
+            if (!options.CommandOptions.TryGetValue(option.Name, out string? value) || string.IsNullOrEmpty(value))
+            {
+                continue;
+            }
+
+            if (option.ValueType == typeof(bool))
+            {
+                if (value.Equals("true", StringComparison.OrdinalIgnoreCase))
+                {
+                    args.Add($"--{option.Name}");
+                }
+            }
+            else
+            {
+                args.Add($"--{option.Name}");
+                args.Add(value);
+            }
+        }
+
+        return args;
     }
 }

--- a/src/WinPrint.TUI/GuiLauncher.cs
+++ b/src/WinPrint.TUI/GuiLauncher.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text;
 
 namespace WinPrint.TUI;
 
@@ -6,10 +7,16 @@ internal static class GuiLauncher
 {
     public static void Launch()
     {
+        Launch([]);
+    }
+
+    public static void Launch(IReadOnlyList<string> arguments)
+    {
         Launch(
             GetCurrentPlatform(),
             AppContext.BaseDirectory,
             Directory.GetCurrentDirectory(),
+            arguments,
             Directory.Exists,
             StartProcess);
     }
@@ -18,17 +25,20 @@ internal static class GuiLauncher
         GuiPlatform platform,
         string baseDirectory,
         string currentDirectory,
+        IReadOnlyList<string> arguments,
         Func<string, bool> directoryExists,
         Func<ProcessStartInfo, bool> startProcess)
     {
         switch (platform)
         {
             case GuiPlatform.Windows:
-                Start(Path.Combine(baseDirectory, "winprint.exe"), "", startProcess, directoryExists);
+                // winprint.exe parses its own args via Environment.GetCommandLineArgs() and resolves
+                // relative paths against the launch CWD, which the child inherits from this process.
+                Start(Path.Combine(baseDirectory, "winprint.exe"), QuoteArgs(arguments), startProcess, directoryExists);
                 return;
 
             case GuiPlatform.MacOS:
-                StartMacGui(baseDirectory, currentDirectory, directoryExists, startProcess);
+                StartMacGui(baseDirectory, currentDirectory, arguments, directoryExists, startProcess);
                 return;
 
             default:
@@ -51,17 +61,17 @@ internal static class GuiLauncher
     private static void StartMacGui(
         string baseDirectory,
         string currentDirectory,
+        IReadOnlyList<string> arguments,
         Func<string, bool> directoryExists,
         Func<ProcessStartInfo, bool> startProcess)
     {
+        // `open` forwards trailing tokens to the launched app only after a `--args` separator.
         string? appPath = FindMacAppBundle(baseDirectory, currentDirectory, directoryExists);
-        if (appPath is not null)
-        {
-            Start("open", appPath, startProcess, directoryExists);
-            return;
-        }
+        string appSpec = appPath is not null ? Quote(appPath) : "-a WinPrint";
+        string forwarded = QuoteArgs(arguments);
+        string openArgs = forwarded.Length == 0 ? appSpec : $"{appSpec} --args {forwarded}";
 
-        Start("open", "-a WinPrint", startProcess, directoryExists);
+        Start("open", openArgs, startProcess, directoryExists);
     }
 
     private static string? FindMacAppBundle(
@@ -110,6 +120,36 @@ internal static class GuiLauncher
         {
             throw new InvalidOperationException($"Could not launch {resolvedFileName}.");
         }
+    }
+
+    // UseShellExecute requires a single Arguments string (ArgumentList is ignored), so quote each
+    // token that contains whitespace or quotes and join with spaces.
+    private static string QuoteArgs(IReadOnlyList<string> arguments)
+    {
+        return string.Join(' ', arguments.Select(Quote));
+    }
+
+    private static string Quote(string value)
+    {
+        if (value.Length > 0 && !value.Any(c => char.IsWhiteSpace(c) || c == '"'))
+        {
+            return value;
+        }
+
+        var sb = new StringBuilder(value.Length + 2);
+        sb.Append('"');
+        foreach (char c in value)
+        {
+            if (c == '"')
+            {
+                sb.Append('\\');
+            }
+
+            sb.Append(c);
+        }
+
+        sb.Append('"');
+        return sb.ToString();
     }
 
     private static bool StartProcess(ProcessStartInfo startInfo)

--- a/src/WinPrint.TUI/Help/gui.md
+++ b/src/WinPrint.TUI/Help/gui.md
@@ -1,0 +1,20 @@
+# wp gui — graphical preview
+
+Launch the WinPrint MAUI GUI (Windows and macOS), optionally on one or more files. Any files and
+shared print options are forwarded to the GUI, which loads the first file and applies the options.
+
+```sh
+wp gui [options] [file…]
+```
+
+## Options
+
+{{OPTIONS}}
+
+## Examples
+
+```sh
+wp gui                                 # open the GUI
+wp gui ./testfiles/Program.cs          # open the GUI with a file loaded
+wp gui report.cs --sheet "Default 2-Up" --landscape
+```

--- a/src/WinPrint.TUI/Help/overview.md
+++ b/src/WinPrint.TUI/Help/overview.md
@@ -1,0 +1,36 @@
+# winprint — `wp` {{VERSION}}
+
+`wp` is winprint's cross-platform front end. Run it with **no command** to open the interactive
+print-preview TUI; pass a file to open it there directly. Use a subcommand to print headlessly or
+open the GUI.
+
+```sh
+wp [options] [file…]          # open the interactive TUI (optionally on a file) — the default
+wp print [options] [file…]    # print file(s) without opening the UI
+wp gui [options] [file…]      # open the MAUI GUI (Windows/macOS)
+```
+
+## Commands
+
+{{COMMANDS}}
+
+Run `wp help <command>` (e.g. `wp help print`) for a command's full options and examples.
+
+## Global Options
+
+These apply to every command. The canonical print options (`--sheet`, `--landscape`, …) are shared
+by the `wp` CLI, the TUI, and the MAUI GUI, so a name means the same thing everywhere.
+
+{{GLOBAL_OPTIONS}}
+
+## Examples
+
+```sh
+wp Program.cs                                      # preview a file in the TUI
+wp print Program.cs --printer "Microsoft Print to PDF" --sheet "Default 2-Up"
+wp print *.cs --landscape                          # print without the UI
+wp gui ./testfiles/Program.cs                      # open the GUI on a file
+wp --version
+```
+
+See `docs/users-guide.md` for sheet definitions, header/footer macros, and content types.

--- a/src/WinPrint.TUI/Help/print.md
+++ b/src/WinPrint.TUI/Help/print.md
@@ -1,0 +1,23 @@
+# wp print — headless printing
+
+Print one or more files directly to a printer **without opening the UI**. Files are loaded and the
+shared print options applied through the same engine and sheet definitions the TUI/GUI use, so the
+output matches the preview. With `--what-if`, `wp print` reports how many sheets each file would
+produce without sending anything to a printer.
+
+```sh
+wp print [options] [file…]
+```
+
+## Options
+
+{{OPTIONS}}
+
+## Examples
+
+```sh
+wp print Program.cs
+wp print Program.cs --printer "Microsoft Print to PDF" --sheet "Default 2-Up"
+wp print *.cs --landscape --from-sheet 1 --to-sheet 4
+wp print Program.cs --what-if      # count sheets without printing
+```

--- a/src/WinPrint.TUI/Help/tui.md
+++ b/src/WinPrint.TUI/Help/tui.md
@@ -1,0 +1,21 @@
+# wp — interactive preview (default)
+
+Running `wp` with no command opens the winprint interactive Terminal.Gui viewer. Pass a file to open
+it there directly — `wp Program.cs` is the normal way to preview a file. (`tui` is the internal name
+of this default command; you don't need to type it.)
+
+```sh
+wp [options] [file…]
+```
+
+## Options
+
+{{OPTIONS}}
+
+## Examples
+
+```sh
+wp Program.cs
+wp Program.cs --printer "Microsoft Print to PDF" --sheet "Default 2-Up"
+wp Program.cs --landscape --from-sheet 1 --to-sheet 4
+```

--- a/src/WinPrint.TUI/PrintCommand.cs
+++ b/src/WinPrint.TUI/PrintCommand.cs
@@ -1,0 +1,112 @@
+using System.Text;
+using Terminal.Gui.App;
+using Terminal.Gui.Cli;
+using WinPrint.Core;
+using WinPrint.Core.Abstractions;
+using WinPrint.Core.Models;
+
+namespace WinPrint.TUI;
+
+/// <summary>
+///     The <c>print</c> command: prints one or more files directly to a printer without opening the
+///     TUI. It loads each file and applies the shared print options through the same
+///     <c>AppViewModel.ApplyOptions</c> / <see cref="PrintOrchestrator" /> path the interactive UI
+///     uses, so headless output matches the preview. <c>--what-if</c> reports the sheet count without
+///     touching a printer.
+/// </summary>
+public sealed class PrintCommand : ICliCommand
+{
+    /// <inheritdoc />
+    public string PrimaryAlias => "print";
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> Aliases { get; } = ["print"];
+
+    /// <inheritdoc />
+    public string Description => "Print one or more files without opening the UI.";
+
+    /// <inheritdoc />
+    public CommandKind Kind => CommandKind.Input;
+
+    /// <inheritdoc />
+    public Type ResultType => typeof(void);
+
+    /// <inheritdoc />
+    public bool AcceptsPositionalArgs => true;
+
+    /// <inheritdoc />
+    // The shared canonical print options plus the print-only --what-if (count sheets, don't print).
+    public IReadOnlyList<CommandOptionDescriptor> Options { get; } =
+    [
+        .. WinPrintOptions.Shared.Select(o =>
+            new CommandOptionDescriptor(o.Name, o.Short?.ToString(), o.ValueType, o.Help, false, null)),
+        new("what-if", "w", typeof(bool), "Report how many sheets would print, without printing.", false, null)
+    ];
+
+    /// <inheritdoc />
+    public async Task<CommandResult> RunAsync(
+        IApplication app,
+        string? initial,
+        CommandRunOptions options,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (options.Arguments.Count == 0)
+        {
+            return new CommandResult(CommandStatus.Error, null, "NoFiles",
+                "Specify at least one file to print, e.g. `wp print Program.cs`.");
+        }
+
+        bool whatIf = CommandOptionsBinder.GetFlag(options, "what-if");
+        var output = new StringBuilder();
+        int totalSheets = 0;
+
+        try
+        {
+            foreach (string file in options.Arguments)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                totalSheets += await PrintOneAsync(file, options, whatIf, output).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or IOException or UnauthorizedAccessException)
+        {
+            return new CommandResult(CommandStatus.Error, output.ToString().TrimEnd(), ex.GetType().Name, ex.Message);
+        }
+
+        string verb = whatIf ? "would print" : "printed";
+        output.Append($"{options.Arguments.Count} file(s) {verb} {totalSheets} sheet(s).");
+        return new CommandResult(CommandStatus.Ok, output.ToString().TrimEnd(), null, null);
+    }
+
+    // Loads one file, applies the options, and either prints it or (for --what-if) counts its sheets.
+    // Returns the number of sheets printed / that would print, and appends a per-file line to output.
+    private static async Task<int> PrintOneAsync(
+        string file, CommandRunOptions options, bool whatIf, StringBuilder output)
+    {
+        var bound = CommandOptionsBinder.ToOptions(options, [file]);
+        var context = SettingsContext.Create(bound);
+
+        if (!await context.App.LoadFileAsync(file).ConfigureAwait(false))
+        {
+            throw new IOException($"Could not load '{file}'.");
+        }
+
+        if (whatIf)
+        {
+            PrintPlan plan = await PrintOrchestrator.PlanAsync(context.PrintService, context).ConfigureAwait(false);
+            output.AppendLine($"{file}: {plan.SelectedSheets} of {plan.TotalSheets} sheet(s) would print.");
+            return plan.SelectedSheets;
+        }
+
+        PrintJobResult result = await PrintOrchestrator.PrintAsync(context.PrintService, context).ConfigureAwait(false);
+        if (!result.Success)
+        {
+            throw new InvalidOperationException($"{file}: {result.Error ?? "print failed."}");
+        }
+
+        output.AppendLine($"{file}: printed {result.SheetsPrinted} sheet(s).");
+        return result.SheetsPrinted;
+    }
+}

--- a/src/WinPrint.TUI/PrintOrchestrator.cs
+++ b/src/WinPrint.TUI/PrintOrchestrator.cs
@@ -24,17 +24,39 @@ public static class PrintOrchestrator
             return PrintJobResult.Succeeded(0);
         }
 
+        PrintRequest request = await BuildRequestAsync(context).ConfigureAwait(false);
+        return await PrintPipeline.PrintAsync(printService, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     Reflows the document and returns the resulting <see cref="PrintPlan" /> without printing —
+    ///     the engine behind <c>wp print --what-if</c> (count sheets without touching a printer).
+    /// </summary>
+    public static async Task<PrintPlan> PlanAsync(IPrintService printService, SettingsContext context)
+    {
+        ArgumentNullException.ThrowIfNull(printService);
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (string.IsNullOrWhiteSpace(context.App.ActiveFile))
+        {
+            return new PrintPlan(context.App.CurrentPageSetup, 0, 0, 0);
+        }
+
+        PrintRequest request = await BuildRequestAsync(context).ConfigureAwait(false);
+        return await PrintPipeline.PlanAsync(printService, request).ConfigureAwait(false);
+    }
+
+    private static async Task<PrintRequest> BuildRequestAsync(SettingsContext context)
+    {
         SheetViewModel printSheet = await CreatePrintSheetAsync(context).ConfigureAwait(false);
         PrintPageSetup pageSetup = CopyPageSetup(context.App.CurrentPageSetup);
         string documentName = Path.GetFileName(context.App.ActiveFile);
 
-        var request = new PrintRequest(printSheet, pageSetup, documentName)
+        return new PrintRequest(printSheet, pageSetup, documentName)
         {
             FromSheet = pageSetup.FromSheet,
-            ToSheet = pageSetup.ToSheet,
+            ToSheet = pageSetup.ToSheet
         };
-
-        return await PrintPipeline.PrintAsync(printService, request, cancellationToken).ConfigureAwait(false);
     }
 
     private static async Task<SheetViewModel> CreatePrintSheetAsync(SettingsContext context)

--- a/src/WinPrint.TUI/Program.cs
+++ b/src/WinPrint.TUI/Program.cs
@@ -1,6 +1,6 @@
 // `wp` — winprint's Terminal.Gui front end, hosted on Terminal.Gui.Cli with real --help/--version,
-// global options, and a default command. `wp foo.cs` opens the interactive TUI for a file; `wp tui foo.cs` or
-// `wp --tui foo.cs` does the same.
+// global options, and a default command. `wp foo.cs` (or bare `wp`) opens the interactive TUI for a
+// file; `wp print foo.cs` prints headlessly; `wp gui` opens the MAUI GUI.
 
 using Serilog;
 using Terminal.Gui.Cli;
@@ -36,10 +36,18 @@ CliHost host = new(options =>
     options.DefaultCommand = "tui";
     options.GlobalOptions.Add(new GlobalOptionDescriptor("verbose", "v", "Write progress details to stderr.", true));
     options.GlobalOptions.Add(new GlobalOptionDescriptor("debug", null, "Write diagnostic details to stderr.", true));
-    options.GlobalOptions.Add(new GlobalOptionDescriptor("tui", null, "Open the interactive TUI (default).", true));
+
+    // The stock MetadataHelpProvider shows no per-command or custom-global options, so `wp help`
+    // looked empty. WpHelpProvider renders curated Markdown (from Help/*.md) with the command/option
+    // tables generated from these same descriptors so help can't drift from the real surface. `tui` is
+    // the default command (bare `wp` / `wp file` open it) and isn't advertised as its own subcommand.
+    options.HelpProvider = new WpHelpProvider(AppHostInfo.DisplayVersion, options.GlobalOptions, "tui");
 });
 
+// `tui` is registered because DefaultCommand must resolve to a real command (it backs bare `wp`),
+// but it's hidden from help — users open the TUI via `wp [file]`, print via `wp print`.
 host.Registry.Register(new TuiCommand());
+host.Registry.Register(new PrintCommand());
 host.Registry.Register(new GuiCommand());
 
 // Guard the whole run so an exception thrown during interactive teardown is logged and

--- a/src/WinPrint.TUI/TuiCommand.cs
+++ b/src/WinPrint.TUI/TuiCommand.cs
@@ -64,8 +64,8 @@ public sealed class TuiCommand : IViewerCommand
 
         // When an explicit --width/--height is given (e.g. tuirec driving a fixed capture size), pin the
         // driver's screen; otherwise the app fills the real terminal / PTY.
-        int width = GetInt(options, "width");
-        int height = GetInt(options, "height");
+        int width = CommandOptionsBinder.GetInt(options, "width");
+        int height = CommandOptionsBinder.GetInt(options, "height");
         if (width > 0 && height > 0)
         {
             app.Driver?.SetScreenSize(width, height);
@@ -159,38 +159,21 @@ public sealed class TuiCommand : IViewerCommand
     // Build either a single catalogued view (--view) or the full MainView bound to the file/options.
     private static View BuildContent(CommandRunOptions options)
     {
-        if (GetOption(options, "view") is { Length: > 0 } view)
+        if (CommandOptionsBinder.GetString(options, "view") is { Length: > 0 } view)
         {
             return ViewCatalog.Create(view);
         }
 
-        return new MainView(context: SettingsContext.Create(BuildOptions(options)));
-    }
-
-    // Map the parsed command options onto the shared winprint Options model so the TUI applies them
-    // through the same AppViewModel.ApplyOptions path MAUI and the CLI use.
-    private static Options BuildOptions(CommandRunOptions options)
-    {
         string? file = options.Arguments.Count > 0 ? options.Arguments[0] : null;
-        return new Options
-        {
-            Files = file is null ? null : [file],
-            Sheet = GetOption(options, "sheet"),
-            Landscape = GetFlag(options, "landscape"),
-            Portrait = GetFlag(options, "portrait"),
-            Printer = GetOption(options, "printer"),
-            PaperSize = GetOption(options, "paper-size"),
-            FromPage = GetInt(options, "from-sheet"),
-            ToPage = GetInt(options, "to-sheet"),
-            ContentType = GetOption(options, "content-type")
-        };
+        return new MainView(context: SettingsContext.Create(
+            CommandOptionsBinder.ToOptions(options, file is null ? null : [file])));
     }
 
     // --width/--height for --cat; fall back to the real terminal size, then a sane default.
     private static (int width, int height) ResolveSize(CommandRunOptions options)
     {
-        int width = GetInt(options, "width");
-        int height = GetInt(options, "height");
+        int width = CommandOptionsBinder.GetInt(options, "width");
+        int height = CommandOptionsBinder.GetInt(options, "height");
         return (width > 0 ? width : SafeWindow(() => Console.WindowWidth, 80),
             height > 0 ? height : SafeWindow(() => Console.WindowHeight, 30));
     }
@@ -241,23 +224,5 @@ public sealed class TuiCommand : IViewerCommand
     private static bool IsEnvEnabled(string name)
     {
         return Environment.GetEnvironmentVariable(name) is "1" or "true";
-    }
-
-    private static string? GetOption(CommandRunOptions options, string name)
-    {
-        return options.CommandOptions.TryGetValue(name, out string? value) ? value : null;
-    }
-
-    private static bool GetFlag(CommandRunOptions options, string name)
-    {
-        return options.CommandOptions.TryGetValue(name, out string? value)
-               && value.Equals("true", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static int GetInt(CommandRunOptions options, string name)
-    {
-        return options.CommandOptions.TryGetValue(name, out string? value) && int.TryParse(value, out int result)
-            ? result
-            : 0;
     }
 }

--- a/src/WinPrint.TUI/WinPrint.TUI.csproj
+++ b/src/WinPrint.TUI/WinPrint.TUI.csproj
@@ -40,6 +40,8 @@
 
     <ItemGroup>
         <EmbeddedResource Include="Resources\CaskaydiaCoveNFM-Regular.ttf" />
+        <!-- Curated Markdown help pages rendered by WpHelpProvider for the wp help command. -->
+        <EmbeddedResource Include="Help\*.md" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/WinPrint.TUI/WpHelpProvider.cs
+++ b/src/WinPrint.TUI/WpHelpProvider.cs
@@ -1,0 +1,182 @@
+using System.Reflection;
+using System.Text;
+using Terminal.Gui.Cli;
+
+namespace WinPrint.TUI;
+
+/// <summary>
+///     Custom <see cref="IHelpProvider" /> for <c>wp</c>, modeled on gui-cs/clet's
+///     <c>CletHelpProvider</c>. It renders curated Markdown help pages embedded from the
+///     <c>Help/</c> folder (whose prose mirrors <c>docs/users-guide.md</c>), while the command and
+///     option <em>tables</em> are generated dynamically from the live command registry / option
+///     descriptors so the help can never drift from the real CLI surface.
+///     <para>
+///         The stock <see cref="MetadataHelpProvider" /> lists neither per-command options nor the
+///         host's custom global options, and emits command help as a tab-separated run-on that
+///         Markdown collapses — which is why <c>wp help</c> showed no command-line options. Anything
+///         this provider doesn't author (e.g. the built-in <c>help</c> command) falls back to the
+///         metadata provider.
+///     </para>
+/// </summary>
+internal sealed class WpHelpProvider : IHelpProvider
+{
+    private readonly MetadataHelpProvider _fallback = new();
+    private readonly IReadOnlyList<GlobalOptionDescriptor> _globalOptions;
+    private readonly string? _hiddenAlias;
+    private readonly string _version;
+
+    public WpHelpProvider(string version, IReadOnlyList<GlobalOptionDescriptor> globalOptions,
+        string? hiddenAlias = null)
+    {
+        // Drop SemVer build metadata (everything after '+': branch/SHA) so the help banner stays tidy.
+        _version = version.Split('+', 2)[0];
+        _globalOptions = globalOptions;
+        _hiddenAlias = hiddenAlias;
+    }
+
+    /// <inheritdoc />
+    public string? GetRootHelp(ICommandRegistry registry)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+
+        return ReadResource("overview.md") is { } template
+            ? template
+                .Replace("{{VERSION}}", _version)
+                .Replace("{{COMMANDS}}", BuildCommandTable(registry))
+                .Replace("{{GLOBAL_OPTIONS}}", BuildGlobalOptionsTable())
+            : _fallback.GetRootHelp(registry);
+    }
+
+    /// <inheritdoc />
+    public string? GetCommandHelp(ICliCommand command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        return ReadResource($"{command.PrimaryAlias}.md") is { } template
+            ? template
+                .Replace("{{VERSION}}", _version)
+                .Replace("{{OPTIONS}}", BuildOptionsTable(command.Options, command.AcceptsPositionalArgs))
+            : _fallback.GetCommandHelp(command);
+    }
+
+    // One row per registered command, with a compact summary of each command's options so the root
+    // page actually advertises the surface. Aliases are rendered as `help:` links so the interactive
+    // browser (wp help) can navigate to each command's full page. The hidden alias (the `tui` default
+    // command, reached via bare `wp`) is omitted so it isn't presented as its own subcommand.
+    private string BuildCommandTable(ICommandRegistry registry)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("| Command | Description | Options |");
+        sb.AppendLine("|---------|-------------|---------|");
+        foreach (ICliCommand command in registry.All)
+        {
+            if (string.Equals(command.PrimaryAlias, _hiddenAlias, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            sb.AppendLine(
+                $"| [`{command.PrimaryAlias}`](help:{command.PrimaryAlias}) " +
+                $"| {EscapeCell(command.Description)} " +
+                $"| {EscapeCell(SummarizeOptions(command))} |");
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    // A compact, comma-joined list of an option's long names plus a [file…] hint — enough to hint at
+    // the surface in the root table; the per-command page carries the full descriptions.
+    private static string SummarizeOptions(ICliCommand command)
+    {
+        IEnumerable<string> names = command.Options.Select(o => $"`--{o.Name}`");
+        if (command.AcceptsPositionalArgs)
+        {
+            names = names.Append("`[file…]`");
+        }
+
+        return string.Join(", ", names);
+    }
+
+    private static string BuildOptionsTable(IReadOnlyList<CommandOptionDescriptor> options, bool acceptsPositionalArgs)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("| Option | Description |");
+        sb.AppendLine("|--------|-------------|");
+        if (acceptsPositionalArgs)
+        {
+            sb.AppendLine("| `[file…]` | One or more files to open (positional). |");
+        }
+
+        foreach (CommandOptionDescriptor option in options)
+        {
+            sb.AppendLine($"| `{FormatOption(option)}` | {EscapeCell(option.Description)} |");
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    // e.g. "-s, --sheet <string>", "-l, --landscape" (flags take no value), "--view <string>".
+    private static string FormatOption(CommandOptionDescriptor option)
+    {
+        string shortPart = string.IsNullOrEmpty(option.ShortName) ? string.Empty : $"-{option.ShortName}, ";
+        string valuePart = option.ValueType == typeof(bool) ? string.Empty : $" <{FriendlyType(option.ValueType)}>";
+        return $"{shortPart}--{option.Name}{valuePart}";
+    }
+
+    // The host's custom global options (--verbose/--debug) followed by the Terminal.Gui.Cli
+    // framework options — neither of which MetadataHelpProvider surfaces on the root page.
+    private string BuildGlobalOptionsTable()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("| Option | Description |");
+        sb.AppendLine("|--------|-------------|");
+        foreach (GlobalOptionDescriptor option in _globalOptions)
+        {
+            string shortPart = string.IsNullOrEmpty(option.ShortName) ? string.Empty : $"-{option.ShortName}, ";
+            string valuePart = option.IsFlag ? string.Empty : " <value>";
+            sb.AppendLine($"| `{shortPart}--{option.Name}{valuePart}` | {EscapeCell(option.Description)} |");
+        }
+
+        sb.AppendLine("| `--help`, `-h` | Show help. |");
+        sb.AppendLine("| `--version` | Show the installed version. |");
+        sb.AppendLine("| `--opencli` | Emit OpenCLI metadata JSON. |");
+        sb.AppendLine("| `--json` | Emit JSON envelope output. |");
+        sb.AppendLine("| `--cat` | Render viewer content to stdout instead of opening the UI. |");
+        return sb.ToString().TrimEnd();
+    }
+
+    private static string FriendlyType(Type type)
+    {
+        return type == typeof(int) ? "int" : type == typeof(bool) ? "bool" : "string";
+    }
+
+    private static string EscapeCell(string? value)
+    {
+        return string.IsNullOrEmpty(value)
+            ? string.Empty
+            : value.Replace("|", "\\|").Replace("\r\n", " ").Replace("\n", " ").Replace("\r", " ");
+    }
+
+    // Embedded resources are named "<RootNamespace>.Help.<file>"; match on suffix so a rename of the
+    // namespace or folder can't silently break lookup.
+    private static string? ReadResource(string fileName)
+    {
+        Assembly assembly = typeof(WpHelpProvider).Assembly;
+        string suffix = $".Help.{fileName}";
+        string? name = Array.Find(assembly.GetManifestResourceNames(),
+            n => n.EndsWith(suffix, StringComparison.Ordinal));
+        if (name is null)
+        {
+            return null;
+        }
+
+        using Stream? stream = assembly.GetManifestResourceStream(name);
+        if (stream is null)
+        {
+            return null;
+        }
+
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+}

--- a/tests/WinPrint.TUI.UnitTests/GuiLauncherTests.cs
+++ b/tests/WinPrint.TUI.UnitTests/GuiLauncherTests.cs
@@ -204,6 +204,11 @@ public class GuiLauncherTests
     [Fact]
     public void MacOS_ForwardsFilesAfterArgsSeparator()
     {
+        if (SkipOnWindows())
+        {
+            return;
+        }
+
         // `open <bundle> --args <files…>` forwards file arguments to the GUI; ArgumentList keeps each as a
         // discrete argv entry after the `--args` separator.
         List<ProcessStartInfo> starts = [];

--- a/tests/WinPrint.TUI.UnitTests/GuiLauncherTests.cs
+++ b/tests/WinPrint.TUI.UnitTests/GuiLauncherTests.cs
@@ -18,6 +18,18 @@ public class GuiLauncherTests
     }
 
     [Fact]
+    public void GuiCommand_AcceptsFilesAndSharedOptions()
+    {
+        var command = new GuiCommand();
+
+        // wp gui ./file.cs must be accepted as a positional file, and the shared print options
+        // (e.g. --sheet) must be advertised so they parse and show in `wp help gui`.
+        Assert.True(command.AcceptsPositionalArgs);
+        Assert.Contains(command.Options, o => o.Name == "sheet");
+        Assert.Contains(command.Options, o => o.Name == "landscape");
+    }
+
+    [Fact]
     public void Windows_LaunchesWinprintExeFromBaseDirectory()
     {
         // Windows-only: GuiLauncher relies on Path.IsPathFullyQualified, which is OS-specific — a
@@ -34,6 +46,7 @@ public class GuiLauncherTests
             GuiPlatform.Windows,
             @"C:\Apps\WinPrint",
             @"C:\Work",
+            [],
             _ => false,
             startInfo =>
             {
@@ -45,6 +58,34 @@ public class GuiLauncherTests
         Assert.Equal(@"C:\Apps\WinPrint\winprint.exe", start.FileName);
         Assert.Equal("", start.Arguments);
         Assert.True(start.UseShellExecute);
+    }
+
+    [Fact]
+    public void Windows_ForwardsFileArgumentsToWinprintExe()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        List<ProcessStartInfo> starts = [];
+
+        GuiLauncher.Launch(
+            GuiPlatform.Windows,
+            @"C:\Apps\WinPrint",
+            @"C:\Work",
+            ["./testfiles/Program.cs", "--sheet", "Default 2-Up"],
+            _ => false,
+            startInfo =>
+            {
+                starts.Add(startInfo);
+                return true;
+            });
+
+        ProcessStartInfo start = Assert.Single(starts);
+        Assert.Equal(@"C:\Apps\WinPrint\winprint.exe", start.FileName);
+        // The file is forwarded verbatim; the value containing a space is quoted.
+        Assert.Equal("./testfiles/Program.cs --sheet \"Default 2-Up\"", start.Arguments);
     }
 
     [Fact]
@@ -61,6 +102,7 @@ public class GuiLauncherTests
                 GuiPlatform.MacOS,
                 baseDirectory,
                 "/tmp",
+                [],
                 Directory.Exists,
                 startInfo =>
                 {
@@ -91,6 +133,7 @@ public class GuiLauncherTests
             GuiPlatform.MacOS,
             "/opt/winprint",
             "/tmp",
+            [],
             _ => false,
             startInfo =>
             {
@@ -104,6 +147,29 @@ public class GuiLauncherTests
     }
 
     [Fact]
+    public void MacOS_ForwardsFilesAfterArgsSeparator()
+    {
+        List<ProcessStartInfo> starts = [];
+
+        GuiLauncher.Launch(
+            GuiPlatform.MacOS,
+            "/opt/winprint",
+            "/tmp",
+            ["report.cs"],
+            _ => false,
+            startInfo =>
+            {
+                starts.Add(startInfo);
+                return true;
+            });
+
+        ProcessStartInfo start = Assert.Single(starts);
+        Assert.Equal("open", start.FileName);
+        // `open` forwards trailing tokens to the app only after `--args`.
+        Assert.Equal("-a WinPrint --args report.cs", start.Arguments);
+    }
+
+    [Fact]
     public void UnsupportedPlatform_ReportsGuiUnavailable()
     {
         InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() =>
@@ -111,6 +177,7 @@ public class GuiLauncherTests
                 GuiPlatform.Unsupported,
                 "/opt/winprint",
                 "/tmp",
+                [],
                 _ => false,
                 _ => true));
 

--- a/tests/WinPrint.TUI.UnitTests/PrintCommandTests.cs
+++ b/tests/WinPrint.TUI.UnitTests/PrintCommandTests.cs
@@ -1,0 +1,63 @@
+using Terminal.Gui.Cli;
+using WinPrint.TUI;
+using Xunit;
+
+namespace WinPrint.TUI.UnitTests;
+
+/// <summary>
+///     Verifies the headless <see cref="PrintCommand" /> (<c>wp print</c>): its CLI surface, the
+///     no-file usage error, and the <c>--what-if</c> path that counts sheets without touching a
+///     printer (so it runs cross-platform without print hardware).
+/// </summary>
+public class PrintCommandTests
+{
+    private static CommandRunOptions Run(IReadOnlyList<string> args, params (string Key, string Value)[] opts)
+    {
+        return new CommandRunOptions
+        {
+            Arguments = args,
+            CommandOptions = opts.ToDictionary(o => o.Key, o => o.Value)
+        };
+    }
+
+    [Fact]
+    public void AdvertisesPrintSurface()
+    {
+        var command = new PrintCommand();
+
+        Assert.Equal("print", command.PrimaryAlias);
+        Assert.Equal(CommandKind.Input, command.Kind);
+        Assert.True(command.AcceptsPositionalArgs);
+        Assert.Contains(command.Options, o => o.Name == "sheet");
+        Assert.Contains(command.Options, o => o is { Name: "what-if", ShortName: "w" });
+    }
+
+    [Fact]
+    public async Task NoFile_ReturnsUsageError()
+    {
+        CommandResult result = await new PrintCommand()
+            .RunAsync(null!, null, Run([]), CancellationToken.None);
+
+        Assert.Equal(CommandStatus.Error, result.Status);
+        Assert.Equal("NoFiles", result.ErrorCode);
+    }
+
+    [Fact]
+    public async Task WhatIf_CountsSheetsWithoutPrinting()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"wp-print-{Guid.NewGuid():N}.cs");
+        await File.WriteAllTextAsync(path, "class Program { static void Main() { } }\n");
+        try
+        {
+            CommandResult result = await new PrintCommand()
+                .RunAsync(null!, null, Run([path], ("what-if", "true")), CancellationToken.None);
+
+            Assert.Equal(CommandStatus.Ok, result.Status);
+            Assert.Contains("would print", result.Value as string);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/tests/WinPrint.TUI.UnitTests/WpHelpProviderTests.cs
+++ b/tests/WinPrint.TUI.UnitTests/WpHelpProviderTests.cs
@@ -1,0 +1,74 @@
+using Terminal.Gui.Cli;
+using WinPrint.TUI;
+using Xunit;
+
+namespace WinPrint.TUI.UnitTests;
+
+/// <summary>
+///     Verifies the custom <see cref="WpHelpProvider" /> surfaces the command-line options the stock
+///     <see cref="MetadataHelpProvider" /> omitted: per-command print options, positional file args,
+///     and the host's custom global options.
+/// </summary>
+public class WpHelpProviderTests
+{
+    private static readonly IReadOnlyList<GlobalOptionDescriptor> Globals =
+    [
+        new("verbose", "v", "Write progress details to stderr.", true),
+        new("debug", null, "Write diagnostic details to stderr.", true)
+    ];
+
+    private static WpHelpProvider Provider()
+    {
+        return new WpHelpProvider("9.9.9+Branch.develop.Sha.deadbeef", Globals);
+    }
+
+    private static ICommandRegistry Registry()
+    {
+        var registry = new CommandRegistry();
+        registry.Register(new TuiCommand());
+        registry.Register(new PrintCommand());
+        registry.Register(new GuiCommand());
+        return registry;
+    }
+
+    [Fact]
+    public void RootHelp_ListsCommandsAndCustomGlobalOptions()
+    {
+        string help = Provider().GetRootHelp(Registry())!;
+
+        Assert.Contains("`print`", help);
+        Assert.Contains("`gui`", help);
+        // Custom globals MetadataHelpProvider never showed.
+        Assert.Contains("--verbose", help);
+        Assert.Contains("--debug", help);
+        // Build metadata after '+' is trimmed from the banner.
+        Assert.Contains("9.9.9", help);
+        Assert.DoesNotContain("deadbeef", help);
+    }
+
+    [Fact]
+    public void RootHelp_HidesDefaultCommandAlias()
+    {
+        // `tui` is the default command (bare `wp`) and must not be advertised as its own subcommand.
+        var provider = new WpHelpProvider("9.9.9", Globals, "tui");
+
+        string help = provider.GetRootHelp(Registry())!;
+
+        Assert.DoesNotContain("`tui`", help);
+        Assert.Contains("`print`", help);
+        Assert.Contains("`gui`", help);
+    }
+
+    [Fact]
+    public void CommandHelp_RendersOptionsTableWithFileArgs()
+    {
+        string help = Provider().GetCommandHelp(new GuiCommand())!;
+
+        // A real Markdown table (header + at least one shared option), not the old run-on paragraph.
+        Assert.Contains("| Option | Description |", help);
+        Assert.Contains("-s, --sheet <string>", help);
+        Assert.Contains("-l, --landscape", help);
+        // gui accepts positional file arguments.
+        Assert.Contains("[file", help);
+    }
+}


### PR DESCRIPTION
## Why

- `wp help` showed **no command-line options**. With no `HelpProvider` set, the host fell back to Terminal.Gui.Cli's `MetadataHelpProvider`, whose root page lists only a bare command table + framework options, and whose per-command help was a tab-separated run-on that Markdown collapsed into one blob.
- `wp gui ./testfiles/Program.cs` ignored the file — the launcher always passed empty args.
- `wp tui` was redundant: bare `wp` already opens the TUI. What was missing was a way to **print without opening the UI**.

## What

**Help (`WpHelpProvider`)** — modeled on [gui-cs/clet](https://github.com/gui-cs/clet)'s `CletHelpProvider`. Renders curated embedded `Help/*.md` pages, with the command and option **tables generated dynamically** from the live registry/`CommandOptionDescriptor`s so help can't drift from the real surface. Falls back to `MetadataHelpProvider` for unauthored pages. `wp --help` now shows commands + a global-options table; `wp help <cmd>` shows a proper per-option table.

**`wp print [file…]`** — prints headlessly via the existing `SettingsContext → PrintOrchestrator → PrintPipeline` path (the same one the TUI's Print button uses). Takes the shared canonical print options plus `--what-if` (`-w`, count sheets without printing). `PrintOrchestrator.PlanAsync` factored out of `PrintAsync`.

**`wp gui [file…]`** — `GuiCommand` now accepts positional files + the shared options and forwards them (quoted) to `winprint.exe` / `open … --args`, which already parses a file argument.

**`tui` demoted** — it's still registered (the framework requires `DefaultCommand` to resolve to a real command; it backs bare `wp`), but hidden from help and no longer advertised. The redundant `--tui` global flag is removed.

Also: extracted `CommandOptionsBinder` so `tui`/`print` share one `CommandRunOptions → Options` mapping; updated `docs/users-guide.md`.

## Testing

- New `PrintCommandTests` (surface, no-file usage error, `--what-if` count) and `WpHelpProviderTests` (options/globals listed, default alias hidden, version trimmed); extended `GuiLauncherTests` for file forwarding. **50 TUI unit tests pass.**
- `dotnet format` clean; both TFMs build with 0 warnings.

> Note: actual printing to physical hardware wasn't exercised locally (no printer / packaged Windows build in-tree); the `--what-if` planning path is verified cross-platform, and the real print path is the same one the TUI Print button already uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)