### PR TITLE
feat(core): IFontEnumerationService; remove hardcoded FontChoices family list (#173)

### DIFF
--- a/src/WinPrint.Core/Models/FontChoices.cs
+++ b/src/WinPrint.Core/Models/FontChoices.cs
@@ -1,28 +1,13 @@
 namespace WinPrint.Core.Models;
 
 /// <summary>
-///     Curated choices for font editing. winprint has no cross-platform font-enumeration service, so
-///     the editor offers a practical list of common monospaced/printing font families and standard
-///     point sizes. The bound <see cref="Font.Family" /> is still a free-form string at the model
-///     level; these are only the picker's suggestions.
+///     Curated point-size suggestions for the font choosers. Font <em>families</em> are no longer curated
+///     here: they come from the installed-font enumeration service
+///     (<see cref="Services.IFontEnumerationService" />, issue #173). The bound <see cref="Font.Size" /> is
+///     still free-form at the model level; these are only the picker's suggestions.
 /// </summary>
 public static class FontChoices
 {
-    /// <summary>Common families suitable for source/document printing.</summary>
-    public static IReadOnlyList<string> Families { get; } =
-    [
-        "Source Code Pro",
-        "Cascadia Mono",
-        "Cascadia Code",
-        "Consolas",
-        "Courier New",
-        "JetBrains Mono",
-        "Fira Code",
-        "Menlo",
-        "DejaVu Sans Mono",
-        "Liberation Mono"
-    ];
-
     /// <summary>Standard point sizes.</summary>
     public static IReadOnlyList<float> Sizes { get; } =
         [6f, 7f, 8f, 9f, 10f, 11f, 12f, 14f, 16f, 18f, 20f, 24f];

--- a/src/WinPrint.Core/Services/IFontEnumerationService.cs
+++ b/src/WinPrint.Core/Services/IFontEnumerationService.cs
@@ -18,8 +18,9 @@ public interface IFontEnumerationService
 {
     /// <summary>
     ///     Returns the installed font families, de-duplicated and sorted by name, each flagged fixed-pitch.
-    ///     Implementations are expected to cache the result for the life of the process (the installed font
-    ///     set does not change while the app runs).
+    ///     The installed font set does not change while the app runs, so callers may treat the result as
+    ///     stable; implementations may cache it (the default <see cref="SystemFontEnumerator" /> caches per
+    ///     instance, and is registered as a singleton).
     /// </summary>
     IReadOnlyList<SystemFontFamily> GetFamilies();
 }

--- a/src/WinPrint.Core/Services/IFontEnumerationService.cs
+++ b/src/WinPrint.Core/Services/IFontEnumerationService.cs
@@ -1,0 +1,25 @@
+// Copyright Kindel, LLC - http://www.kindel.com
+// Published under the MIT License at https://github.com/tig/winprint
+
+namespace WinPrint.Core.Services;
+
+/// <summary>
+///     Enumerates the font families installed on the current system, each flagged with whether it is
+///     fixed-pitch (monospaced). This is the cross-platform font-enumeration service that
+///     <see cref="Models.FontChoices" /> noted was missing, so the font chooser can offer the user's actual
+///     fonts instead of a hard-coded list (issue #173).
+///     <para>
+///         Keeping enumeration behind an abstraction lets each front end / platform supply its own source
+///         while WinPrint.Core stays backend-agnostic. <see cref="SystemFontEnumerator" /> is
+///         the default, SkiaSharp-backed implementation and works on every platform WinPrint targets.
+///     </para>
+/// </summary>
+public interface IFontEnumerationService
+{
+    /// <summary>
+    ///     Returns the installed font families, de-duplicated and sorted by name, each flagged fixed-pitch.
+    ///     Implementations are expected to cache the result for the life of the process (the installed font
+    ///     set does not change while the app runs).
+    /// </summary>
+    IReadOnlyList<SystemFontFamily> GetFamilies();
+}

--- a/src/WinPrint.Core/Services/ServiceLocator.cs
+++ b/src/WinPrint.Core/Services/ServiceLocator.cs
@@ -22,6 +22,8 @@ public class ServiceLocator
 
     public UpdateService UpdateService => Services.UpdateService;
 
+    public IFontEnumerationService FontEnumerationService => Services.FontEnumerationService;
+
     public static void Reset()
     {
         s_current = null;

--- a/src/WinPrint.Core/Services/SystemFontEnumerator.cs
+++ b/src/WinPrint.Core/Services/SystemFontEnumerator.cs
@@ -6,24 +6,22 @@ using SkiaSharp;
 namespace WinPrint.Core.Services;
 
 /// <summary>
-///     Enumerates the installed font families and detects which are fixed-pitch (monospaced).
+///     Default <see cref="IFontEnumerationService" />: enumerates the installed font families and detects
+///     which are fixed-pitch (monospaced).
 ///     <para>
 ///         Uses SkiaSharp's <see cref="SKFontManager" />, which is available on every platform WinPrint
-///         targets (DirectWrite on Windows, CoreText on macOS, FreeType/Fontconfig on Linux). This is the
-///         cross-platform font-enumeration service that <see cref="Models.FontChoices" /> noted was missing,
-///         so the font chooser can offer the user's actual fonts instead of a hard-coded list.
+///         targets (DirectWrite on Windows, CoreText on macOS, FreeType/Fontconfig on Linux), so the font
+///         chooser can offer the user's actual fonts instead of a hard-coded list (issue #173). Resolved
+///         through the abstraction (see <see cref="WinPrintServices.FontEnumerationService" />) so a front
+///         end can substitute its own source.
 ///     </para>
 /// </summary>
-public static class SystemFontEnumerator
+public sealed class SystemFontEnumerator : IFontEnumerationService
 {
-    private static IReadOnlyList<SystemFontFamily>? _cache;
+    private IReadOnlyList<SystemFontFamily>? _cache;
 
-    /// <summary>
-    ///     Returns the installed font families, de-duplicated and sorted by name, each flagged with whether
-    ///     it is fixed-pitch. The result is cached for the life of the process (the installed font set does
-    ///     not change while the app runs).
-    /// </summary>
-    public static IReadOnlyList<SystemFontFamily> GetFamilies()
+    /// <inheritdoc />
+    public IReadOnlyList<SystemFontFamily> GetFamilies()
     {
         return _cache ??= Enumerate();
     }

--- a/src/WinPrint.Core/Services/WinPrintServices.cs
+++ b/src/WinPrint.Core/Services/WinPrintServices.cs
@@ -29,6 +29,13 @@ public sealed class WinPrintServices
 
     public UpdateService UpdateService { get; } = new();
 
+    /// <summary>
+    ///     Cross-platform installed-font enumeration for the font choosers (issue #173). The default is the
+    ///     SkiaSharp-backed <see cref="SystemFontEnumerator" />; the abstraction lets a front end substitute
+    ///     its own source.
+    /// </summary>
+    public IFontEnumerationService FontEnumerationService { get; } = new SystemFontEnumerator();
+
     public Options Options { get; } = new();
 
     public Settings Settings => _settings ??= SettingsService.ReadSettings() ?? Settings.CreateDefaultSettings();

--- a/src/WinPrint.Maui/Views/FontChooserPage.cs
+++ b/src/WinPrint.Maui/Views/FontChooserPage.cs
@@ -57,7 +57,7 @@ internal sealed class FontChooserPage : ContentPage
     {
         BackgroundColor = Color.FromRgba(0, 0, 0, 0.45);
 
-        _allFamilies = SystemFontEnumerator.GetFamilies();
+        _allFamilies = WinPrintServices.Current.FontEnumerationService.GetFamilies();
         _selectedFamily = currentFamily;
         _initialSize = currentSize;
         _fixedPitchOnly = preferFixedPitch;

--- a/src/WinPrint.TUI/Views/FontChooserDialog.cs
+++ b/src/WinPrint.TUI/Views/FontChooserDialog.cs
@@ -15,8 +15,9 @@ namespace WinPrint.TUI.Views;
 /// <summary>
 ///     Modal chooser for a content <see cref="Font" /> — family, point size, and <b>bold</b>/<b>italic</b>
 ///     style — with a <b>live preview</b> rasterized through the same render path the page preview uses
-///     (issue #177). The family list comes from the cross-platform <see cref="SystemFontEnumerator" />, with
-///     a fixed-pitch-only toggle that favors the monospaced faces source printing wants. The preview is a
+///     (issue #177). The family list comes from the cross-platform <see cref="IFontEnumerationService" />
+///     (issue #173), with a fixed-pitch-only toggle that favors the monospaced faces source printing wants.
+///     The preview is a
 ///     compact raster strip occupying the dialog's bottom <see cref="View.Padding" />, beside the buttons.
 ///     Confirm returns the chosen font; cancel/Esc discards.
 /// </summary>
@@ -64,7 +65,12 @@ public sealed class FontChooserDialog : Dialog
     public Font? SelectedFont { get; private set; }
 
     /// <summary>Creates the chooser seeded from <paramref name="current" />.</summary>
-    public FontChooserDialog(Font current)
+    /// <param name="current">The font to seed family, size, and style from.</param>
+    /// <param name="fontEnumeration">
+    ///     Installed-font source; defaults to <see cref="WinPrintServices.FontEnumerationService" />. Injectable
+    ///     so tests can supply a deterministic list instead of the host's actual fonts.
+    /// </param>
+    public FontChooserDialog(Font current, IFontEnumerationService? fontEnumeration = null)
     {
         ArgumentNullException.ThrowIfNull(current);
 
@@ -76,11 +82,9 @@ public sealed class FontChooserDialog : Dialog
         Width = Dim.Percent(72);
         Height = Dim.Auto(DimAutoStyle.Content, Dim.Absolute(14));
 
-        // Cross-platform enumeration; fall back to the curated list if the platform returns nothing.
-        IReadOnlyList<SystemFontFamily> families = SystemFontEnumerator.GetFamilies();
-        _allFamilies = families.Count > 0
-            ? families
-            : FontChoices.Families.Select(n => new SystemFontFamily(n, true)).ToList();
+        // Cross-platform enumeration of the user's actual installed fonts (issue #173).
+        IFontEnumerationService enumerator = fontEnumeration ?? WinPrintServices.Current.FontEnumerationService;
+        _allFamilies = enumerator.GetFamilies();
 
         // Top-left: fixed-pitch toggle. Source printing wants monospaced faces, so default it on — but the
         // current family is always kept selectable (see RebuildList) so a proportional pick survives.

--- a/tests/WinPrint.Core.UnitTests/Services/FontEnumerationServiceWiringTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Services/FontEnumerationServiceWiringTests.cs
@@ -1,0 +1,34 @@
+// Copyright Kindel, LLC - http://www.kindel.com
+// Published under the MIT License at https://github.com/tig/winprint
+
+using WinPrint.Core.Services;
+using Xunit;
+
+namespace WinPrint.Core.UnitTests.Services;
+
+/// <summary>
+///     Verifies the installed-font enumeration service is wired into the app's service registry (issue #173)
+///     so the font choosers resolve it instead of calling a concrete type.
+/// </summary>
+public class FontEnumerationServiceWiringTests
+{
+    [Fact]
+    public void WinPrintServices_ExposesDefaultEnumerator()
+    {
+        IFontEnumerationService service = WinPrintServices.Current.FontEnumerationService;
+
+        Assert.NotNull(service);
+        Assert.IsType<SystemFontEnumerator>(service);
+        Assert.NotEmpty(service.GetFamilies());
+    }
+
+    [Fact]
+    public void ServiceLocator_ReturnsSameInstanceAsWinPrintServices()
+    {
+        // ServiceLocator is the front-end-facing facade; it must delegate to the one WinPrintServices
+        // singleton so every caller shares the (cached) enumerator.
+        Assert.Same(
+            WinPrintServices.Current.FontEnumerationService,
+            ServiceLocator.Current.FontEnumerationService);
+    }
+}

--- a/tests/WinPrint.Core.UnitTests/Services/SystemFontEnumeratorTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Services/SystemFontEnumeratorTests.cs
@@ -14,10 +14,13 @@ namespace WinPrint.Core.UnitTests.Services;
 /// </summary>
 public class SystemFontEnumeratorTests
 {
+    // A fresh instance per test (xUnit news up the class each [Fact]); the instance caches across calls.
+    private readonly IFontEnumerationService _enumerator = new SystemFontEnumerator();
+
     [Fact]
     public void GetFamilies_ReturnsInstalledFamilies()
     {
-        IReadOnlyList<SystemFontFamily> families = SystemFontEnumerator.GetFamilies();
+        IReadOnlyList<SystemFontFamily> families = _enumerator.GetFamilies();
 
         Assert.NotEmpty(families);
         Assert.All(families, f => Assert.False(string.IsNullOrWhiteSpace(f.Name)));
@@ -26,8 +29,8 @@ public class SystemFontEnumeratorTests
     [Fact]
     public void GetFamilies_IsCachedAndSortedDistinct()
     {
-        IReadOnlyList<SystemFontFamily> first = SystemFontEnumerator.GetFamilies();
-        IReadOnlyList<SystemFontFamily> second = SystemFontEnumerator.GetFamilies();
+        IReadOnlyList<SystemFontFamily> first = _enumerator.GetFamilies();
+        IReadOnlyList<SystemFontFamily> second = _enumerator.GetFamilies();
 
         Assert.Same(first, second);
 
@@ -41,7 +44,7 @@ public class SystemFontEnumeratorTests
     {
         // Every platform WinPrint targets ships at least one monospaced family (Consolas/Courier New on
         // Windows, Menlo/Monaco/Courier on macOS, DejaVu/Liberation Mono on typical Linux).
-        IReadOnlyList<SystemFontFamily> families = SystemFontEnumerator.GetFamilies();
+        IReadOnlyList<SystemFontFamily> families = _enumerator.GetFamilies();
         Assert.Contains(families, f => f.IsFixedPitch);
     }
 
@@ -50,7 +53,7 @@ public class SystemFontEnumeratorTests
     {
         // The flag must mean what it says: in a family marked fixed-pitch a narrow and a wide glyph advance
         // identically; in one marked proportional they differ. Verify both directions against Skia directly.
-        IReadOnlyList<SystemFontFamily> families = SystemFontEnumerator.GetFamilies();
+        IReadOnlyList<SystemFontFamily> families = _enumerator.GetFamilies();
 
         SystemFontFamily? mono = families.FirstOrDefault(f => f.IsFixedPitch);
         if (mono is not null)
@@ -72,7 +75,7 @@ public class SystemFontEnumeratorTests
         // char as the same .notdef advance, which made the width-only test report them as monospace and
         // flooded the "fixed-pitch only" filter with non-mono faces. A real fixed-pitch family must contain
         // the glyphs it's being measured by.
-        IReadOnlyList<SystemFontFamily> families = SystemFontEnumerator.GetFamilies();
+        IReadOnlyList<SystemFontFamily> families = _enumerator.GetFamilies();
 
         foreach (SystemFontFamily family in families.Where(f => f.IsFixedPitch))
         {

--- a/tests/WinPrint.TUI.UITests/FakeFontEnumerationService.cs
+++ b/tests/WinPrint.TUI.UITests/FakeFontEnumerationService.cs
@@ -1,3 +1,6 @@
+// Copyright Kindel, LLC - http://www.kindel.com
+// Published under the MIT License at https://github.com/tig/winprint
+
 using WinPrint.Core.Services;
 
 namespace WinPrint.TUI.UnitTests;

--- a/tests/WinPrint.TUI.UITests/FakeFontEnumerationService.cs
+++ b/tests/WinPrint.TUI.UITests/FakeFontEnumerationService.cs
@@ -1,0 +1,18 @@
+using WinPrint.Core.Services;
+
+namespace WinPrint.TUI.UnitTests;
+
+/// <summary>
+///     A deterministic <see cref="IFontEnumerationService" /> for tests: returns exactly the families it
+///     was given, so a chooser's family list can be asserted without depending on the host's installed
+///     fonts.
+/// </summary>
+internal sealed class FakeFontEnumerationService(params SystemFontFamily[] families) : IFontEnumerationService
+{
+    private readonly IReadOnlyList<SystemFontFamily> _families = families;
+
+    public IReadOnlyList<SystemFontFamily> GetFamilies()
+    {
+        return _families;
+    }
+}

--- a/tests/WinPrint.TUI.UITests/FontChooserDialogTests.cs
+++ b/tests/WinPrint.TUI.UITests/FontChooserDialogTests.cs
@@ -38,17 +38,34 @@ public class FontChooserDialogTests
     public void Render_ListsFamiliesFromInjectedEnumerator()
     {
         // The family list must come from the IFontEnumerationService (issue #173), not a hard-coded list.
-        // Seed the dialog with a made-up fixed-pitch family that could only appear if the dialog sourced it
+        // Seed the dialog with made-up fixed-pitch families that could only appear if the dialog sourced them
         // from the injected enumerator (the default fixed-pitch filter keeps fixed-pitch families visible).
+        // The proportional family proves the default "Fixed Pitch Only" toggle actually filters the injected
+        // list rather than showing everything.
         var enumerator = new FakeFontEnumerationService(
             new SystemFontFamily("Nonexistent Mono", true),
-            new SystemFontFamily("Another Test Mono", true));
+            new SystemFontFamily("Another Test Mono", true),
+            new SystemFontFamily("Proportional Test Sans", false));
         var dialog = new FontChooserDialog(
             new Font { Family = "Nonexistent Mono", Size = 10f }, enumerator);
         var fixture = new AppFixture(dialog, 100, 30);
 
         DriverAssert.ContainsText(fixture.Screen, "Nonexistent Mono");
         DriverAssert.ContainsText(fixture.Screen, "Another Test Mono");
+        DriverAssert.DoesNotContainText(fixture.Screen, "Proportional Test Sans");
+    }
+
+    [Fact]
+    public void Render_WithEmptyEnumeration_KeepsSeededFamilySelectable()
+    {
+        // Removing the curated FontChoices.Families fallback (issue #173) means an empty enumeration yields
+        // an empty installed-font list. The chooser must degrade gracefully — not crash — and must still keep
+        // the seeded current family selectable so a configured font is never silently dropped.
+        var dialog = new FontChooserDialog(
+            new Font { Family = "Seeded Family", Size = 10f }, new FakeFontEnumerationService());
+        var fixture = new AppFixture(dialog, 100, 30);
+
+        DriverAssert.ContainsText(fixture.Screen, "Seeded Family");
     }
 
     [Fact]

--- a/tests/WinPrint.TUI.UITests/FontChooserDialogTests.cs
+++ b/tests/WinPrint.TUI.UITests/FontChooserDialogTests.cs
@@ -2,6 +2,7 @@ using Terminal.Gui.App;
 using Terminal.Gui.Drivers;
 using Terminal.Gui.Input;
 using WinPrint.Core.Models;
+using WinPrint.Core.Services;
 using WinPrint.TUI.UnitTests.Testing;
 using WinPrint.TUI.Views;
 using Xunit;
@@ -31,6 +32,23 @@ public class FontChooserDialogTests
         DriverAssert.ContainsText(fixture.Screen, "Italic");
         DriverAssert.ContainsText(fixture.Screen, "OK");
         DriverAssert.ContainsText(fixture.Screen, "Cancel");
+    }
+
+    [Fact]
+    public void Render_ListsFamiliesFromInjectedEnumerator()
+    {
+        // The family list must come from the IFontEnumerationService (issue #173), not a hard-coded list.
+        // Seed the dialog with a made-up fixed-pitch family that could only appear if the dialog sourced it
+        // from the injected enumerator (the default fixed-pitch filter keeps fixed-pitch families visible).
+        var enumerator = new FakeFontEnumerationService(
+            new SystemFontFamily("Nonexistent Mono", true),
+            new SystemFontFamily("Another Test Mono", true));
+        var dialog = new FontChooserDialog(
+            new Font { Family = "Nonexistent Mono", Size = 10f }, enumerator);
+        var fixture = new AppFixture(dialog, 100, 30);
+
+        DriverAssert.ContainsText(fixture.Screen, "Nonexistent Mono");
+        DriverAssert.ContainsText(fixture.Screen, "Another Test Mono");
     }
 
     [Fact]


### PR DESCRIPTION
Closes #173.

## What

Completes the deferred PR-183 follow-up: the font choosers now resolve installed fonts through a Core abstraction instead of calling a concrete type, and the hardcoded family list is gone.

PR #177/#183 already added the Skia-backed `SystemFontEnumerator` and the `FontChooserDialog`/`FontChooserPage`, but enumeration was a **static** call and `FontChoices.Families` lingered as a fallback. This PR finishes #173.

### Core abstraction
- **`IFontEnumerationService`** (`WinPrint.Core.Services`) — returns the installed `SystemFontFamily` list. Keeping enumeration behind an interface lets each front end / platform supply its own source while Core stays backend-agnostic.
- **`SystemFontEnumerator`** is now the default implementation: `sealed`, instance-based, with a per-instance cache (was a static class). The Skia probing logic is unchanged.
- Registered on **`WinPrintServices`** (`FontEnumerationService { get; } = new SystemFontEnumerator()`) and surfaced on **`ServiceLocator`** — explicit construction, AOT-friendly (no reflection), matching the existing service-registry pattern.

### Call sites
- **`FontChooserDialog`** resolves the service (defaults to `WinPrintServices.Current.FontEnumerationService`, but accepts an injected `IFontEnumerationService` for deterministic tests) and **drops the `FontChoices.Families` fallback**.
- **MAUI `FontChooserPage`** resolves the same service.

### FontChoices
- **`FontChoices.Families` removed entirely.** Only `FontChoices.Sizes` remains — curated point sizes aren't "installed fonts", so that list is legitimately static.

## Tests
- `SystemFontEnumeratorTests` converted to the interface (`new SystemFontEnumerator()` via `IFontEnumerationService`); cache assertion now per-instance.
- New `FontEnumerationServiceWiringTests` — `WinPrintServices`/`ServiceLocator` expose the default enumerator and return families.
- New `FontChooserDialogTests.Render_ListsFamiliesFromInjectedEnumerator` — injects a fake enumerator with made-up family names and asserts the dialog lists them, proving the source is the service and not a hardcoded list (`FakeFontEnumerationService` test double).

Local: Core + TUI build clean; full TUI.UITests green (72); font/wiring tests green. Style gate (`dotnet format` + `jb cleanupcode`) produces no diff. (The macOS box can't load `libgdiplus`, so the GDI+ `System.Drawing` Core tests fail locally for environment reasons only — they run on windows-latest CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)