### PR TITLE
docs: Scoop as the Windows install path; winget "coming soon"

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,17 @@ Human and AI Agent friendly print utility with syntax highlighting, multiple pag
 
 ### Windows
 
+Install with [Scoop](https://scoop.sh) — one command gives you both the GUI and the `wp` terminal UI:
+
 ```powershell
-winget install Kindel.WinPrint
+scoop bucket add winprint https://github.com/kindel/scoop-winprint
+scoop install winprint
 ```
+
+Or download the signed installer **`Kindel.WinPrint-win-x64-Setup.exe`** from the
+[latest release](https://github.com/tig/winprint/releases/latest) and run it.
+
+> `winget install Kindel.WinPrint` is **coming soon** (pending first submission to winget-pkgs).
 
 ### macOS
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,8 +19,9 @@ Advanced source code and text file printing for terminals (all platforms) and Wi
 ## Quick Start
 
 ```bash
-# Install (Windows)
-winget install Kindel.WinPrint
+# Install (Windows) — Scoop gives you the GUI + `wp` TUI in one command
+scoop bucket add winprint https://github.com/kindel/scoop-winprint && scoop install winprint
+# (or download Kindel.WinPrint-win-x64-Setup.exe from the latest GitHub release; winget coming soon)
 
 # Install (Mac) — GUI cask, which also bundles the `wp` TUI
 brew tap kindel/winprint && brew install winprint

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,29 +2,48 @@
 
 ## Windows
 
-### Install with winget (Recommended)
+### Install with Scoop (Recommended)
 
-```bash
-winget install Kindel.WinPrint
-```
-
-### Install with Scoop
-
-[Scoop](https://scoop.sh) installs from a bucket we own, so it needs no Microsoft approval. One
-install gives you both the `wp` terminal UI (on your `PATH`) and the **WinPrint** GUI (Start-Menu
-shortcut):
+[Scoop](https://scoop.sh) installs from a bucket we own, so it needs no app-store approval and works
+the moment a release ships. One install gives you both the `wp` terminal UI (on your `PATH`) and the
+**WinPrint** GUI (Start-Menu shortcut):
 
 ```powershell
 scoop bucket add winprint https://github.com/kindel/scoop-winprint
 scoop install winprint
 ```
 
-Upgrade with `scoop update winprint`; remove with `scoop uninstall winprint`. Only the x64 build is
-published via Scoop today.
+Don't have Scoop yet? Install it first (no admin required):
 
-### Install from GitHub Releases
+```powershell
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
+```
 
-Download the latest installer from [GitHub Releases](https://github.com/tig/winprint/releases) and run it.
+Only the x64 build is published via Scoop today.
+
+### Install from GitHub Releases (download the installer)
+
+If you'd rather not use a package manager, download and run the signed installer directly:
+
+1. Open the [latest release](https://github.com/tig/winprint/releases/latest).
+2. Under **Assets**, download **`Kindel.WinPrint-win-x64-Setup.exe`**.
+3. Run it. The installer is Authenticode-signed (Azure Trusted Signing), so Windows SmartScreen
+   should show **Kindel, LLC** as the verified publisher — no "unknown publisher" warning.
+
+This installs the GUI to the Start Menu and puts `wp` on your `PATH`, and includes a built-in
+updater for future versions.
+
+> Prefer a no-installer copy? The same release also ships **`Kindel.WinPrint-win-x64-Portable.zip`**
+> — unzip it anywhere and run `WinPrint.exe` (GUI) or `current\wp.exe` (TUI). This is the same
+> artifact Scoop uses.
+
+### Install with winget (coming soon)
+
+`winget install Kindel.WinPrint` isn't available yet — the package is pending its first submission to
+the Microsoft [winget-pkgs](https://github.com/microsoft/winget-pkgs) community repository. Until
+that lands, use **Scoop** or the **GitHub Releases** installer above. This page will be updated when
+winget goes live.
 
 ### Prerequisites
 
@@ -32,21 +51,15 @@ No additional prerequisites are required on Windows. WinPrint is a self-containe
 
 ### Upgrade
 
-Installed builds include a built-in updater, and winget can also upgrade the installed package:
-
-You can also upgrade manually:
-
-```powershell
-winget upgrade Kindel.WinPrint
-```
+- **Scoop:** `scoop update winprint`
+- **Installer / Portable:** installed builds include a built-in updater that pulls new versions
+  automatically; you can also re-download the latest `Setup.exe` and run it over the top.
 
 ### Uninstall
 
-```powershell
-winget uninstall Kindel.WinPrint
-```
-
-Or use **Settings → Apps → Installed apps** and search for "WinPrint".
+- **Scoop:** `scoop uninstall winprint`
+- **Installer:** use **Settings → Apps → Installed apps**, search for "WinPrint", and uninstall — or
+  delete the unzipped folder if you used the portable zip.
 
 ---
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -135,8 +135,8 @@ WinPrint's packaged builds include a built-in install/update engine.
 You can also update manually using your package manager:
 
 ```bash
-# Windows
-winget upgrade Kindel.WinPrint
+# Windows (Scoop; winget coming soon)
+scoop update winprint
 
 # macOS
 brew upgrade --cask winprint


### PR DESCRIPTION
## Why

`winget install Kindel.WinPrint` isn't live yet (the package hasn't been bootstrapped into winget-pkgs), so the docs shouldn't present it as the recommended Windows method. Scoop **is** live (`kindel/scoop-winprint`), so it becomes the recommended path.

## Changes

- **Scoop = recommended Windows install** in `README.md` and `docs/install.md` (+ how to install Scoop itself).
- **Explicit installer download steps** — get `Kindel.WinPrint-win-x64-Setup.exe` from the latest release; notes it's Authenticode-signed (SmartScreen shows *Kindel, LLC*). Plus the `Portable.zip` no-installer alternative.
- **winget → "coming soon"** note everywhere it appeared: `README.md`, `docs/install.md`, `docs/index.md` (Quick Start), `docs/users-guide.md` (upgrade → `scoop update`).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)