### PR TITLE
chore(deps): update Terminal.Gui 2.4.9 → 2.4.13 (+ Editor 2.5.5)

### DIFF
--- a/src/WinPrint.TUI/WinPrint.TUI.csproj
+++ b/src/WinPrint.TUI/WinPrint.TUI.csproj
@@ -21,9 +21,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Terminal.Gui" Version="2.4.9" />
+        <PackageReference Include="Terminal.Gui" Version="2.4.13" />
         <PackageReference Include="Terminal.Gui.Cli" Version="0.3.0" />
-        <PackageReference Include="Terminal.Gui.Editor" Version="2.5.4" />
+        <PackageReference Include="Terminal.Gui.Editor" Version="2.5.5" />
         <PackageReference Include="Velopack" Version="1.1.1" />
         <!-- Cross-platform, pure-managed image decode/draw for the sixel preview (no System.Drawing). -->
         <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />


### PR DESCRIPTION
Updates to the latest stable **Terminal.Gui** release.

- `Terminal.Gui` **2.4.9 → 2.4.13**
- `Terminal.Gui.Editor` **2.5.4 → 2.5.5**
- `Terminal.Gui.Cli` stays **0.3.0** (already latest stable; 0.3.1 is pre-release)

**Lockstep constraints verified** (these have broken `wp` startup before):
- TG 2.4.13 still pulls transitive **Markdig 1.3.2** → Core's exact pin unchanged.
- TG 2.4.13 uses **TextMateSharp 2.0.4** → Core floats `2.0.*`, auto-resolves.
- Editor 2.5.5 requires TG ≥ 2.4.11 → satisfied.

**Verified locally:** `wp` builds + `wp --version` starts cleanly (no TG-config startup fault); TUI unit tests (58) and golden/UI tests (73) all pass — no render-snapshot drift from the TG bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)