### PR TITLE
chore: remove demo-regen note from README (3.0-beta prep)

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,6 +1,6 @@
 mode: ContinuousDelivery
 tag-prefix: '[vV]'
-next-version: '3.0.0'
+next-version: 'v2.6.0'
 semantic-version-format: Loose
 
 branches:

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,6 +1,6 @@
 mode: ContinuousDelivery
 tag-prefix: '[vV]'
-next-version: 'v2.6.0'
+next-version: '3.0.0'
 semantic-version-format: Loose
 
 branches:

--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ Human and AI Agent friendly print utility with syntax highlighting, multiple pag
 
 *The GUI on Windows and macOS: visual print preview, settings, and `wp gui` to launch from the terminal.*
 
-> Regenerate these demos: `scripts/record-hero-gifs.sh` (tuirec for TUI/print; macOS screen capture for GUI).
-
 ## Installation
 
 ### Windows


### PR DESCRIPTION
Prep for the **3.0 beta**.

- **README**: removed the "Regenerate these demos" maintainer note from the hero section.

> Originally also bumped GitVersion `next-version` to `3.0.0`, but GitVersion 6.4 fails to parse that as a base version (the old `v2.6.0` was simply ignored as below the 2.x tags). Reverted — the 3.0 line is driven by the release **tag** `v3.0.0-beta.1` instead, which is how GitVersion is meant to work here.

After merge: `develop` → `main`, then tag **`v3.0.0-beta.1`** → publishes a GitHub **pre-release**. Pre-release tags intentionally skip `scoop`/`brew`/`winget`, so the beta ships as a GitHub release only (stable channels stay on 2.9.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)