### PR TITLE
Ship an x86_64_linux Homebrew bottle so wp installs on toolchain-less Linux (#211)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -576,6 +576,7 @@ jobs:
         shell: bash
         env:
           TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
@@ -584,6 +585,8 @@ jobs:
           sha() { curl -fsSL "$base/$1" | sha256sum | awk '{print $1}'; }
 
           # Formula = free TUI (wp); Cask = free MAUI GUI (WinPrint.app). Both ship via the tap.
+          # The formula's x86_64_linux {{sha_bottle_linux_x64}} is filled AFTER we build the bottle
+          # below (we don't know its SHA until it exists); every other placeholder is filled now.
           sed -e "s|{{version}}|${version}|g" \
               -e "s|{{base}}|${base}|g" \
               -e "s|{{sha_osx_arm}}|$(sha wp-osx-arm64.tar.gz)|" \
@@ -598,10 +601,6 @@ jobs:
               -e "s|{{sha_cask_x64}}|$(sha WinPrint-osx-x64.app.zip)|" \
               packaging/homebrew/Casks/winprint.rb > /tmp/winprint-cask.rb
 
-          # Validate the rendered cask + formula actually LOAD under Homebrew before publishing.
-          # `ruby -c` only checks syntax and misses invalid DSL — e.g. a cask using the formula-only
-          # `conflicts_with formula:` key, which once shipped a cask the tap couldn't even parse.
-          # Load them by name from a throwaway local tap so an invalid stanza fails this job instead.
           # On ubuntu-latest Homebrew is pre-installed but NOT on PATH — load its shellenv first, or
           # every `brew` call below fails with "command not found" and breaks the tap publish.
           if ! command -v brew >/dev/null 2>&1; then
@@ -612,12 +611,54 @@ jobs:
           rm -rf "$VTAP"; mkdir -p "$VTAP/Casks" "$VTAP/Formula"
           git -C "$VTAP" init -q
           cp /tmp/winprint-cask.rb "$VTAP/Casks/winprint.rb"
-          cp /tmp/wp.rb "$VTAP/Formula/wp.rb"
+
+          # --- Build the x86_64_linux bottle (issue #211) --------------------------------------
+          # We build the bottle from a source install of the formula. `wp` compiles nothing (the
+          # "install" just extracts the prebuilt AOT tarball), but Homebrew classifies a bottle-less
+          # formula as a source build and needs a compiler present on THIS runner — ubuntu-latest
+          # ships gcc, so the gate passes (no code is actually compiled). End users then POUR this
+          # bottle and never need a toolchain. Strip the rendered bottle block via its sentinels so
+          # the build formula is bottle-less (its {{sha_bottle_linux_x64}} isn't a valid SHA yet).
+          sed '/# >>> winprint:bottle/,/# <<< winprint:bottle/d' /tmp/wp.rb > "$VTAP/Formula/wp.rb"
           git -C "$VTAP" add -A
-          git -C "$VTAP" -c user.email=ci@example.com -c user.name=ci commit -qm validate
-          echo "Validating rendered cask + formula load under Homebrew…"
+          git -C "$VTAP" -c user.email=ci@example.com -c user.name=ci commit -qm build
+          echo "Validating cask + (bottle-less) formula load under Homebrew…"
           brew info --cask kindel/winprint/winprint > /dev/null
           brew info --formula kindel/winprint/wp > /dev/null
+          echo "Building x86_64_linux bottle…"
+          brew install --build-bottle --verbose kindel/winprint/wp
+          # --skip-relocation makes the built bottle match the formula's :any_skip_relocation DSL
+          # (correct: the payload bakes in no Cellar/prefix paths). --no-rebuild keeps the filename
+          # suffix-free (wp-<version>.<tag>.bottle.tar.gz) for the first bottle of this version.
+          brew bottle --no-rebuild --skip-relocation --root-url="$base" kindel/winprint/wp
+          # `brew bottle` writes <name>--<version>.<tag>.bottle.tar.gz (double dash) into CWD; the
+          # download name Homebrew fetches is single-dash. Content (and thus SHA) is identical.
+          local_bottle="$(ls wp--"${version}".*.bottle.tar.gz)"
+          up_bottle="wp-${version}.x86_64_linux.bottle.tar.gz"
+          mv "$local_bottle" "$up_bottle"
+          bottle_sha="$(sha256sum "$up_bottle" | awk '{print $1}')"
+          echo "Uploading $up_bottle (sha256=$bottle_sha) to release $TAG…"
+          gh release upload "$TAG" "$up_bottle" --clobber
+          brew uninstall --force wp
+
+          # Fill the freshly-built bottle's SHA into the final formula, then re-stage it.
+          sed -i "s|{{sha_bottle_linux_x64}}|${bottle_sha}|" /tmp/wp.rb
+          cp /tmp/wp.rb "$VTAP/Formula/wp.rb"
+          git -C "$VTAP" add -A
+          git -C "$VTAP" -c user.email=ci@example.com -c user.name=ci commit -qm final
+
+          # Validate the FINAL cask + formula LOAD, then POUR-TEST end to end. `brew info` alone
+          # can't catch a missing/mismatched bottle (it never fetches one), so actually install: it
+          # must POUR the bottle we just uploaded (no compiler) and run. Guard on "Pouring" so a
+          # silent fall-back to a source build fails this job instead of shipping a broken bottle.
+          echo "Validating final cask + formula load…"
+          brew info --cask kindel/winprint/winprint > /dev/null
+          brew info --formula kindel/winprint/wp > /dev/null
+          echo "Pour-testing the uploaded bottle…"
+          brew install --verbose kindel/winprint/wp 2>&1 | tee /tmp/pour.log
+          grep -q "Pouring" /tmp/pour.log || { echo "::error title=Bottle pour failed::wp installed without pouring its bottle — the x86_64_linux bottle is missing or mismatched."; exit 1; }
+          wp --version
+          brew uninstall --force wp
           rm -rf "$VTAP"
 
           git clone "https://x-access-token:${TAP_TOKEN}@github.com/kindel/homebrew-winprint.git" tap

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,11 +73,22 @@ smoke-runs the packaged `wp.exe` (`scripts/Test-WindowsVelopackShortcut.ps1`, cu
 **Homebrew (the free distribution path).** Tap = `kindel/homebrew-winprint`, pushed by the release
 `brew` job (needs the `HOMEBREW_TAP_TOKEN` PAT; a missing-token skip now *fails* loudly). TWO
 artifacts in the tap:
-- **Formula** `winprint` → the `wp` TUI (Linux + CLI-only macOS).
+- **Formula** `wp` → the `wp` TUI (Linux + CLI-only macOS).
 - **Cask** `winprint` → the MAUI GUI, which **also embeds `wp`** at `WinPrint.app/Contents/Helpers/wp`
   (release.yml copies the self-contained CLI in *before* signing; a `binary` stanza symlinks it onto
   PATH), so one cask install gives GUI + `wp`. Both provide `wp`, so installing formula + cask
   collides on the symlink — pick one on macOS (casks **cannot** declare `conflicts_with formula:`).
+- **The `wp` formula carries an `x86_64_linux` bottle** (issue #211). `wp` compiles nothing — the
+  "install" just extracts the prebuilt AOT tarball — but Homebrew treats a *bottle-less* formula as a
+  source build and **refuses it on any host with no C compiler** (fresh containers, minimal WSL). The
+  bottle makes `brew install` *pour* a prebuilt tree, so toolchain-less Linux installs cleanly. Bottles
+  are **formula-only**, so this does **not** touch the cask or the GUI+TUI dual install. The `brew` job
+  source-builds the bottle on ubuntu-latest (it has gcc), uploads `wp-<ver>.x86_64_linux.bottle.tar.gz`
+  to the release, renders its SHA into the formula, then **pour-tests** it (guards on `Pouring`) before
+  pushing. **Only `x86_64_linux` is tagged**: every other platform has NO tag and keeps installing from
+  the `url` blocks (macOS has Clang; arm64 Linux source-builds). **Never declare a bottle tag without
+  publishing + pour-testing its file** — a declared-but-missing bottle hard-fails that platform with no
+  source fallback. (arm64 Linux bottle = follow-up; needs bottling on an arm64 runner.)
 - **Validate a cask by LOADING it, never `ruby -c`.** `ruby -c` checks Ruby *syntax* and happily
   passes invalid cask **DSL** (e.g. `conflicts_with formula:` — that key is cask-only-`cask:`), which
   once shipped a tap cask Homebrew couldn't parse and broke `brew install --cask` for everyone. The

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,11 +73,22 @@ smoke-runs the packaged `wp.exe` (`scripts/Test-WindowsVelopackShortcut.ps1`, cu
 **Homebrew (the free distribution path).** Tap = `kindel/homebrew-winprint`, pushed by the release
 `brew` job (needs the `HOMEBREW_TAP_TOKEN` PAT; a missing-token skip now *fails* loudly). TWO
 artifacts in the tap:
-- **Formula** `winprint` → the `wp` TUI (Linux + CLI-only macOS).
+- **Formula** `wp` → the `wp` TUI (Linux + CLI-only macOS).
 - **Cask** `winprint` → the MAUI GUI, which **also embeds `wp`** at `WinPrint.app/Contents/Helpers/wp`
   (release.yml copies the self-contained CLI in *before* signing; a `binary` stanza symlinks it onto
   PATH), so one cask install gives GUI + `wp`. Both provide `wp`, so installing formula + cask
   collides on the symlink — pick one on macOS (casks **cannot** declare `conflicts_with formula:`).
+- **The `wp` formula carries an `x86_64_linux` bottle** (issue #211). `wp` compiles nothing — the
+  "install" just extracts the prebuilt AOT tarball — but Homebrew treats a *bottle-less* formula as a
+  source build and **refuses it on any host with no C compiler** (fresh containers, minimal WSL). The
+  bottle makes `brew install` *pour* a prebuilt tree, so toolchain-less Linux installs cleanly. Bottles
+  are **formula-only**, so this does **not** touch the cask or the GUI+TUI dual install. The `brew` job
+  source-builds the bottle on ubuntu-latest (it has gcc), uploads `wp-<ver>.x86_64_linux.bottle.tar.gz`
+  to the release, renders its SHA into the formula, then **pour-tests** it (guards on `Pouring`) before
+  pushing. **Only `x86_64_linux` is tagged**: every other platform has NO tag and keeps installing from
+  the `url` blocks (macOS has Clang; arm64 Linux source-builds). **Never declare a bottle tag without
+  publishing + pour-testing its file** — a declared-but-missing bottle hard-fails that platform with no
+  source fallback. (arm64 Linux bottle = follow-up; needs bottling on an arm64 runner.)
 - **Validate a cask by LOADING it, never `ruby -c`.** `ruby -c` checks Ruby *syntax* and happily
   passes invalid cask **DSL** (e.g. `conflicts_with formula:` — that key is cask-only-`cask:`), which
   once shipped a tap cask Homebrew couldn't parse and broke `brew install --cask` for everyone. The

--- a/packaging/homebrew/Formula/wp.rb
+++ b/packaging/homebrew/Formula/wp.rb
@@ -36,6 +36,27 @@ class Wp < Formula
     end
   end
 
+  # Homebrew bottle for x86_64 Linux (issue #211). `wp` is a self-contained, prebuilt Native AOT
+  # binary, so the "install" is just extracting the tarball above — no compiler is ever invoked.
+  # But Homebrew treats a formula with NO bottle as a *source* build and refuses it on any host
+  # without a C compiler (fresh containers, minimal WSL). This bottle makes `brew install` POUR a
+  # prebuilt tree instead, so a toolchain-less Linux host installs cleanly. :any_skip_relocation is
+  # correct because the payload bakes in no Cellar paths.
+  #
+  # ONLY x86_64_linux is tagged on purpose. Every other platform intentionally has NO tag and keeps
+  # installing from the `url` blocks above (macOS has Clang via the Command Line Tools; arm64 Linux
+  # source-builds). A declared tag whose bottle file is missing makes Homebrew HARD-FAIL that
+  # platform with no source fallback — so never add a tag here without also publishing AND
+  # pour-testing its bottle file in the release `brew` job. The block below is rendered + built +
+  # uploaded by .github/workflows/release.yml; the sentinel markers let that job strip it to build
+  # the bottle from source first. Do not hand-edit the SHA.
+  # >>> winprint:bottle (rendered by release.yml — do not hand-edit)
+  bottle do
+    root_url "{{base}}"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "{{sha_bottle_linux_x64}}"
+  end
+  # <<< winprint:bottle
+
   def install
     libexec.install Dir["*"]
     bin.install_symlink libexec/"wp"


### PR DESCRIPTION
Fixes #211.

## Problem
`brew install kindel/winprint/wp` fails on Linux hosts with no C compiler:

```
Error: ... cannot be installed from bottle and must be built from source.
Install Clang or run `brew install gcc`.
```

The `wp` formula compiles nothing — its `install` just extracts the prebuilt Native AOT tarball — but Homebrew classifies any **bottle-less** formula as a *source* build and gates that on a compiler being present, even though none is ever invoked. macOS masks this (Command Line Tools ship Clang); a bare Linux Homebrew blocks the install.

## Fix
Publish an **`x86_64_linux` bottle** so `brew install` *pours* a prebuilt tree instead of "building" from source.

- **Formula** (`packaging/homebrew/Formula/wp.rb`): add a sentinel-delimited `bottle do` block (`x86_64_linux`, `:any_skip_relocation`). All `url`/`sha256` source blocks are unchanged.
- **`release.yml` `brew` job**: source-build the bottle on ubuntu-latest (has `gcc`), upload `wp-<ver>.x86_64_linux.bottle.tar.gz` to the release, render its SHA into the formula, then **pour-test end-to-end** (guards on `Pouring`) before pushing to the tap.
- **Docs** (`AGENTS.md`/`CLAUDE.md`): record the bottle behavior + the "never tag without publishing + pour-testing" rule; fix the stale "Formula `winprint`" → `wp`.

## Safety — won't break macOS or the GUI/TUI cask
- **Bottles are formula-only**, so `packaging/homebrew/Casks/winprint.rb` is **untouched** — GUI + embedded-`wp` dual install and the formula↔cask `wp` collision are unchanged (poured vs built ⇒ identical installed layout).
- **Scoped to `x86_64_linux` only.** Every other platform has no bottle tag and keeps its existing source `url` path (macOS has Clang; arm64 Linux source-builds). A declared-but-missing bottle would hard-fail that platform with **no** source fallback — which is exactly why only the one published+pour-tested tag is declared, and why the CI pour-test exists.
- arm64 Linux bottle = follow-up (needs bottling on an arm64 runner).

## Verified locally (against real Homebrew)
- Bottle + matching tag → **pours, no compiler**; missing bottle file → **hard error, no source fallback**; tag omitted → source fallback (today's behavior).
- Final formula (with bottle block) and the sentinel-stripped build formula both **load** under `brew info`; no leftover placeholders; `release.yml` parses as valid YAML.

The live `brew install --build-bottle` / `gh release upload` path only runs on a real tag; the in-job pour-test is the guard that a broken bottle fails the release instead of shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)