### PR TITLE
feat(release): Windows arm64 build + installer (#187)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,11 @@ jobs:
           - os: windows-latest
             runtime: win-x64
             framework: net10.0-windows
+          # Native Windows arm64 runner (free for public repos) — gates the win-arm64 AOT TUI
+          # build on PRs so a regression surfaces here, not only at release (issue #187).
+          - os: windows-11-arm
+            runtime: win-arm64
+            framework: net10.0-windows
 
     steps:
       - name: Checkout source

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,10 @@ jobs:
   package:
     name: Package ${{ matrix.runtime }}
     runs-on: ${{ matrix.os }}
+    # An experimental leg (e.g. win-arm64 while it's being proven out) must NOT fail the whole
+    # release: continue-on-error lets the other arches still publish if it breaks. Remove the
+    # matrix `experimental` flag once the leg is reliable.
+    continue-on-error: ${{ matrix.experimental == true }}
 
     strategy:
       fail-fast: false
@@ -35,6 +39,22 @@ jobs:
             channel: win-x64
             mainExe: winprint.exe
             icon: packaging/windows/winprint.ico
+
+          # Windows arm64 on a NATIVE arm64 runner (windows-11-arm — free for public repos), so the
+          # AOT TUI links natively and the MAUI/WinUI3 GUI builds against arm64 WindowsAppSDK packs,
+          # mirroring how linux-arm64 uses ubuntu-24.04-arm. Marked experimental (continue-on-error
+          # above) until proven on real arm64 hardware — Velopack's win-arm64 packer is newer (see
+          # velopack#85). Issue #187.
+          - os: windows-11-arm
+            runtime: win-arm64
+            tuiFramework: net10.0-windows
+            includeGui: true
+            mauiFramework: net10.0-windows10.0.19041.0
+            mauiRuntime: win-arm64
+            channel: win-arm64
+            mainExe: winprint.exe
+            icon: packaging/windows/winprint.ico
+            experimental: true
 
           - os: macos-26
             runtime: osx-x64
@@ -518,7 +538,7 @@ jobs:
           identifier: Kindel.WinPrint
           version: ${{ steps.ver.outputs.version }}
           release-tag: ${{ github.ref_name }}
-          installers-regex: 'win-x64-Setup\.exe$'
+          installers-regex: 'win-(x64|arm64)-Setup\.exe$'
           token: ${{ secrets.WINGET_TOKEN }}
 
   # Update the Homebrew tap (kindel/homebrew-winprint) with the new TUI on every STABLE


### PR DESCRIPTION
Closes #187.

## What
Adds a **Windows arm64** build + installer to the release, so `winget` / direct download offer a native arm64 package alongside x64.

- **Release matrix**: new `win-arm64` leg on the **native `windows-11-arm`** runner (free for public repos — GA Aug 2025), mirroring how `linux-arm64` uses `ubuntu-24.04-arm`. AOT TUI links natively; the MAUI/WinUI3 GUI builds against arm64 WindowsAppSDK packs. Reuses the existing Velopack pack + Azure Trusted Signing path with its own `win-arm64` channel → ships `Kindel.WinPrint-win-arm64-Setup.exe`.
- **Non-blocking rollout**: the leg is **experimental** (`continue-on-error: ${{ matrix.experimental == true }}`). If arm64 breaks, x64/macOS/Linux still publish — it can't block a release. Remove the `experimental` flag once it's proven on real hardware.
- **PR CI signal**: added `win-arm64` to the `aot-publish` matrix so the arm64 AOT TUI compile is gated on every PR (not just at release).
- **winget**: widened `installers-regex` to `win-(x64|arm64)-Setup\.exe$` so the auto-update manifest includes both arches.

## Validation
I can't test Windows (let alone arm64) locally, so:
- ✅ **PR CI** (`aot-publish (win-arm64)`) validates the **arm64 AOT TUI** build natively.
- ⏳ The **GUI + Velopack + Azure signing** arm64 legs only run in `release.yml` — on a real tag, or a `workflow_dispatch` **from `develop`/`main`** (Azure OIDC federated creds only match those branches, not feature branches).

**Recommended before relying on it:** after merge to develop, trigger `release.yml` via `workflow_dispatch` from develop to dry-run the full matrix (incl. arm64 GUI/Velopack/sign). Because the leg is experimental, even a real release is safe — a broken arm64 leg just won't ship that arch.

Known risk: Velopack's win-arm64 packer is newer ([velopack#85](https://github.com/velopack/velopack/issues/85)) — hence the experimental gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)