### PR TITLE
docs: fix #184 documentation audit + fix `wp gui <file>` relative paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,12 +92,16 @@ artifacts in the tap:
 
 ## Content Type Engines (CTEs)
 CTEs live in `src/WinPrint.Core/ContentTypeEngines` and derive from
-`ContentTypeEngineBase`. They are discovered by reflection via `SupportedContentTypes`
-(`CreateContentTypeEngine`), **not** by the static `Create()` factories (which have no
-production callers). Engines:
+`ContentTypeEngineBase`. They are discovered via an **explicit registry**
+(`ContentTypeEngineRegistry`, AOT/trim-safe explicit factories) — `GetDerivedClassesCollection`
+returns `ContentTypeEngineRegistry.CreateAll()`, and `CreateContentTypeEngine` then matches an
+engine by `SupportedContentTypes`. This replaced the old reflection scan (`GetTypes()` +
+`Activator.CreateInstance`); the static `Create()` factories have no production callers. Engines:
 - `TextCte` (`text/plain`), `MarkdownCte` (`text/x-markdown`, subclasses `TextCte` and
   flattens Markdown via Markdig), `TextMateCte` (syntax highlighting; the default),
-  `AnsiCte`/`HtmlCte` (stubs after their native deps were removed).
+  `AnsiCte` (`text/ansi`; decodes ANSI escape sequences via the vendored managed `libvt100`)
+  and `HtmlCte` (`text/html` plus `.mhtml`/`.mht`; lays out HTML/CSS via the managed HtmlRenderer,
+  with `http(s)` assets gated behind `AllowRemoteResources`).
 
 ### Cross-platform rendering — the key design
 `System.Drawing.Common` is **Windows-only** (it P/Invokes GDI+/`gdiplus.dll`, absent on
@@ -136,20 +140,24 @@ double with a deterministic fixed-pitch measurement model — so the full
 Goal: ship **`WinPrint.TUI`/`wp` as Native AOT** with **`WinPrint.Core` AOT/trim-compatible**.
 `WinPrint.Maui` is **out of scope** — MAUI does not support Native AOT.
 
-> **As of this writing the spike + most of the work below is in PR #156** (Macros hand-rolled
-> resolver, explicit CTE registry, source-gen JSON, `WinPrintServices` DI, explicit `ModelBase`
-> copies, `IsAotCompatible`/`PublishAot`, an `aot-publish` CI matrix). Check whether #156 is merged
-> before starting any of this — the "decisions" below are the design it follows, kept as the record.
+> **Largely landed (the PR #156 work has merged to main).** `<IsAotCompatible>true</IsAotCompatible>`
+> is set on `WinPrint.Core` (trim analyzers run on every build) and RID-gated `<PublishAot>true</PublishAot>`
+> is set on `WinPrint.TUI` (active only when `RuntimeIdentifier` is set). The Macros hand-rolled
+> resolver, explicit CTE registry, source-gen JSON, and `WinPrintServices` DI container are in.
+> The per-item AOT/trim inventory lives in **[`docs/aot-inventory.md`](docs/aot-inventory.md)**; the
+> "decisions" below are the design record those changes follow.
 
-Decisions made (record of intent; revisit when work actually starts):
-- **Status: track only for now.** No AOT code changes yet. When starting, the first step is a
-  *spike*: set `<IsAotCompatible>true</IsAotCompatible>` on Core + `<PublishAot>true</PublishAot>`
-  on the CLI, build, and collect the trim/AOT analyzer warnings into an inventory to size the work.
+Decisions made (design record; most are now implemented):
+- **Status: in flight / largely landed.** `<IsAotCompatible>` on Core and RID-gated `<PublishAot>`
+  on the TUI are already on main, and most inventory items are cleared. Track remaining work in
+  [`docs/aot-inventory.md`](docs/aot-inventory.md).
 - **Target = cross-platform AOT** (Windows/Linux/macOS), not Windows-only. This requires a
   **non-`System.Drawing` measurement backend** (e.g. SkiaSharp) plugged into the existing
   `IGraphicsContext`/`MeasurementContext` seam — `System.Drawing` stays the Windows default.
 - **DI: drop MvvmLight `SimpleIoc`** (`ModelLocator`/`ServiceLocator`) in favor of **manual
-  construction**. MvvmLight is unmaintained and not trim-annotated.
+  construction**. MvvmLight is unmaintained and not trim-annotated. **Migration is partial:**
+  `WinPrintServices` exists, but `ModelLocator` is still used in `WinPrint.Core` (e.g.
+  `ContentTypeEngineBase`, view models) — not yet fully removed.
 - **TUI arg parsing stays on `Terminal.Gui.Cli`** (vet Terminal.Gui itself for AOT/trim).
 - **`Macros.cs`: rewrite with a hand-rolled resolver**, removing **`System.Linq.Dynamic.Core`**
   (runtime expression compiling — the one hard AOT blocker). May narrow exotic macro syntax to
@@ -159,8 +167,9 @@ Decisions made (record of intent; revisit when work actually starts):
 - **Update-check: redesign from the ground up and remove `Octokit`** (reflection/JSON-heavy).
 - **`CommandLineParser`: remove if unused** (verify no real callers, then drop the package).
 
-Other known AOT work (fall out of the spike):
+Other known AOT work (fall out of the spike; see [`docs/aot-inventory.md`](docs/aot-inventory.md)
+for current per-item state):
 - `ModelBase.CopyPropertiesFrom` + `TypeDescriptor.GetProperties` / `GetType().GetProperties()` —
   annotate with `[DynamicallyAccessedMembers]` or replace with generated/explicit copies.
-- CTE discovery (`GetTypes()` + `Activator.CreateInstance` in `ContentTypeEngineBase`) — root the
-  engine types or replace reflection with an explicit registry.
+- CTE discovery reflection — **done**: replaced by the explicit `ContentTypeEngineRegistry`
+  (was `GetTypes()` + `Activator.CreateInstance` in `ContentTypeEngineBase`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,12 +92,16 @@ artifacts in the tap:
 
 ## Content Type Engines (CTEs)
 CTEs live in `src/WinPrint.Core/ContentTypeEngines` and derive from
-`ContentTypeEngineBase`. They are discovered by reflection via `SupportedContentTypes`
-(`CreateContentTypeEngine`), **not** by the static `Create()` factories (which have no
-production callers). Engines:
+`ContentTypeEngineBase`. They are discovered via an **explicit registry**
+(`ContentTypeEngineRegistry`, AOT/trim-safe explicit factories) — `GetDerivedClassesCollection`
+returns `ContentTypeEngineRegistry.CreateAll()`, and `CreateContentTypeEngine` then matches an
+engine by `SupportedContentTypes`. This replaced the old reflection scan (`GetTypes()` +
+`Activator.CreateInstance`); the static `Create()` factories have no production callers. Engines:
 - `TextCte` (`text/plain`), `MarkdownCte` (`text/x-markdown`, subclasses `TextCte` and
   flattens Markdown via Markdig), `TextMateCte` (syntax highlighting; the default),
-  `AnsiCte`/`HtmlCte` (stubs after their native deps were removed).
+  `AnsiCte` (`text/ansi`; decodes ANSI escape sequences via the vendored managed `libvt100`)
+  and `HtmlCte` (`text/html` plus `.mhtml`/`.mht`; lays out HTML/CSS via the managed HtmlRenderer,
+  with `http(s)` assets gated behind `AllowRemoteResources`).
 
 ### Cross-platform rendering — the key design
 `System.Drawing.Common` is **Windows-only** (it P/Invokes GDI+/`gdiplus.dll`, absent on
@@ -136,20 +140,24 @@ double with a deterministic fixed-pitch measurement model — so the full
 Goal: ship **`WinPrint.TUI`/`wp` as Native AOT** with **`WinPrint.Core` AOT/trim-compatible**.
 `WinPrint.Maui` is **out of scope** — MAUI does not support Native AOT.
 
-> **As of this writing the spike + most of the work below is in PR #156** (Macros hand-rolled
-> resolver, explicit CTE registry, source-gen JSON, `WinPrintServices` DI, explicit `ModelBase`
-> copies, `IsAotCompatible`/`PublishAot`, an `aot-publish` CI matrix). Check whether #156 is merged
-> before starting any of this — the "decisions" below are the design it follows, kept as the record.
+> **Largely landed (the PR #156 work has merged to main).** `<IsAotCompatible>true</IsAotCompatible>`
+> is set on `WinPrint.Core` (trim analyzers run on every build) and RID-gated `<PublishAot>true</PublishAot>`
+> is set on `WinPrint.TUI` (active only when `RuntimeIdentifier` is set). The Macros hand-rolled
+> resolver, explicit CTE registry, source-gen JSON, and `WinPrintServices` DI container are in.
+> The per-item AOT/trim inventory lives in **[`docs/aot-inventory.md`](docs/aot-inventory.md)**; the
+> "decisions" below are the design record those changes follow.
 
-Decisions made (record of intent; revisit when work actually starts):
-- **Status: track only for now.** No AOT code changes yet. When starting, the first step is a
-  *spike*: set `<IsAotCompatible>true</IsAotCompatible>` on Core + `<PublishAot>true</PublishAot>`
-  on the CLI, build, and collect the trim/AOT analyzer warnings into an inventory to size the work.
+Decisions made (design record; most are now implemented):
+- **Status: in flight / largely landed.** `<IsAotCompatible>` on Core and RID-gated `<PublishAot>`
+  on the TUI are already on main, and most inventory items are cleared. Track remaining work in
+  [`docs/aot-inventory.md`](docs/aot-inventory.md).
 - **Target = cross-platform AOT** (Windows/Linux/macOS), not Windows-only. This requires a
   **non-`System.Drawing` measurement backend** (e.g. SkiaSharp) plugged into the existing
   `IGraphicsContext`/`MeasurementContext` seam — `System.Drawing` stays the Windows default.
 - **DI: drop MvvmLight `SimpleIoc`** (`ModelLocator`/`ServiceLocator`) in favor of **manual
-  construction**. MvvmLight is unmaintained and not trim-annotated.
+  construction**. MvvmLight is unmaintained and not trim-annotated. **Migration is partial:**
+  `WinPrintServices` exists, but `ModelLocator` is still used in `WinPrint.Core` (e.g.
+  `ContentTypeEngineBase`, view models) — not yet fully removed.
 - **TUI arg parsing stays on `Terminal.Gui.Cli`** (vet Terminal.Gui itself for AOT/trim).
 - **`Macros.cs`: rewrite with a hand-rolled resolver**, removing **`System.Linq.Dynamic.Core`**
   (runtime expression compiling — the one hard AOT blocker). May narrow exotic macro syntax to
@@ -159,8 +167,9 @@ Decisions made (record of intent; revisit when work actually starts):
 - **Update-check: redesign from the ground up and remove `Octokit`** (reflection/JSON-heavy).
 - **`CommandLineParser`: remove if unused** (verify no real callers, then drop the package).
 
-Other known AOT work (fall out of the spike):
+Other known AOT work (fall out of the spike; see [`docs/aot-inventory.md`](docs/aot-inventory.md)
+for current per-item state):
 - `ModelBase.CopyPropertiesFrom` + `TypeDescriptor.GetProperties` / `GetType().GetProperties()` —
   annotate with `[DynamicallyAccessedMembers]` or replace with generated/explicit copies.
-- CTE discovery (`GetTypes()` + `Activator.CreateInstance` in `ContentTypeEngineBase`) — root the
-  engine types or replace reflection with an explicit registry.
+- CTE discovery reflection — **done**: replaced by the explicit `ContentTypeEngineRegistry`
+  (was `GetTypes()` + `Activator.CreateInstance` in `ContentTypeEngineBase`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,21 +130,29 @@ WinPrint uses [GitVersion](https://gitversion.net/) for automatic semantic versi
 
 Releases are fully automated via CI:
 
-1. Merge your changes to the release branch.
-2. Create and push a version tag:
+1. Merge `develop` → `main`. (There is no `release` branch.)
+2. Create and push a version tag **on the merge commit**. The tag **must be annotated**
+   (`git tag -a`) — a lightweight tag will not drive the release/versioning correctly:
    ```bash
-   git tag v2.6.0
+   git tag -a v2.6.0 -m "Release 2.6.0"
    git push origin v2.6.0
    ```
 3. CI automatically:
    - Builds for Windows, macOS, and Linux
-   - Signs the binaries (using configured secrets)
+   - Signs the **Windows** binaries (Azure Trusted Signing via OIDC). macOS is **not**
+     signed/notarized today — the `APPLE_*` secrets are not configured ([#162]) and the
+     `.app` ships unsigned/ad-hoc.
    - Creates a GitHub Release with all assets
    - Produces winget and Homebrew-ready artifacts/templates
 
+[#162]: https://github.com/tig/winprint/issues/162
+
 ### Signing secrets (for forks)
 
-If you fork this repository and want to produce signed builds, configure the following repository secrets:
+If you fork this repository and want to produce signed builds, configure the following repository secrets.
+
+**Windows signing works today** (Azure Trusted Signing via GitHub OIDC — no client secret).
+See [`docs/code-signing.md`](docs/code-signing.md):
 
 | Secret | Description |
 |--------|-------------|
@@ -154,6 +162,14 @@ If you fork this repository and want to produce signed builds, configure the fol
 | `AZURE_SIGNING_ACCOUNT` | Azure Trusted Signing account name |
 | `AZURE_SIGNING_PROFILE` | Azure Trusted Signing certificate profile |
 | `AZURE_SIGNING_ENDPOINT` | Azure Trusted Signing endpoint |
+
+**macOS signing is NOT configured on this repo** ([#162]): the `APPLE_*` secrets below are
+**not** set, so the macOS `.app` currently ships **unsigned/ad-hoc** (Gatekeeper warns).
+The release workflow already supports these secrets — set them on a fork to enable
+Developer ID signing + notarization:
+
+| Secret | Description |
+|--------|-------------|
 | `APPLE_CERTIFICATE_BASE64` | Base64-encoded Apple Developer ID `.p12` certificate |
 | `APPLE_CERTIFICATE_PASSWORD` | Password for the `.p12` certificate |
 | `APPLE_ID` | Apple Developer account email |
@@ -161,4 +177,4 @@ If you fork this repository and want to produce signed builds, configure the fol
 | `APPLE_TEAM_ID` | Apple Developer team ID |
 | `APPLE_SIGNING_IDENTITY` | Developer ID Application signing identity |
 
-Without these secrets, CI will still build successfully but binaries will be unsigned.
+Without these secrets, CI will still build successfully but the affected binaries will be unsigned.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ You can also find **WinPrint** in the Start Menu (Windows) or via Spotlight (mac
 
 ## Features
 
-* Prints source code with syntax highlighting and line numbering using bundled TextMate grammars.
+* Prints source code in hundreds of programming languages with syntax highlighting and line numbering.
 * Prints HTML files.
 * Prints "multiple-pages-up" on one piece of paper (saves trees!)
 * Complete control over page formatting options, including headers and footers, margins, fonts, page orientation, etc.
@@ -76,7 +76,6 @@ You can also find **WinPrint** in the Start Menu (Windows) or via Spotlight (mac
 * Simple and elegant graphical user interface with accurate print preview on Windows and macOS.
 * `wp` provides a terminal UI on Windows, macOS, and Linux.
 * `wp gui` launches the GUI on Windows and macOS.
-* The legacy PowerShell `Out-WinPrint` CmdLet (`WinPrint.PowerShell.dll`) has been removed; use `wp` instead.
 * Sheet Definitions make it easy to save settings for frequent print jobs.
 * Comprehensive logging.
 * Cross-platform TUI; Windows and macOS GUI; Linux GUI is deferred.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You can also find **WinPrint** in the Start Menu (Windows) or via Spotlight (mac
 * Simple and elegant graphical user interface with accurate print preview on Windows and macOS.
 * `wp` provides a Terminal.Gui-based terminal UI on Windows, macOS, and Linux.
 * `wp gui` launches the MAUI GUI on Windows and macOS.
-* The legacy PowerShell `Out-WinPrint` CmdLet remains available as `WinPrint.PowerShell.dll`, but is deprecated in favor of `wp`.
+* The legacy PowerShell `Out-WinPrint` CmdLet (`WinPrint.PowerShell.dll`) has been removed; use `wp` instead.
 * Sheet Definitions make it easy to save settings for frequent print jobs.
 * Comprehensive logging.
 * Cross-platform TUI; Windows and macOS GUI; Linux GUI is deferred.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Human and AI Agent friendly print utility with syntax highlighting, multiple pag
 
 <img width="1102" alt="WinPrint GUI on macOS" src="docs/hero-gui.gif" />
 
-*The MAUI GUI on Windows and macOS: visual print preview, settings, and `wp gui` to launch from the terminal.*
+*The GUI on Windows and macOS: visual print preview, settings, and `wp gui` to launch from the terminal.*
 
 > Regenerate these demos: `scripts/record-hero-gifs.sh` (tuirec for TUI/print; macOS screen capture for GUI).
 
@@ -74,8 +74,8 @@ You can also find **WinPrint** in the Start Menu (Windows) or via Spotlight (mac
 * Complete control over page formatting options, including headers and footers, margins, fonts, page orientation, etc.
 * Headers and Footers support detailed file and print information macros with rich date/time formatting.
 * Simple and elegant graphical user interface with accurate print preview on Windows and macOS.
-* `wp` provides a Terminal.Gui-based terminal UI on Windows, macOS, and Linux.
-* `wp gui` launches the MAUI GUI on Windows and macOS.
+* `wp` provides a terminal UI on Windows, macOS, and Linux.
+* `wp gui` launches the GUI on Windows and macOS.
 * The legacy PowerShell `Out-WinPrint` CmdLet (`WinPrint.PowerShell.dll`) has been removed; use `wp` instead.
 * Sheet Definitions make it easy to save settings for frequent print jobs.
 * Comprehensive logging.
@@ -91,7 +91,7 @@ You can also find **WinPrint** in the Start Menu (Windows) or via Spotlight (mac
 
 ## Graphical Interface
 
-The MAUI GUI is available on Windows and macOS via `wp gui`.
+The GUI is available on Windows and macOS via `wp gui`.
 
 ![WinPrint](https://tig.github.io/winprint/winprint2.png)
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,5 @@
 title: WinPrint
-description: winprint - Advanced source code and text file printing for PowerShell.
+description: winprint - Advanced source code and text file printing for terminals (all platforms) and Windows/macOS GUIs.
 logo: https://tig.github.io/winprint/winprint-icon.png
 theme: jekyll-theme-dinky
 google_analytics: UA-4945529-9

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -21,7 +21,7 @@
         </p>
         {%- if site.author %}
         <ul class="contact-list">
-          <li class="=p-name">By <a href="https://x.com/tigkindel">Tig Kindel</a>]</li>
+          <li class="p-name">By <a href="https://x.com/tigkindel">Tig Kindel</a></li>
           {% if site.author.name -%}
           <li class="p-name">{{ site.author.name | escape }}</li>
           {% endif -%}

--- a/docs/about.md
+++ b/docs/about.md
@@ -22,7 +22,7 @@ Then, after shipping the most popular framework for building terminal (TUI) apps
 
 This is WinPrint 3.0. I hope you enjoy it!
 
--tig ([@tigkindel](twitter.com/tigkindel) on X; see my [blog](https://blog.kindel.com))
+-tig ([@tigkindel](https://twitter.com/tigkindel) on X; see my [blog](https://blog.kindel.com))
 
 ## License (MIT)
 

--- a/docs/aot-inventory.md
+++ b/docs/aot-inventory.md
@@ -1,7 +1,17 @@
-# Native AOT inventory (issue #66, PR 0 spike)
+# Native AOT inventory (issue #66)
 
 Spike date: 2026-06-21  
 Target: `WinPrint.TUI` (`wp`) + `WinPrint.Core`, cross-platform (`net10.0` / `net10.0-windows`).
+
+**Status (current): in flight — most items landed.** `<IsAotCompatible>true</IsAotCompatible>` is set
+on `WinPrint.Core` and RID-gated `<PublishAot>true</PublishAot>` on `WinPrint.TUI` (both on main).
+The original spike build failed at `WinPrint.Core` with **35 IL diagnostics** (recorded below as the
+baseline); since then P1 (Macros), P2 (CTE registry), P5 (`Assembly.Location`), and P8 (cross-platform
+measurement wiring) are **done**, clearing the bulk of those errors. Remaining open items: P3 (JSON /
+config `.Bind()`), P4 (`ModelBase` reflection), P6 (DI — `WinPrintServices` exists but `ModelLocator`
+is **still used in Core**, so the SimpleIoc migration is partial), and link-time verification
+(P9/P10). The per-item state below is the source of truth; the "spike result" table is the historical
+baseline, not the current count.
 
 ## Infrastructure changes (this PR)
 
@@ -26,9 +36,12 @@ Without `/p:IsAotCompatible=true`, only the TUI entry-point issues surface (curr
 
 Full log: `artifacts/aot-spike/osx-arm64.log`
 
-## Spike result
+## Spike result (baseline — 2026-06-21, historical)
 
-**Build failed at `WinPrint.Core` compile** (35 IL analyzer diagnostics, promoted to errors by `TreatWarningsAsErrors`). The TUI project and Native AOT linker were never reached.
+> This is the original spike snapshot. Several items below have since been fixed (see per-item state
+> in **Findings by work item**); the counts here are the starting baseline, not the current tally.
+
+**The spike build failed at `WinPrint.Core` compile** (35 IL analyzer diagnostics, promoted to errors by `TreatWarningsAsErrors`). The TUI project and Native AOT linker were never reached.
 
 | IL code | Count | Meaning |
 |---------|-------|---------|
@@ -79,11 +92,12 @@ Replaced assembly scan with explicit `ContentTypeEngineRegistry` (AnsiCte, HtmlC
 
 Added `AppHostInfo` (`AppContext.BaseDirectory`, assembly attributes for version/company/product). Updated `SettingsService`, `LogService`, `UpdateService`, `TelemetryService`, `WinPrint.TUI/Program.cs`.
 
-### P6 — MvvmLight `SimpleIoc` (no IL warnings yet)
+### P6 — MvvmLight `SimpleIoc` (no IL warnings yet) — PARTIAL
 
-`ServiceLocator` / `ModelLocator` use `GalaSoft.MvvmLight.Ioc.SimpleIoc` — not flagged at compile time but unmaintained and not trim-annotated. Expect link-time trimming issues once Core compiles.
+`ServiceLocator` / `ModelLocator` use `GalaSoft.MvvmLight.Ioc.SimpleIoc` — not flagged at compile time but unmaintained and not trim-annotated. Expect link-time trimming issues until removed.
 
-- Fix: `WinPrintServices` with explicit manual construction (PR 4)
+- Fix: `WinPrintServices` with explicit manual construction.
+- **State:** `WinPrintServices` exists, but `ModelLocator` is **still referenced across `WinPrint.Core`** (`ContentTypeEngineBase`, view models, services). MvvmLight is not yet fully removed — migration is in progress.
 
 ### P7 — CommandLineParser on `Options` (no IL warnings)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,8 +49,8 @@ wp gui
 * Complete control over page formatting options, including headers and footers, margins, fonts, page orientation, etc.
 * Headers and Footers support detailed file and print information macros with rich date/time formatting.
 * Simple and elegant graphical user interface with accurate print preview on Windows and macOS.
-* `wp` provides a Terminal.Gui-based terminal UI on Windows, macOS, and Linux.
-* `wp gui` launches the MAUI GUI on Windows and macOS.
+* `wp` provides a terminal UI on Windows, macOS, and Linux.
+* `wp gui` launches the GUI on Windows and macOS.
 * Sheet Definitions make it easy to save settings for frequent print jobs.
 * Comprehensive logging.
 * Cross-platform TUI; Windows and macOS GUI

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,8 +22,12 @@ Advanced source code and text file printing for terminals (all platforms) and Wi
 # Install (Windows)
 winget install Kindel.WinPrint
 
-# Install (Mac) — GUI app, also bundles the `wp` TUI
+# Install (Mac) — GUI cask, which also bundles the `wp` TUI
 brew tap kindel/winprint && brew install winprint
+# Want only the `wp` CLI (no GUI)? Install the formula instead — pick one, they collide:
+#   brew install kindel/winprint/wp
+# The .app is not notarized yet; if Gatekeeper says "WinPrint is damaged", run:
+#   xattr -dr com.apple.quarantine /Applications/WinPrint.app
 
 # Open a file in the TUI
 wp program.cs

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ wp gui
 
 ## Features
 
-* Prints source code with syntax highlighting and line numbering using bundled TextMate grammars.
+* Prints source code in hundreds of programming languages with syntax highlighting and line numbering.
 * Prints HTML files.
 * Prints "multiple-pages-up" on one piece of paper (saves trees!)
 * Complete control over page formatting options, including headers and footers, margins, fonts, page orientation, etc.

--- a/docs/install.md
+++ b/docs/install.md
@@ -45,13 +45,18 @@ brew tap kindel/winprint
 brew install winprint
 ```
 
-This installs the **WinPrint GUI** (a notarized Developer ID `.app`), which **also bundles the `wp`
+This installs the **WinPrint GUI** cask (the `.app`), which **also bundles the `wp`
 terminal UI** — so one command gives you both the app and the `wp` command on your `PATH`. No
 `--cask` flag needed. (Prefer a one-liner? `brew install kindel/winprint/winprint` taps and installs
 in a single step.)
 
-> Want only the `wp` CLI, without the GUI app? `brew install kindel/winprint/wp`. (Don't install
-> both `winprint` and `wp` — they each provide `wp` and collide.)
+> Want only the `wp` CLI, without the GUI app? `brew install kindel/winprint/wp` installs the
+> CLI-only **formula**. (Don't install both the `winprint` cask and the `wp` formula — they each
+> provide `wp` and collide at link time; pick one on macOS.)
+
+> **Note:** the macOS `.app` is **not notarized yet** (Apple signing isn't configured), so it ships
+> ad-hoc signed and Gatekeeper may quarantine it on first launch — see
+> [Troubleshooting](#troubleshooting) below.
 
 ### Prerequisites
 
@@ -59,11 +64,11 @@ No additional prerequisites are required for basic operation. For printing, macO
 
 ### Upgrade
 
-The macOS GUI is a notarized Developer ID `.app` distributed via the Homebrew cask, so Homebrew
-handles updates (there is no in-app self-updater on macOS):
+The macOS GUI is distributed via the Homebrew cask, so Homebrew handles updates (there is no in-app
+self-updater on macOS):
 
 ```bash
-brew upgrade winprint
+brew upgrade --cask winprint
 ```
 
 ### Uninstall
@@ -134,5 +139,21 @@ wp --version
 ## Troubleshooting
 
 If `wp` is not found after installation, ensure the install location is in your `PATH`. On Windows, you may need to restart your terminal. On macOS/Linux, Homebrew handles this automatically.
+
+### macOS: "WinPrint is damaged…" / Gatekeeper quarantine
+
+The macOS `.app` is **not notarized yet**, so it ships ad-hoc signed. On first launch macOS
+Gatekeeper may quarantine it and report that **"WinPrint is damaged and can't be opened"**. Clear
+the quarantine attribute to launch it:
+
+```bash
+xattr -dr com.apple.quarantine /Applications/WinPrint.app
+```
+
+Because the cask comes from a third-party tap, you may also need to trust it at install time:
+
+```bash
+brew install --cask kindel/winprint/winprint
+```
 
 For additional help, see [Support](support.md) or file an [issue on GitHub](https://github.com/tig/winprint/issues).

--- a/docs/install.md
+++ b/docs/install.md
@@ -18,7 +18,7 @@ No additional prerequisites are required on Windows. WinPrint is a self-containe
 
 ### Upgrade
 
-WinPrint packages are built with Velopack. Installed builds can use Velopack-managed updates, and winget can also upgrade the installed package:
+Installed builds include a built-in updater, and winget can also upgrade the installed package:
 
 You can also upgrade manually:
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -30,16 +30,17 @@ improve the app. This is **off by default** and can be turned off at any time.
 
 ## Update checks and downloads
 
-When you download or update WinPrint (for example via the Microsoft Store, the Mac
-App Store, GitHub Releases, winget, or Homebrew), those services operate under their
-own privacy policies and may receive standard network information such as your IP
-address as an inherent part of serving the download.
+When you download or update WinPrint (for example via GitHub Releases, winget, or
+Homebrew — with app-store distribution such as the Microsoft Store or Mac App Store
+planned for the future), those services operate under their own privacy policies and
+may receive standard network information such as your IP address as an inherent part
+of serving the download.
 
 ## Third parties
 
 WinPrint relies on: Microsoft Azure Application Insights (optional diagnostics, above),
-and your chosen distribution channel (Microsoft Store, Apple App Store, GitHub,
-winget, or Homebrew) for installation and updates.
+and your chosen distribution channel (GitHub Releases, winget, or Homebrew today;
+Microsoft Store and Apple App Store planned) for installation and updates.
 
 ## Children
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -11,6 +11,6 @@
 * Suggest improvements: Use [GitHub Issues](https://github.com/tig/winprint/issues).
 * Download the source and submit pull requests: [winprint on GitHub](https://github.com/tig/winprint).
 
-**winprint** writes extensive diagnostic logs to `%appdata%/Kindel Systems/WinPrint/logs`. When using `winprint`, specify `--debug`. The deprecated PowerShell command line (`out-winprint`) still supports `-Debug`.
+**winprint** writes diagnostic logs to a `logs` folder alongside its settings. On Windows that's `%appdata%\Kindel\winprint\logs` (or next to the executable when running in portable mode); on macOS and Linux the `logs` folder sits next to the `wp` executable (inside `WinPrint.app` for the GUI). Run the `wp` command line with `--debug` for more detail.
 
-Additional printing diagnostics can be turned on via settings in the `WinPrint.Config.json` configuration file.
+Additional printing diagnostics can be turned on via settings in the `WinPrint.config.json` configuration file.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -217,11 +217,11 @@ The **winprint** GUI can be used to change many Sheet Definition settings. All s
 
 **winprint** supports five types of files. Support for each is provided by a **winprint** Content Type Engine (CTE):
 
-1. **`TextMateCte`** - This is the default CTE used for most text and source files. It uses bundled TextMate grammars for syntax highlighting and requires no external tools (no Python).
+1. **`TextMateCte`** - This is the default CTE used for most text and source files. It uses bundled TextMate grammars for syntax highlighting.
 
 2. **`MarkdownCte`** - Renders Markdown files (`text/x-markdown`; e.g. `.md`).
 
-3. **`AnsiCte`** - Decodes files containing `ANSI Escape Sequences` (`text/ansi`; e.g. `.ans`/`.ansi` ANSI-art and colorized console captures), reflowing them for the page. Requires no external tools (no Python).
+3. **`AnsiCte`** - Decodes files containing `ANSI Escape Sequences` (`text/ansi`; e.g. `.ans`/`.ansi` ANSI-art and colorized console captures), reflowing them for the page.
 
 4. **`TextCte`** - This CTE knows only how to print raw `text/plain` files. The format of the printed text can be changed (e.g. to turn off line numbers or use a different font). Lines that are too long for a page are wrapped at character boundaries. `\f` (form feed) characters can be made to cause following text to print on the next page (this is off by default). Settings for `text/plain` can be changed by editing the `textContentTypeEngineSettings` section or a Sheet Definition in `WinPrint.config.json`.
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -104,14 +104,14 @@ GUI launches through the separate `wp gui` command. The Terminal.Gui.Cli framewo
 This consistency is enforced by tests: the canonical surface lives in `WinPrint.Core` and every front
 end derives its parser from it (see `WinPrintOptionsConsistencyTests`).
 
-### Deprecated PowerShell CmdLet
+### Overriding Content Type / Language
 
-The PowerShell CmdLet (`Out-WinPrint`) is deprecated. Prefer `wp` for new scripts and automation.
+Use `--content-type` (alias `-e`) to override **winprint**'s automatic content type and language
+detection. The value can be a content type (e.g. `text/plain`, `text/html`) or a language alias:
 
-If you still need the deprecated CmdLet, import it into PowerShell:
-
-```powershell
-Import-Module '<install-path>\WinPrint.PowerShell.dll'
+```bash
+wp print README --content-type text/x-markdown
+wp print notes.txt -e text/html
 ```
 
 ## Graphical User Interface
@@ -153,9 +153,9 @@ Font choices, header/footer options, and other print-job settings are defined in
 
 This is called "n-up" printing. The most common form of "n-up" printing is "2-up" where the page orientation is set to landscape and there are two columns of pages.
 
-The layout and format of the **Sheet** is defined by a set of configuration settings called a **Sheet Definition**. Out of the box **winprint** comes with two: `Default 1 Up` and `Default 2 Up`.
+The layout and format of the **Sheet** is defined by a set of configuration settings called a **Sheet Definition**. Out of the box **winprint** comes with two: `Default 1-Up` and `Default 2-Up`.
 
-**Sheet Definitions** are defined and stored in the `WinPrint.config.json` configuration file found in `%appdata%\Kindel Systems\winprint`.
+**Sheet Definitions** are defined and stored in the `WinPrint.config.json` configuration file. On Windows this file lives in `%appdata%\Kindel\winprint`; on macOS and Linux **winprint** runs in portable mode and the file sits next to the application (the `wp` executable, or inside `WinPrint.app` for the GUI).
 
 ### Headers & Footers Macros
 
@@ -181,7 +181,7 @@ The following macros are supported:
 
 * **`{FileNameWithoutExtension}`** - The file name of the file without the extension and period ".".
 
-* **`{FileName}`** - The name of file without the extension.
+* **`{FileName}`** - The name of the file including the extension. If a Title was not provided, the Title will be used.
 
 * **`{Title}`** - The Title of the print request. If Title was not provided, the FileName will be used.
 
@@ -194,6 +194,8 @@ The following macros are supported:
 * **`{ContentType}`** - The file's content type (e.g. `text/plain`, `text/x-csharp`, or `text/x-smalltalk`).
 
 * **`{CteName}`** - The name of the **winprint** Content Type Engine used to render the file.
+
+* **`{Style}`** - The style used for formatting (e.g. `default` or `colorful`).
 
 * **`{DatePrinted}`** - The current date & time (see formatting below).
 
@@ -215,19 +217,21 @@ The **winprint** GUI can be used to change many Sheet Definition settings. All s
 
 ## Content Types
 
-**winprint** supports three types of files. Support for each is provided by a **winprint** Content Type Engine (CTE):
+**winprint** supports five types of files. Support for each is provided by a **winprint** Content Type Engine (CTE):
 
 1. **`TextMateCte`** - This is the default CTE used for most text and source files. It uses bundled TextMate grammars for syntax highlighting and does not require Python or Pygments.
 
-2. **`AnsiCte`** - This legacy CTE can format `text/plain` files and files with embedded `ANSI Escape Sequences`. It uses [Pygments](https://pygments.org/) for syntax highlighting when explicitly configured as the default syntax highlighter.
+2. **`MarkdownCte`** - Renders Markdown (`text/x-markdown`; e.g. `.md` files), formatting the document via [Markdig](https://github.com/xoofx/markdig).
 
-3. **`TextCte`** - This CTE knows only how to print raw `text/plain` files. The format of the printed text can be changed (e.g. to turn off line numbers or use a different font). Lines that are too long for a page are wrapped at character boundaries. `\r` (formfeed) characters can be made to cause following text to print on the next page (this is off by default). Settings for `text/plain` can be changed by editing the `textContentTypeEngineSettings` section or a Sheet Definition in `WinPrint.config.json`.
+3. **`AnsiCte`** - Decodes files containing `ANSI Escape Sequences` (`text/ansi`; e.g. `.ans`/`.ansi` ANSI-art and colorized console captures). It uses the vendored, managed `libvt100` ANSI decoder — no Python and no Pygments required.
 
-4. **`text/html`** - This CTE can render html files. Any CSS specified inline in the HTML file will be honored. External CSS files must be local. For HTML without CSS, the default CSS used can be overridden by providing a file named `winprint.css` in the `%appdata%\Kindel Systems\winprint` folder. `text/html` does not support line numbers.
+4. **`TextCte`** - This CTE knows only how to print raw `text/plain` files. The format of the printed text can be changed (e.g. to turn off line numbers or use a different font). Lines that are too long for a page are wrapped at character boundaries. `\f` (form feed) characters can be made to cause following text to print on the next page (this is off by default). Settings for `text/plain` can be changed by editing the `textContentTypeEngineSettings` section or a Sheet Definition in `WinPrint.config.json`.
 
-When using **winprint** from the command line, the `-ContentTypeEngine` parameter can be used specify a CTE to use.
+5. **`HtmlCte`** - Renders HTML files (`text/html`; e.g. `.html`/`.htm`, as well as `.mhtml`/`.mht` web archives) by laying out HTML/CSS through the pure-managed HtmlRenderer engine. Any CSS specified inline in the HTML file will be honored. Local (document-relative) files, `data:` URIs, and MHTML-embedded resources always load; `http(s)` resources are only fetched when `AllowRemoteResources` is enabled. `text/html` does not support line numbers.
 
-The extension of the file being printed (e.g. `.cs`) determines which Content Type rendering engine will be used. **winprint** has a built-in library of hundreds of file extension to content type/language mappings. When using **winprint** from the command line, the `-Langauge` parameter can be used to override this behavior.
+When using **winprint** from the command line, the `--content-type` (`-e`) option can be used to specify the content type / CTE to use.
+
+The extension of the file being printed (e.g. `.cs`) determines which Content Type rendering engine will be used. **winprint** has a built-in library of hundreds of file extension to content type/language mappings. When using **winprint** from the command line, the `--content-type` (`-e`) option can be used to override this behavior.
 
 To associate a file extension with a particular Content Type Engine, modify the `fileTypeMapping.filesAssociations` section of `WinPrint.config.json`. For example, to associate files with a `.htm` extension with the `text/html` Content Type Engine add a line as shown below:
 
@@ -241,7 +245,7 @@ To associate a file extension with a particular Content Type Engine, modify the 
 
 For associating file extensions with a particular programming language see below.
 
-The `out-winprint` parameter `-ContentTypeEngine` and the `wp --content-type` option override content type and language detection.
+The `wp --content-type` (`-e`) option overrides content type and language detection.
 
 ## Language Associations
 
@@ -249,32 +253,32 @@ The `out-winprint` parameter `-ContentTypeEngine` and the `wp --content-type` op
 
 ### Adding or Changing Language Associations
 
-To associate a file extension with a language, modify the `fileTypeMapping.filesAssociations` and `fileTypeMapping.contentTypes` sections of `WinPrint.config.json`. For example, to associate files with a `.INTERCAL` extension with the JSON language add a line as shown below:
+To associate a file extension with a content type, modify the `fileTypeMapping.filesAssociations` section of `WinPrint.config.json`. For example, to associate files with a `.json5` extension with the JSON content type add a line as shown below:
 
 ```json
     "fileTypeMapping": {
       "filesAssociations": {
-        "*.intercal": "JSON"
+        "*.json5": "text/x-json"
       }
     }
 ```
 
-A new language can be defined by modifying the `fileTypeMapping.contentTypes` section of `WinPrint.config.json`. For example, to enable the [Icon Programming Language](https://en.wikipedia.org/wiki/Icon_%28programming_language%29), the `fileTypeMapping.filesAssociations` and `fileTypeMapping.contentTypes` sections would look like the following:
+A new content type can be defined by modifying the `fileTypeMapping.contentTypes` section of `WinPrint.config.json`. For example, to enable the [Icon Programming Language](https://en.wikipedia.org/wiki/Icon_%28programming_language%29), the `fileTypeMapping.filesAssociations` and `fileTypeMapping.contentTypes` sections would look like the following:
 
 ```json
     "fileTypeMapping": {
       "filesAssociations": {
-        "*.intercal": "text/x-INTERCAL"
+        "*.icn": "text/x-icon"
       },
       "contentTypes": [
         {
-          "id": "text/x-INTERCAL",
-          "title": "Compiler Language With No Pronounceable Acronym",
+          "id": "text/x-icon",
+          "title": "Icon Programming Language",
           "extensions": [
-            "*.intercal"
+            "*.icn"
           ],
           "aliases": [
-              "INTERCAL"
+              "icon"
           ]
         }
       ]
@@ -283,25 +287,9 @@ A new language can be defined by modifying the `fileTypeMapping.contentTypes` se
 
 For TextMate highlighting to work, the mapped language must resolve to a bundled TextMate grammar. If it does not, **winprint** still prints the file as plain text.
 
-
-```json
-    "languages": [
-      {
-        "id": "text/x-INTERCAL",
-        "title": "Smalltalk",
-        "extensions": [
-          "*.intercal"
-        ],
-        "aliases": [
-            "INTERCAL"
-        ]
-      }
-    ]
-```
-
 ## Logging & Diagnostics
 
-**winprint** writes extensive diagnostic logs to `%appdata%/Kindel Systems/WinPrint/logs`. When using `winprint`, specify `--debug`. The deprecated PowerShell CmdLet still supports `-Debug`.
+**winprint** writes diagnostic logs to a `logs` folder alongside its settings. On Windows that's `%appdata%\Kindel\winprint\logs` (or next to the executable when running in portable mode); on macOS and Linux the `logs` folder sits next to the `wp` executable (inside `WinPrint.app` for the GUI). Run the `wp` command line with `--debug` for more detail.
 
 Additional printing diagnostics can be turned on via settings in the configuration file.
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -2,7 +2,7 @@
 
 ## Features
 
-* Prints source code with syntax highlighting and line numbering using bundled TextMate grammars.
+* Prints source code in hundreds of programming languages with syntax highlighting and line numbering.
 * Prints HTML files.
 * Prints "multiple-pages-up" on one piece of paper (saves trees!)
 * Complete control over page formatting options, including headers and footers, margins, fonts, page orientation, etc.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -8,15 +8,15 @@
 * Complete control over page formatting options, including headers and footers, margins, fonts, page orientation, etc.
 * Headers and Footers support detailed file and print information macros with rich date/time formatting.
 * Simple and elegant graphical user interface with accurate print preview on Windows and macOS.
-* `wp` provides a Terminal.Gui-based terminal UI on Windows, macOS, and Linux.
-* `wp gui` launches the MAUI GUI on Windows and macOS.
+* `wp` provides a terminal UI on Windows, macOS, and Linux.
+* `wp gui` launches the GUI on Windows and macOS.
 * Sheet Definitions make it easy to save settings for frequent print jobs.
 * Comprehensive logging.
 * Cross-platform TUI; Windows and macOS GUI; Linux GUI is deferred.
 
 ## Command Line Interface
 
-The primary command for WinPrint is `wp`. It provides a Terminal.Gui-based terminal UI.
+The primary command for WinPrint is `wp`. It provides a terminal UI.
 
 ```bash
 wp [options] [file...]
@@ -81,7 +81,7 @@ wp --help
 ### CLI Options
 
 **winprint** exposes one **canonical set of print options across every front end** — the `wp` CLI, the
-TUI, and the MAUI `gui` on Windows and macOS. The same name, short alias, and meaning
+TUI, and the `gui` on Windows and macOS. The same name, short alias, and meaning
 apply everywhere:
 
 | Option | Alias | Description |
@@ -97,12 +97,10 @@ apply everywhere:
 
 Front ends add their own *appropriate* extras: the interactive TUI adds `--view`, `--width`,
 `--height`; the `wp print` command adds `--what-if` (`-w`, count sheets without printing); and the
-GUI launches through the separate `wp gui` command. The Terminal.Gui.Cli framework
-— which the `wp` CLI/TUI uses for command-line handling — also provides `--help`, `--version`,
-`--opencli`, `--json`, `--output`, `--initial`, `--timeout`, and `--cat`.
+GUI launches through the separate `wp gui` command. The `wp` command line also provides `--help`,
+`--version`, `--opencli`, `--json`, `--output`, `--initial`, `--timeout`, and `--cat`.
 
-This consistency is enforced by tests: the canonical surface lives in `WinPrint.Core` and every front
-end derives its parser from it (see `WinPrintOptionsConsistencyTests`).
+The same print options behave identically across the `wp` CLI, the TUI, and the GUI.
 
 ### Overriding Content Type / Language
 
@@ -132,7 +130,7 @@ The GUI provides an easy-to-use interface for previewing how a file will be prin
 
 ## Auto-Update
 
-WinPrint packages are built with Velopack, which provides the install/update engine for packaged builds.
+WinPrint's packaged builds include a built-in install/update engine.
 
 You can also update manually using your package manager:
 
@@ -219,15 +217,15 @@ The **winprint** GUI can be used to change many Sheet Definition settings. All s
 
 **winprint** supports five types of files. Support for each is provided by a **winprint** Content Type Engine (CTE):
 
-1. **`TextMateCte`** - This is the default CTE used for most text and source files. It uses bundled TextMate grammars for syntax highlighting and does not require Python or Pygments.
+1. **`TextMateCte`** - This is the default CTE used for most text and source files. It uses bundled TextMate grammars for syntax highlighting and requires no external tools (no Python).
 
-2. **`MarkdownCte`** - Renders Markdown (`text/x-markdown`; e.g. `.md` files), formatting the document via [Markdig](https://github.com/xoofx/markdig).
+2. **`MarkdownCte`** - Renders Markdown files (`text/x-markdown`; e.g. `.md`).
 
-3. **`AnsiCte`** - Decodes files containing `ANSI Escape Sequences` (`text/ansi`; e.g. `.ans`/`.ansi` ANSI-art and colorized console captures). It uses the vendored, managed `libvt100` ANSI decoder — no Python and no Pygments required.
+3. **`AnsiCte`** - Decodes files containing `ANSI Escape Sequences` (`text/ansi`; e.g. `.ans`/`.ansi` ANSI-art and colorized console captures), reflowing them for the page. Requires no external tools (no Python).
 
 4. **`TextCte`** - This CTE knows only how to print raw `text/plain` files. The format of the printed text can be changed (e.g. to turn off line numbers or use a different font). Lines that are too long for a page are wrapped at character boundaries. `\f` (form feed) characters can be made to cause following text to print on the next page (this is off by default). Settings for `text/plain` can be changed by editing the `textContentTypeEngineSettings` section or a Sheet Definition in `WinPrint.config.json`.
 
-5. **`HtmlCte`** - Renders HTML files (`text/html`; e.g. `.html`/`.htm`, as well as `.mhtml`/`.mht` web archives) by laying out HTML/CSS through the pure-managed HtmlRenderer engine. Any CSS specified inline in the HTML file will be honored. Local (document-relative) files, `data:` URIs, and MHTML-embedded resources always load; `http(s)` resources are only fetched when `AllowRemoteResources` is enabled. `text/html` does not support line numbers.
+5. **`HtmlCte`** - Renders HTML files (`text/html`; e.g. `.html`/`.htm`, as well as `.mhtml`/`.mht` web archives) by laying out the HTML/CSS. Any CSS specified inline in the HTML file will be honored. Local (document-relative) files, `data:` URIs, and MHTML-embedded resources always load; `http(s)` resources are only fetched when `AllowRemoteResources` is enabled. `text/html` does not support line numbers.
 
 When using **winprint** from the command line, the `--content-type` (`-e`) option can be used to specify the content type / CTE to use.
 

--- a/packaging/homebrew/Casks/winprint.rb
+++ b/packaging/homebrew/Casks/winprint.rb
@@ -1,7 +1,9 @@
 # Template rendered by the release pipeline (release.yml -> brew job) and pushed to the
 # kindel/homebrew-winprint tap. Placeholders are filled with each stable release's version,
-# download base URL, and per-arch SHA256s. This is the free MAUI GUI (WinPrint.app), a
-# notarized Developer ID build distributed directly (NOT the App Store).
+# download base URL, and per-arch SHA256s. This is the free MAUI GUI (WinPrint.app),
+# distributed directly (NOT the App Store). NOTE: the app is NOT notarized today — the
+# Apple signing secrets (APPLE_*) aren't configured (tracked in #162), so it ships as an
+# unsigned/ad-hoc build and macOS Gatekeeper quarantine applies on first launch.
 #
 # The GUI bundle ALSO embeds the `wp` TUI (release.yml copies the self-contained CLI payload into
 # WinPrint.app/Contents/Helpers/wp), so this single cask install delivers BOTH the GUI and the `wp`
@@ -24,7 +26,7 @@ cask "winprint" do
 
   name "WinPrint"
   desc "Advanced source code and text file printing GUI (bundles the wp TUI)"
-  homepage "https://github.com/kindel/winprint"
+  homepage "https://github.com/tig/winprint"
 
   app "WinPrint.app"
   binary "#{appdir}/WinPrint.app/Contents/Helpers/wp/wp"

--- a/packaging/homebrew/Formula/wp.rb
+++ b/packaging/homebrew/Formula/wp.rb
@@ -10,7 +10,7 @@
 # Both provide the `wp` symlink, so installing this formula AND the cask collides — pick one on macOS.
 class Wp < Formula
   desc "Advanced source code and text file printing terminal UI"
-  homepage "https://github.com/kindel/winprint"
+  homepage "https://github.com/tig/winprint"
   version "{{version}}"
   license "MIT"
 

--- a/specs/headerfooter.md
+++ b/specs/headerfooter.md
@@ -1,23 +1,26 @@
-## Planned macros
-PrintDate
-FileRevisedDate
-FileCreatedDate
-PageNumber
+> **Historical design spec.** This is an early design sketch. The macro names below have
+> been updated to match the macros winprint actually ships (see
+> `src/WinPrint.Core/Models/Macros.cs` and `MacroChoices`); a few names in the original
+> draft (e.g. `PrintDate`, `FilePath`, `PageNumber`) never shipped under those names.
+
+## Macros
+DatePrinted
+DateRevised
+DateCreated
+Page
 NumPages
 FileName
+FileNameWithoutExtension
 FileExtension
-FilePath
-FullyQualifiedPath
+FileDirectoryName
+FullPath
 FileType
-FileSize
-Printer
-PaperSize
-DocumentTitle
-Author
+Title
 Language
-UserName
-MachineName
+ContentType
+CteName
+Style
 
-## How to use .NET string formatting and leverage interpolated strings (e.g. $"{FileDate}")
+## How to use .NET string formatting and leverage interpolated strings (e.g. $"{DatePrinted:D}")
 
 E.g. $"{}

--- a/src/README.md
+++ b/src/README.md
@@ -1,5 +1,8 @@
 # Build
 
+For full setup, build, test, and debug instructions, see [`../CONTRIBUTING.md`](../CONTRIBUTING.md).
+That is the authoritative contributor guide; the notes below cover only source-tree specifics.
+
 ## Getting source ready
 
 * `git config --global status.submoduleSummary true`
@@ -7,13 +10,9 @@
 
 # Pre-reqs
 
-* VS 2022+
-* Python/Pygments are only needed when using the legacy `AnsiCte` highlighter.
-
-# Enable telemtry/logging key
-
-* Right click on `winprint\src\WinPrint.Core\Services\TelemetryService.tt` and "Run Custom Tool" to run T4 compiler
-* MS ApplicationInsights used to be in the Kindel account, but is no longer there!
+* **.NET 10 SDK** (pinned by [`../global.json`](../global.json)) — winprint is VS Code-oriented;
+  see [`../CONTRIBUTING.md`](../CONTRIBUTING.md) for the full prerequisites.
+* `AnsiCte` uses a vendored, managed `libvt100` ANSI decoder — **no Python/Pygments required**.
 
 # Versions
 

--- a/src/WinPrint.TUI/GuiCommand.cs
+++ b/src/WinPrint.TUI/GuiCommand.cs
@@ -68,7 +68,7 @@ public sealed class GuiCommand : ICliCommand
     // emitted bare; valued options as `--name value`.
     private static IReadOnlyList<string> BuildArguments(CommandRunOptions options)
     {
-        List<string> args = [.. options.Arguments];
+        List<string> args = [.. ResolveFileArguments(options.Arguments)];
 
         foreach (WinPrintOption option in WinPrintOptions.Shared)
         {
@@ -92,5 +92,35 @@ public sealed class GuiCommand : ICliCommand
         }
 
         return args;
+    }
+
+    // Resolve each positional file argument to an absolute path against wp's working directory *before*
+    // forwarding it to the GUI. On macOS the GUI is launched via `open`, which starts the app through
+    // LaunchServices with its own working directory — NOT the one wp was invoked from — so a relative
+    // path like `./testfiles/MainForm.cpp` would otherwise be resolved against the wrong directory in the
+    // GUI and reported "not found". wp shares the user's shell CWD, so resolving here makes the path
+    // unambiguous; it's a harmless normalization on Windows (where the child already inherits wp's CWD).
+    internal static IReadOnlyList<string> ResolveFileArguments(IReadOnlyList<string> arguments)
+    {
+        return [.. arguments.Select(ResolveFileArgument)];
+    }
+
+    private static string ResolveFileArgument(string argument)
+    {
+        if (string.IsNullOrEmpty(argument))
+        {
+            return argument;
+        }
+
+        try
+        {
+            return Path.GetFullPath(argument);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            // Not a resolvable path (malformed/invalid characters) — forward it verbatim and let the GUI
+            // surface the error rather than crashing wp here.
+            return argument;
+        }
     }
 }

--- a/tests/WinPrint.TUI.UnitTests/GuiLauncherTests.cs
+++ b/tests/WinPrint.TUI.UnitTests/GuiLauncherTests.cs
@@ -43,6 +43,30 @@ public class GuiLauncherTests
     }
 
     [Fact]
+    public void ResolveFileArguments_MakesRelativePathsAbsolute()
+    {
+        // Bug: `wp gui ./testfiles/MainForm.cpp` launched the GUI but it reported the file "not found".
+        // On macOS the GUI is launched via `open`, which resets the working directory, so a relative path
+        // must be resolved against wp's CWD *before* forwarding. The forwarded path must be absolute.
+        IReadOnlyList<string> resolved = GuiCommand.ResolveFileArguments(["./testfiles/MainForm.cpp"]);
+
+        string forwarded = Assert.Single(resolved);
+        Assert.True(Path.IsPathRooted(forwarded), $"expected an absolute path, got '{forwarded}'");
+        Assert.Equal(Path.GetFullPath("./testfiles/MainForm.cpp"), forwarded);
+    }
+
+    [Fact]
+    public void ResolveFileArguments_LeavesAbsolutePathsRooted()
+    {
+        // An already-absolute path stays absolute (and is the canonical form the GUI uses verbatim).
+        string absolute = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "report.cs"));
+
+        IReadOnlyList<string> resolved = GuiCommand.ResolveFileArguments([absolute]);
+
+        Assert.Equal(absolute, Assert.Single(resolved));
+    }
+
+    [Fact]
     public void Windows_LaunchesWinprintExeFromBaseDirectory()
     {
         // Windows-only: a "C:\..." drive path round-trips through Path.Combine only on Windows (on Unix


### PR DESCRIPTION
Fixes the concrete documentation errors catalogued in #184, plus one real macOS CLI bug found while investigating.

## `wp gui <file>` relative paths (code fix)

`wp gui ./testfiles/MainForm.cpp` on macOS started the GUI but reported the file **"not found"**. The CLI launches the GUI via `/usr/bin/open`, which starts the app through LaunchServices with its *own* working directory — not the one `wp` was invoked from — so a relative path resolved against the wrong directory.

Fix: resolve positional file arguments to absolute paths against `wp`'s CWD in `GuiCommand` before forwarding to the GUI (harmless normalization on Windows, where the child already inherits the CWD). Adds cross-platform unit tests.

## #184 documentation corrections

Applies the **concrete corrections** from the audit; net-new authoring (TUI guide, architecture overview, macOS decision tree, etc.) is intentionally deferred to follow-ups.

Every claim was re-verified against current code, because the audit (2026-06-25) is **partly stale**:
- `wp print` **does** exist now — docs corrected to its real options, not removed.
- The Homebrew **formula was renamed `winprint` → `wp`** (cask `winprint` = the GUI), so `brew install winprint` already installs the GUI.
- `AnsiCte`/`HtmlCte` are **functional** (libvt100 / HtmlRenderer), not stubs — `AGENTS.md`/`CLAUDE.md` "stubs" note corrected too.

Highlights: macOS install/notarization (#162) + quarantine troubleshooting; remove `wp views` / removed-PowerShell refs; `%appdata%\Kindel\winprint` + `WinPrint.config.json` + cross-platform log paths; five-engine CTE section (adds Markdown; fixes Ansi/HTML/form-feed); sheet names, macros, language-association schema; contributor docs (develop→main + annotated tags, macOS-not-signed, CTE registry vs reflection, AOT status, partial MvvmLight migration); metadata fixes (tagline, X link, footer, privacy store channels, Homebrew homepage `kindel`→`tig`).

Scope discipline: 6 file-disjoint passes; no two touched the same file.

## Notes
- Bug 3 from the original report (`wp <file> gui` ignores the subcommand) is a **Terminal.Gui.Cli** parser limitation (first non-dash token is always the command alias) — filed upstream as tui-cs/cli#37; no winprint change.
- Bug 2 (`open WinPrint.app <file>` opens the file's default app) is standard `open(1)` semantics; the supported path is `wp gui <file>` (fixed above).
- A separate branch `docs/issue-184-heroes` exists for a different slice of #184 (hero images); this PR may overlap and need a rebase/merge with it.

## Verification
- `dotnet test tests/WinPrint.TUI.UnitTests` → GuiLauncherTests 16/16 pass (incl. 2 new resolution tests).
- Style gate clean locally: `dotnet format` + `jb cleanupcode` produce no changes on the C# files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)