### PR TITLE
feat(dist): add Scoop bucket as approval-free Windows channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -635,3 +635,62 @@ jobs:
           git diff --cached --quiet && { echo "Tap unchanged."; exit 0; }
           git commit -m "winprint ${version}"
           git push
+
+  # Update the Scoop bucket (kindel/scoop-winprint) with the new Windows build on every STABLE
+  # release. Renders packaging/scoop/winprint.json with the version + win-x64 SHA256 and pushes it
+  # to bucket/winprint.json. This is the approval-free Windows channel — a Scoop bucket is just a Git
+  # repo you own, with no Microsoft moderation (unlike the winget job). Requires a classic PAT (repo
+  # scope) in SCOOP_BUCKET_TOKEN with push access to the bucket; see packaging/scoop/README.md.
+  scoop:
+    name: Update Scoop bucket
+    needs: publish
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.ref_name, '-') }}
+    steps:
+      # A missing token must FAIL this job, never silently skip into a green check (same rule as the
+      # brew/winget jobs): a skipped publish reporting success would hide that nothing shipped.
+      - name: Require SCOOP_BUCKET_TOKEN
+        shell: bash
+        env:
+          SCOOP_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}
+        run: |
+          if [ -z "${SCOOP_TOKEN}" ]; then
+            echo "::error title=Scoop bucket not published::SCOOP_BUCKET_TOKEN is not set, so the Scoop bucket was NOT updated for this release. See packaging/scoop/README.md to create the bucket + token, then re-run this job."
+            exit 1
+          fi
+
+      - name: Checkout source
+        uses: actions/checkout@v5
+
+      - name: Render manifest and push to bucket
+        shell: bash
+        env:
+          SCOOP_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          base="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}"
+          sha() { curl -fsSL "$base/$1" | sha256sum | awk '{print $1}'; }
+
+          # win-x64 is the only Windows arch published today (the win-arm64 Velopack leg is still
+          # experimental). Add an arm64 block + {{sha_win_arm64}} here when it graduates.
+          sed -e "s|{{version}}|${version}|g" \
+              -e "s|{{base}}|${base}|g" \
+              -e "s|{{sha_win_x64}}|$(sha Kindel.WinPrint-win-x64-Portable.zip)|" \
+              packaging/scoop/winprint.json > /tmp/winprint.json
+
+          # Scoop manifests are plain JSON (no DSL footguns like Homebrew casks), so a parse check is
+          # the meaningful pre-publish guard; loading under Scoop proper needs Windows/PowerShell.
+          jq empty /tmp/winprint.json
+
+          git clone "https://x-access-token:${SCOOP_TOKEN}@github.com/kindel/scoop-winprint.git" bucket-repo
+          mkdir -p bucket-repo/bucket
+          cp /tmp/winprint.json bucket-repo/bucket/winprint.json
+          cd bucket-repo
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add bucket/winprint.json
+          git diff --cached --quiet && { echo "Bucket unchanged."; exit 0; }
+          git commit -m "winprint ${version}"
+          git push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,15 @@ artifacts in the tap:
   release `brew` job renders into a throwaway tap and `brew info --cask/--formula <name>` them before
   publishing (`brew audit [path]` is disabled; loading by name is the reliable check) — keep that guard.
 
