### PR TITLE
docs: correct SmartScreen expectations for the signed installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ scoop install winprint
 ```
 
 Or download the signed installer **`Kindel.WinPrint-win-x64-Setup.exe`** from the
-[latest release](https://github.com/tig/winprint/releases/latest) and run it.
+[latest release](https://github.com/tig/winprint/releases/latest) and run it. (On new releases
+SmartScreen may say it "isn't commonly downloaded" — that's a reputation check, not a signing
+problem; the publisher reads *Kindel, LLC*. See the [Installation Guide](https://tig.github.io/winprint/install.html#install-from-github-releases-download-the-installer).)
 
 > `winget install Kindel.WinPrint` is **coming soon** (pending first submission to winget-pkgs).
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -28,11 +28,19 @@ If you'd rather not use a package manager, download and run the signed installer
 
 1. Open the [latest release](https://github.com/tig/winprint/releases/latest).
 2. Under **Assets**, download **`Kindel.WinPrint-win-x64-Setup.exe`**.
-3. Run it. The installer is Authenticode-signed (Azure Trusted Signing), so Windows SmartScreen
-   should show **Kindel, LLC** as the verified publisher — no "unknown publisher" warning.
+3. Run it. The installer is Authenticode-signed (Azure Trusted Signing), so Windows identifies the
+   publisher as **Kindel, LLC** — not "unknown publisher".
 
 This installs the GUI to the Start Menu and puts `wp` on your `PATH`, and includes a built-in
 updater for future versions.
+
+> **SmartScreen "isn't commonly downloaded" prompt.** On brand-new releases, Microsoft Defender
+> SmartScreen may still warn that the file *"isn't commonly downloaded"*. This is a **reputation**
+> check based on download volume — **not** a problem with the signature (the publisher line correctly
+> reads *Kindel, LLC*). It fades as each release accumulates downloads. To proceed: in Edge, on the
+> download choose **••• → Keep**, then **Show more → Keep anyway**; if Windows prompts at launch,
+> click **More info → Run anyway** and confirm the publisher is *Kindel, LLC*. Installing via
+> **Scoop** (above) avoids this prompt entirely.
 
 > Prefer a no-installer copy? The same release also ships **`Kindel.WinPrint-win-x64-Portable.zip`**
 > — unzip it anywhere and run `WinPrint.exe` (GUI) or `current\wp.exe` (TUI). This is the same


### PR DESCRIPTION
## Why

A real download (see issue report / screenshot) shows Microsoft Defender SmartScreen warning *"isn't commonly downloaded"* on `Kindel.WinPrint-win-x64-Setup.exe` — even though it's correctly signed (the publisher line reads **Kindel, LLC**). The prior docs claimed "no warning", which is wrong.

## What

- Clarify that this is SmartScreen **reputation** (download volume), **not** a signing problem — the signature is valid and the publisher is identified.
- Tell users how to proceed: Edge **••• → Keep → Keep anyway**; at launch **More info → Run anyway**, confirming publisher *Kindel, LLC*.
- Note it fades as releases accrue downloads, and that **Scoop** avoids the prompt.

`README.md` gets a one-line version linking to the install guide; `docs/install.md` gets the full note.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)