### PR TITLE
docs: correct stale "macOS not notarized" claims (it IS signed + notarized)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,11 +84,13 @@ artifacts in the tap:
   release `brew` job renders into a throwaway tap and `brew info --cask/--formula <name>` them before
   publishing (`brew audit [path]` is disabled; loading by name is the reliable check) — keep that guard.
 
-**winget & macOS notarization — known gaps (don't mistake for regressions).**
+**winget gap & macOS signing — don't mistake for regressions.**
 - **winget:** `winget-releaser` only *updates* an existing winget-pkgs package, so the **first**
   submission must be bootstrapped manually. Until then the `winget` job **failing is expected**.
-- **macOS is not notarized:** the Apple signing secrets (`APPLE_*`) aren't set, so the cask ships an
-  unsigned/ad-hoc `.app` (Gatekeeper warns; 3rd-party-tap casks also need `brew trust --cask`).
+- **macOS is signed + notarized:** the Apple signing secrets (`APPLE_*`) **are** configured, so the
+  release pipeline signs the `.app` with an Apple Developer ID and notarizes + staples it (the
+  `Sign, notarize, and zip macOS GUI` step). Gatekeeper accepts the cask normally — **no**
+  quarantine/`xattr` workaround. (Set up in the 2.8.x line; #162.)
 - **Per-arch cask size differs by design:** `maccatalyst-arm64` is Mono-**AOT** (~130 MB), `-x64` is
   Mono-**JIT** (~35 MB). The SDK gates AOT to `maccatalyst-arm64` only (the `RunAOTCompilation`
   property is ignored for MacCatalyst); see the comment in `release.yml`. Not a broken x64 build.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,11 +93,13 @@ holds the real `winprint.exe` (GUI) + `wp.exe` (TUI), so the manifest shims `wp`
 `current\wp.exe` and shortcuts the root `WinPrint.exe` — one install gives GUI + `wp`, like the cask.
 **win-x64 only** today (win-arm64 Velopack leg is still experimental); see `packaging/scoop/README.md`.
 
-**winget & macOS notarization — known gaps (don't mistake for regressions).**
+**winget gap & macOS signing — don't mistake for regressions.**
 - **winget:** `winget-releaser` only *updates* an existing winget-pkgs package, so the **first**
   submission must be bootstrapped manually. Until then the `winget` job **failing is expected**.
-- **macOS is not notarized:** the Apple signing secrets (`APPLE_*`) aren't set, so the cask ships an
-  unsigned/ad-hoc `.app` (Gatekeeper warns; 3rd-party-tap casks also need `brew trust --cask`).
+- **macOS is signed + notarized:** the Apple signing secrets (`APPLE_*`) **are** configured, so the
+  release pipeline signs the `.app` with an Apple Developer ID and notarizes + staples it (the
+  `Sign, notarize, and zip macOS GUI` step). Gatekeeper accepts the cask normally — **no**
+  quarantine/`xattr` workaround. (Set up in the 2.8.x line; #162.)
 - **Per-arch cask size differs by design:** `maccatalyst-arm64` is Mono-**AOT** (~130 MB), `-x64` is
   Mono-**JIT** (~35 MB). The SDK gates AOT to `maccatalyst-arm64` only (the `RunAOTCompilation`
   property is ignored for MacCatalyst); see the comment in `release.yml`. Not a broken x64 build.

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,8 +30,7 @@ scoop bucket add winprint https://github.com/kindel/scoop-winprint && scoop inst
 brew tap kindel/winprint && brew install winprint
 # Want only the `wp` CLI (no GUI)? Install the formula instead — pick one, they collide:
 #   brew install kindel/winprint/wp
-# The .app is not notarized yet; if Gatekeeper says "WinPrint is damaged", run:
-#   xattr -dr com.apple.quarantine /Applications/WinPrint.app
+# The .app is Apple Developer ID-signed and notarized, so Gatekeeper accepts it normally.
 
 # Open a file in the TUI
 wp program.cs

--- a/docs/install.md
+++ b/docs/install.md
@@ -89,9 +89,8 @@ in a single step.)
 > CLI-only **formula**. (Don't install both the `winprint` cask and the `wp` formula — they each
 > provide `wp` and collide at link time; pick one on macOS.)
 
-> **Note:** the macOS `.app` is **not notarized yet** (Apple signing isn't configured), so it ships
-> ad-hoc signed and Gatekeeper may quarantine it on first launch — see
-> [Troubleshooting](#troubleshooting) below.
+> The macOS `.app` is signed with an **Apple Developer ID** and **notarized by Apple** (and stapled),
+> so Gatekeeper accepts it normally — no quarantine/`xattr` workaround is needed.
 
 ### Prerequisites
 
@@ -175,20 +174,7 @@ wp --version
 
 If `wp` is not found after installation, ensure the install location is in your `PATH`. On Windows, you may need to restart your terminal. On macOS/Linux, Homebrew handles this automatically.
 
-### macOS: "WinPrint is damaged…" / Gatekeeper quarantine
-
-The macOS `.app` is **not notarized yet**, so it ships ad-hoc signed. On first launch macOS
-Gatekeeper may quarantine it and report that **"WinPrint is damaged and can't be opened"**. Clear
-the quarantine attribute to launch it:
-
-```bash
-xattr -dr com.apple.quarantine /Applications/WinPrint.app
-```
-
-Because the cask comes from a third-party tap, you may also need to trust it at install time:
-
-```bash
-brew install --cask kindel/winprint/winprint
-```
+The macOS `.app` is Apple Developer ID–signed and notarized, so Gatekeeper accepts it without the
+*"WinPrint is damaged"* / quarantine errors that unsigned apps trigger — no `xattr` workaround needed.
 
 For additional help, see [Support](support.md) or file an [issue on GitHub](https://github.com/tig/winprint/issues).

--- a/packaging/homebrew/Casks/winprint.rb
+++ b/packaging/homebrew/Casks/winprint.rb
@@ -1,9 +1,9 @@
 # Template rendered by the release pipeline (release.yml -> brew job) and pushed to the
 # kindel/homebrew-winprint tap. Placeholders are filled with each stable release's version,
 # download base URL, and per-arch SHA256s. This is the free MAUI GUI (WinPrint.app),
-# distributed directly (NOT the App Store). NOTE: the app is NOT notarized today — the
-# Apple signing secrets (APPLE_*) aren't configured (tracked in #162), so it ships as an
-# unsigned/ad-hoc build and macOS Gatekeeper quarantine applies on first launch.
+# distributed directly (NOT the App Store). The app is signed with an Apple Developer ID and
+# notarized + stapled by the release pipeline (the APPLE_* secrets are configured), so Gatekeeper
+# accepts it without a quarantine workaround.
 #
 # The GUI bundle ALSO embeds the `wp` TUI (release.yml copies the self-contained CLI payload into
 # WinPrint.app/Contents/Helpers/wp), so this single cask install delivers BOTH the GUI and the `wp`


### PR DESCRIPTION
Fixes docs that wrongly claim the macOS `.app` is unsigned/not-notarized. It **is** Apple Developer ID–signed and **notarized + stapled**.

## Evidence (v3.0.2 release run)
Both `osx-arm64` and `osx-x64` "Sign, notarize, and zip macOS GUI (.app)" steps succeeded:
- codesign: *"valid on disk / satisfies its Designated Requirement"*
- `Notarization status: **Accepted**` (Apple)
- *"The staple and validate action worked!"*

The `APPLE_*` secrets are configured, **#162 is closed**, and `docs/code-signing.md` already documents the Developer ID + notarization runbook (left unchanged — it was correct).

## Why it was wrong
The #184 doc audit was dated **2026-06-25**, just before Apple signing was wired up (secrets added the same day; `2.8.0 — first notarized macOS .app`). That stale "not notarized (#162)" snapshot got carried into the user docs, the cask comment, and the agent docs.

## Changes
- `docs/install.md`, `docs/index.md`: drop the "not notarized yet" notes and the Gatekeeper *"WinPrint is damaged"* / `xattr` quarantine troubleshooting (a notarized + stapled app doesn't hit that).
- `packaging/homebrew/Casks/winprint.rb`: correct the header comment.
- `CLAUDE.md`, `AGENTS.md`: macOS is signed + notarized, not an open gap.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)