+**Scoop (the approval-free Windows path).** Bucket = `kindel/scoop-winprint`, pushed by the release
+`scoop` job (needs `SCOOP_BUCKET_TOKEN`; a missing token *fails* loudly, like brew). Unlike winget it
+needs no Microsoft moderation. The job renders `packaging/scoop/winprint.json` and pushes it to
+`bucket/winprint.json`. Source artifact is the Velopack **Portable** zip
+(`Kindel.WinPrint-win-x64-Portable.zip`): root holds the stub launcher `WinPrint.exe`; `current/`
+holds the real `winprint.exe` (GUI) + `wp.exe` (TUI), so the manifest shims `wp` from
+`current\wp.exe` and shortcuts the root `WinPrint.exe` — one install gives GUI + `wp`, like the cask.
+**win-x64 only** today (win-arm64 Velopack leg is still experimental); see `packaging/scoop/README.md`.
+
 **winget & macOS notarization — known gaps (don't mistake for regressions).**
 - **winget:** `winget-releaser` only *updates* an existing winget-pkgs package, so the **first**
   submission must be bootstrapped manually. Until then the `winget` job **failing is expected**.

--- a/docs/install.md
+++ b/docs/install.md
@@ -8,6 +8,20 @@
 winget install Kindel.WinPrint
 ```
 
+### Install with Scoop
+
+[Scoop](https://scoop.sh) installs from a bucket we own, so it needs no Microsoft approval. One
+install gives you both the `wp` terminal UI (on your `PATH`) and the **WinPrint** GUI (Start-Menu
+shortcut):
+
+```powershell
+scoop bucket add winprint https://github.com/kindel/scoop-winprint
+scoop install winprint
+```
+
+Upgrade with `scoop update winprint`; remove with `scoop uninstall winprint`. Only the x64 build is
+published via Scoop today.
+
 ### Install from GitHub Releases
 
 Download the latest installer from [GitHub Releases](https://github.com/tig/winprint/releases) and run it.

--- a/packaging/scoop/README.md
+++ b/packaging/scoop/README.md
@@ -1,0 +1,73 @@
+# Scoop packaging
+
+Makes WinPrint installable on Windows via [Scoop](https://scoop.sh) **without any Microsoft
+approval** — unlike winget (whose first submission is moderated by the winget-pkgs team), a Scoop
+bucket is just a Git repo you own. `winprint.json` here is the manifest **template** and the source
+of truth; the release pipeline renders it with each stable version + SHA256 and pushes it to the
+**`kindel/scoop-winprint`** bucket (the Scoop analog of the Homebrew tap).
+
+## Install (for users)
+
+```powershell
+scoop bucket add winprint https://github.com/kindel/scoop-winprint
+scoop install winprint
+```
+
+One install delivers **both** heads:
+
+- `wp` is shimmed onto your `PATH` (the terminal UI).
+- **WinPrint** (the GUI) gets a Start-Menu shortcut.
+
+Upgrade / remove with `scoop update winprint` / `scoop uninstall winprint`.
+
+## How it works
+
+| Stage | Who | What |
+|-------|-----|------|
+| Bucket repo | **manual, once** | Create `kindel/scoop-winprint` and set the `SCOOP_BUCKET_TOKEN` secret (below). No Microsoft involvement, ever. |
+| Every stable release | **automated** | The `scoop` job in `.github/workflows/release.yml` renders this template and pushes `bucket/winprint.json` to the bucket. |
+
+The source artifact is the Velopack **Portable** zip (`Kindel.WinPrint-win-x64-Portable.zip`) — the
+"run without installing" build — which is exactly the shape Scoop wants (extract, don't run an
+installer, no admin). Its layout is:
+
+```
+WinPrint.exe        <- Velopack stub launcher (root); the Start-Menu shortcut target
+Update.exe
+.portable
+current/
+  winprint.exe      <- real MAUI GUI
+  wp.exe            <- real terminal UI (Scoop shims this onto PATH)
+  RestartAgent.exe
+  *.dll             <- shared assemblies for both exes
+```
+
+So the manifest sets `bin: current\wp.exe` and a `shortcuts` entry on the root `WinPrint.exe`.
+This mirrors the macOS Homebrew **cask**, which also delivers GUI + `wp` from one install.
+
+## One-time setup
+
+1. **Create the bucket repo.** A public GitHub repo named **`kindel/scoop-winprint`**. The release
+   job writes the manifest to `bucket/winprint.json` in it (the job `mkdir -p bucket` on first run,
+   so the repo can start empty apart from a README).
+
+2. **Create the token.** A classic GitHub **PAT** with **`repo`** scope that can push to
+   `kindel/scoop-winprint`, saved as the repo secret **`SCOOP_BUCKET_TOKEN`** (same pattern as
+   `HOMEBREW_TAP_TOKEN`). Until this secret exists the `scoop` job **fails loudly** — it never
+   silently skips into a green check.
+
+After that, every stable release auto-updates the bucket. No moderation, no queue.
+
+## Notes / things to validate on a real install
+
+- **Auto-update ownership:** updates are managed by **Scoop** (`scoop update`). The Velopack
+  in-app updater is not the path here; the portable build does not check on launch, so the two
+  don't fight. (If a future build ever calls Velopack's `UpdateManager`, it would write into Scoop's
+  app dir — keep updates on the Scoop side.)
+- **arm64:** only **win-x64** ships today (the win-arm64 Velopack leg is still `experimental` in
+  `release.yml`, and v2.8.10 published no `win-arm64-Portable.zip`). When that leg graduates, add an
+  `arm64` block under both `architecture` and `autoupdate`, and render its SHA in the `scoop` job —
+  same limitation winget currently has.
+- **Validation in CI:** the job validates the rendered manifest is well-formed JSON (`jq empty`).
+  Loading it under Scoop proper needs Windows/PowerShell; unlike Homebrew casks, Scoop manifests are
+  plain JSON with no DSL footguns, so a parse check is sufficient before publishing.

--- a/packaging/scoop/winprint.json
+++ b/packaging/scoop/winprint.json
@@ -1,0 +1,27 @@
+{
+    "version": "{{version}}",
+    "description": "Advanced source code and text file printing — GUI (winprint) and terminal UI (wp).",
+    "homepage": "https://github.com/tig/winprint",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "{{base}}/Kindel.WinPrint-win-x64-Portable.zip",
+            "hash": "{{sha_win_x64}}"
+        }
+    },
+    "bin": "current\\wp.exe",
+    "shortcuts": [
+        [
+            "WinPrint.exe",
+            "WinPrint"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/tig/winprint/releases/download/v$version/Kindel.WinPrint-win-x64-Portable.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds **Scoop** as a Windows distribution channel that needs **no Microsoft approval** (unlike winget, whose first submission is moderated). A Scoop bucket is just a Git repo we own.

One `scoop install` delivers both heads from the Velopack **Portable** zip — `wp` (TUI) shimmed onto `PATH`, and the **WinPrint** GUI as a Start-Menu shortcut — mirroring the macOS Homebrew cask.

```powershell
scoop bucket add winprint https://github.com/kindel/scoop-winprint
scoop install winprint
```

## Changes

- **`packaging/scoop/winprint.json`** — manifest template. Layout verified against the **real** v2.8.10 Portable zip: `bin -> current\wp.exe`, shortcut on the root stub `WinPrint.exe`.
- **`release.yml` `scoop` job** — mirrors `brew`: `needs: publish`, stable-only, **fails loudly** on a missing `SCOOP_BUCKET_TOKEN`, renders + `jq`-validates the manifest, pushes to `bucket/winprint.json` in `kindel/scoop-winprint`.
- **`packaging/scoop/README.md`, `docs/install.md`, `CLAUDE.md`** — docs.

## One-time manual prerequisites (not in this PR)

1. Create the bucket repo **`kindel/scoop-winprint`**.
2. Create a classic PAT (repo scope, push to the bucket) as the **`SCOOP_BUCKET_TOKEN`** secret.

## Notes

- **win-x64 only** for now — v2.8.10 shipped no `win-arm64-Portable.zip` (that Velopack leg is still `experimental`). TODO left in template/job/README for when it graduates; same limitation winget has.
- Validated: rendered manifest parses (`jq empty`), no leftover placeholders, full `release.yml` parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)