### PR TITLE
fix(maui): match TUI zoom keys in the GUI — plain +/=/-/0 (#199)

### DIFF
--- a/src/WinPrint.Maui/MainPage.xaml.cs
+++ b/src/WinPrint.Maui/MainPage.xaml.cs
@@ -305,9 +305,14 @@ public partial class MainPage : ContentPage
 #endif
 
     /// <summary>
-    ///     Handle keyboard shortcuts (F5, PgUp, PgDn, Home, End, +, -).
+    ///     Handle keyboard shortcuts (F5, PgUp, PgDn, Home, End, and zoom +/=/-/0).
+    ///     Zoom keys mirror the wp TUI preview (see <c>PreviewPane.IsImageZoomKey</c>): plain
+    ///     <c>+</c>/<c>=</c> zoom in, <c>-</c> zooms out, <c>0</c> fits — no modifier needed when the
+    ///     preview (rather than a text field) has focus. The <c>Ctrl</c>/<c>Cmd</c>+ variants keep
+    ///     working everywhere. <paramref name="fromTextInput" /> is true when a text entry is focused,
+    ///     so plain zoom keys never hijack typing (the TUI gets this for free via focus-scoped bindings).
     /// </summary>
-    public void HandleKeyDown(string key, bool ctrl, bool shift)
+    public void HandleKeyDown(string key, bool ctrl, bool shift, bool fromTextInput = false)
     {
         switch (key)
         {
@@ -328,9 +333,11 @@ public partial class MainPage : ContentPage
             case "End":
                 _viewModel.LastPageCommand.Execute(null);
                 break;
+            // Zoom keys match the TUI: plain +/=/-/0 zoom when the preview has focus; the Ctrl/Cmd+
+            // variants also work while a text field is focused (fromTextInput) without hijacking typing.
             case "OemPlus":
             case "Add":
-                if (ctrl)
+                if (ctrl || !fromTextInput)
                 {
                     _viewModel.ZoomInCommand.Execute(null);
                 }
@@ -338,7 +345,7 @@ public partial class MainPage : ContentPage
                 break;
             case "OemMinus":
             case "Subtract":
-                if (ctrl)
+                if (ctrl || !fromTextInput)
                 {
                     _viewModel.ZoomOutCommand.Execute(null);
                 }
@@ -346,7 +353,7 @@ public partial class MainPage : ContentPage
                 break;
             case "D0":
             case "NumPad0":
-                if (ctrl)
+                if (ctrl || !fromTextInput)
                 {
                     _viewModel.ZoomFitCommand.Execute(null);
                 }
@@ -726,8 +733,10 @@ public partial class MainPage : ContentPage
 
         string key = e.Key.ToString();
 
-        // In a text box, Home/End move the caret — that must win over page navigation.
-        if (e.OriginalSource is Microsoft.UI.Xaml.Controls.TextBox && key is "Home" or "End")
+        // A focused text entry must keep plain keys for typing/caret: Home/End move the caret, and the
+        // plain zoom keys (+/=/-/0) must type rather than zoom. fromTextInput gates those in HandleKeyDown.
+        bool fromTextInput = e.OriginalSource is Microsoft.UI.Xaml.Controls.TextBox;
+        if (fromTextInput && key is "Home" or "End")
         {
             return;
         }
@@ -738,7 +747,7 @@ public partial class MainPage : ContentPage
         bool shift = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(Windows.System.VirtualKey.Shift)
             .HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down);
 
-        HandleKeyDown(key, ctrl, shift);
+        HandleKeyDown(key, ctrl, shift, fromTextInput);
     }
 
     private void OnNativePointerWheel(object sender, Microsoft.UI.Xaml.Input.PointerRoutedEventArgs e)

--- a/src/WinPrint.Maui/Platforms/MacCatalyst/AppDelegate.cs
+++ b/src/WinPrint.Maui/Platforms/MacCatalyst/AppDelegate.cs
@@ -76,8 +76,13 @@ public class AppDelegate : MauiUIApplicationDelegate
     ///     priority over system behavior, so they work no matter which sidebar control
     ///     UIKit hands focus to (the sheet Picker would otherwise pop its menu open on
     ///     a stray Down arrow). The one exception: while a text field is being edited,
-    ///     arrows and Home/End are NOT claimed at all, so caret movement keeps working.
-    ///     This getter is consulted per keystroke, so the check is live.
+    ///     arrows, Home/End, and the plain zoom keys are NOT claimed at all, so caret
+    ///     movement and typing keep working. This getter is consulted per keystroke, so
+    ///     the check is live.
+    ///
+    ///     Zoom keys mirror the wp TUI (plain +/=/-/0): claimed only when no text field is
+    ///     focused, so they zoom the preview but still type into entries. The Cmd+ variants
+    ///     stay claimed everywhere for Mac-standard familiarity.
     /// </summary>
     public override UIKeyCommand[] KeyCommands
     {
@@ -102,6 +107,12 @@ public class AppDelegate : MauiUIApplicationDelegate
                 commands.Add(MakeKeyCommand(UIKeyCommand.DownArrow, 0));
                 commands.Add(MakeKeyCommand(UIKeyCommand.LeftArrow, 0));
                 commands.Add(MakeKeyCommand(UIKeyCommand.RightArrow, 0));
+
+                // Plain zoom keys (no modifier), matching the TUI. Only claimed when not editing text.
+                commands.Add(MakeKeyCommand((NSString)"=", 0));
+                commands.Add(MakeKeyCommand((NSString)"+", 0));
+                commands.Add(MakeKeyCommand((NSString)"-", 0));
+                commands.Add(MakeKeyCommand((NSString)"0", 0));
             }
 
             return [.. commands];


### PR DESCRIPTION
Closes #199.

The GUI required a modifier to zoom (`Ctrl`+ on Windows, `Cmd`+ on Mac), but the `wp` TUI zooms on **plain `+`/`=`/`-`/`0`** (`PreviewPane.IsImageZoomKey`). This makes the GUI match the TUI.

## Why the GUI needed the modifier
The GUI's key handling is **app-global** (a content-level `KeyDown` handler on Windows; app-level `UIKeyCommand`s on Mac), so plain `+`/`-`/`0` would hijack typing in text entries (margins, font size, header text, …). The TUI doesn't have this problem because its preview is a focus-scoped widget. So the fix makes plain zoom keys work **only when a text field isn't focused**, and keeps the `Ctrl`/`Cmd`+ variants working everywhere.

## Changes
- **Shared** (`MainPage.HandleKeyDown`): new `fromTextInput` flag; zoom fires on `ctrl || !fromTextInput`.
- **Windows** (`OnNativeKeyDown`): `fromTextInput` = event source is a `TextBox` (Entry/Editor).
- **macOS** (`AppDelegate.KeyCommands`): register plain `=`/`+`/`-`/`0` `UIKeyCommand`s **only when no text field is focused** — the exact pattern already used for arrows/Home/End — so they zoom the preview but still type into entries. The `Cmd`+ variants stay for Mac-standard familiarity.

## Behavior matrix
| Focus | Plain `+`/`-`/`0` | `Ctrl`/`Cmd`+`+`/`-`/`0` |
|---|---|---|
| Preview / non-text | **zoom** (matches TUI) | zoom |
| Text entry | types normally (no zoom) | zoom |

Pan keys (arrows) and page nav (PgUp/PgDn/Home/End) were already shared between the frontends and are unchanged.

## Verification
- MacCatalyst build succeeds; `dotnet format` + `jb cleanupcode` produce no changes.
- The Windows handler change is `#if WINDOWS` (verified by CI / FlaUI).

## Follow-up (not in this PR)
A single shared source-of-truth for the keymap (today the TUI defines it in `PreviewPane` and the GUI in `MainPage`/`AppDelegate`) and the user-facing keyboard guide (the #184 doc gap) remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)