### PR TITLE
fix(markdown): render GIFs from HTML img tags (fixes #213)

### DIFF
--- a/src/WinPrint.Core/ContentTypeEngines/MarkdownCte.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/MarkdownCte.cs
@@ -2,6 +2,7 @@
 // Published under the MIT License at https://github.com/tig/winprint
 
 using System.Globalization;
+using System.Net;
 using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -46,6 +47,10 @@ public class MarkdownCte : ContentTypeEngineBase
     private static readonly Regex s_htmlImgAttrRegex = new(
         @"(?<name>src|alt)\s*=\s*(?:""(?<dq>[^""]*)""|'(?<sq>[^']*)'|(?<uq>[^\s""'/>]+))",
         RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex s_htmlCommentRegex = new(
+        @"<!--.*?-->",
+        RegexOptions.Singleline | RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     /// <summary>Decoded image bytes keyed by source URL/path; null marks a load that failed (don't retry).</summary>
     private readonly Dictionary<string, byte[]?> _imageCache = new(StringComparer.Ordinal);
@@ -278,7 +283,7 @@ public class MarkdownCte : ContentTypeEngineBase
                     }
 
                     break;
-                case HtmlBlock html:
+                case HtmlBlock html when !IsHtmlComment(html):
                     foreach ((string src, string alt) in ParseHtmlImages(html))
                     {
                         EmitImage(src, alt, g, fonts, indentLevel, quoteDepth);
@@ -696,8 +701,25 @@ public class MarkdownCte : ContentTypeEngineBase
 
     private static IEnumerable<(string Src, string Alt)> ParseHtmlImages(HtmlBlock block)
     {
-        return ParseHtmlImgTags(block.Lines.ToString());
+        if (IsHtmlComment(block))
+        {
+            yield break;
+        }
+
+        foreach ((string src, string alt) in ParseHtmlImgTags(block.Lines.ToString()))
+        {
+            yield return (src, alt);
+        }
     }
+
+    private static bool IsHtmlComment(HtmlBlock block)
+    {
+        string text = block.Lines.ToString().Trim();
+        return text.StartsWith("<!--", StringComparison.Ordinal)
+               && text.EndsWith("-->", StringComparison.Ordinal);
+    }
+
+    private static string StripHtmlComments(string html) => s_htmlCommentRegex.Replace(html, string.Empty);
 
     private static IEnumerable<(string Src, string Alt)> ParseHtmlImgTags(string html)
     {
@@ -706,7 +728,7 @@ public class MarkdownCte : ContentTypeEngineBase
             yield break;
         }
 
-        foreach (Match tag in s_htmlImgTagRegex.Matches(html))
+        foreach (Match tag in s_htmlImgTagRegex.Matches(StripHtmlComments(html)))
         {
             string attrs = tag.Groups["attrs"].Value;
             string? src = null;
@@ -714,9 +736,9 @@ public class MarkdownCte : ContentTypeEngineBase
             foreach (Match attr in s_htmlImgAttrRegex.Matches(attrs))
             {
                 string name = attr.Groups["name"].Value;
-                string value = attr.Groups["dq"].Success ? attr.Groups["dq"].Value
+                string value = WebUtility.HtmlDecode(attr.Groups["dq"].Success ? attr.Groups["dq"].Value
                     : attr.Groups["sq"].Success ? attr.Groups["sq"].Value
-                    : attr.Groups["uq"].Value;
+                    : attr.Groups["uq"].Value);
                 if (name.Equals("src", StringComparison.OrdinalIgnoreCase))
                 {
                     src = value;
@@ -757,6 +779,11 @@ public class MarkdownCte : ContentTypeEngineBase
 
         foreach (HtmlBlock html in ast.Descendants<HtmlBlock>())
         {
+            if (IsHtmlComment(html))
+            {
+                continue;
+            }
+
             foreach ((string src, _) in ParseHtmlImages(html))
             {
                 await PreloadImageUrlAsync(src);

--- a/src/WinPrint.Core/ContentTypeEngines/MarkdownCte.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/MarkdownCte.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Text.RegularExpressions;
 using Markdig;
 using Markdig.Extensions.Tables;
 using Markdig.Syntax;
@@ -22,9 +23,10 @@ namespace WinPrint.Core.ContentTypeEngines;
 ///     bulleted/numbered/nested lists, blockquotes (indented with a bar), fenced/indented code blocks
 ///     (monospace on a shaded background), horizontal rules, and links (colored). Reflow word-wraps
 ///     styled runs into variable-height <see cref="MarkdownLine" />s and paginates by cumulative height.
-///     Images that sit alone in a paragraph (<c>![alt](src)</c>) are decoded and drawn through
-///     <see cref="IGraphicsContext.DrawImage" />, scaled to fit the page; local files (resolved relative
-///     to <see cref="ContentTypeEngineBase.SourceFileName" />), <c>data:</c> URIs, and <c>http(s)</c>
+///     Images that sit alone in a paragraph (<c>![alt](src)</c> or a standalone HTML <c>&lt;img&gt;</c>)
+///     are decoded and drawn through <see cref="IGraphicsContext.DrawImage" />, scaled to fit the page;
+///     GIFs render their first frame. Local files (resolved relative to
+///     <see cref="ContentTypeEngineBase.SourceFileName" />), <c>data:</c> URIs, and <c>http(s)</c>
 ///     URLs are supported. Anything that fails to load (and inline images mixed with text) falls back
 ///     to alt text.
 /// </summary>
@@ -36,6 +38,14 @@ public class MarkdownCte : ContentTypeEngineBase
         new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
 
     private static readonly HttpClient s_http = new() { Timeout = TimeSpan.FromSeconds(10) };
+
+    private static readonly Regex s_htmlImgTagRegex = new(
+        @"<img\b(?<attrs>[^>]*)/?>",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex s_htmlImgAttrRegex = new(
+        @"(?<name>src|alt)\s*=\s*(?:""(?<dq>[^""]*)""|'(?<sq>[^']*)'|(?<uq>[^\s""'/>]+))",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     /// <summary>Decoded image bytes keyed by source URL/path; null marks a load that failed (don't retry).</summary>
     private readonly Dictionary<string, byte[]?> _imageCache = new(StringComparer.Ordinal);
@@ -254,10 +264,24 @@ public class MarkdownCte : ContentTypeEngineBase
                         quoteDepth > 0 ? QuoteColor : TextColor, indentLevel, quoteDepth,
                         _baseLineHeight * (h.Level <= 2 ? 1.0f : 0.7f));
                     break;
+                case ParagraphBlock p when GetStandaloneHtmlImages(p) is { } htmlImages:
+                    foreach ((string src, string alt) in htmlImages)
+                    {
+                        EmitImage(src, alt, g, fonts, indentLevel, quoteDepth);
+                    }
+
+                    break;
                 case ParagraphBlock p when GetStandaloneImages(p) is { } images:
                     foreach (LinkInline image in images)
                     {
                         EmitImage(image.Url ?? string.Empty, GetInlineText(image), g, fonts, indentLevel, quoteDepth);
+                    }
+
+                    break;
+                case HtmlBlock html:
+                    foreach ((string src, string alt) in ParseHtmlImages(html))
+                    {
+                        EmitImage(src, alt, g, fonts, indentLevel, quoteDepth);
                     }
 
                     break;
@@ -637,26 +661,117 @@ public class MarkdownCte : ContentTypeEngineBase
         return images.Count > 0 ? images : null;
     }
 
+    /// <summary>
+    ///     Returns <c>&lt;img&gt;</c> tags from a paragraph that contains only HTML images and whitespace.
+    /// </summary>
+    private static List<(string Src, string Alt)>? GetStandaloneHtmlImages(ParagraphBlock paragraph)
+    {
+        if (paragraph.Inline is null)
+        {
+            return null;
+        }
+
+        var images = new List<(string Src, string Alt)>();
+        foreach (Inline node in paragraph.Inline)
+        {
+            switch (node)
+            {
+                case HtmlInline html:
+                    foreach ((string src, string alt) in ParseHtmlImgTags(html.Tag))
+                    {
+                        images.Add((src, alt));
+                    }
+
+                    break;
+                case LiteralInline lit when string.IsNullOrWhiteSpace(lit.Content.ToString()):
+                case LineBreakInline:
+                    break;
+                default:
+                    return null;
+            }
+        }
+
+        return images.Count > 0 ? images : null;
+    }
+
+    private static IEnumerable<(string Src, string Alt)> ParseHtmlImages(HtmlBlock block)
+    {
+        return ParseHtmlImgTags(block.Lines.ToString());
+    }
+
+    private static IEnumerable<(string Src, string Alt)> ParseHtmlImgTags(string html)
+    {
+        if (string.IsNullOrWhiteSpace(html))
+        {
+            yield break;
+        }
+
+        foreach (Match tag in s_htmlImgTagRegex.Matches(html))
+        {
+            string attrs = tag.Groups["attrs"].Value;
+            string? src = null;
+            string alt = string.Empty;
+            foreach (Match attr in s_htmlImgAttrRegex.Matches(attrs))
+            {
+                string name = attr.Groups["name"].Value;
+                string value = attr.Groups["dq"].Success ? attr.Groups["dq"].Value
+                    : attr.Groups["sq"].Success ? attr.Groups["sq"].Value
+                    : attr.Groups["uq"].Value;
+                if (name.Equals("src", StringComparison.OrdinalIgnoreCase))
+                {
+                    src = value;
+                }
+                else if (name.Equals("alt", StringComparison.OrdinalIgnoreCase))
+                {
+                    alt = value;
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(src))
+            {
+                yield return (src, alt);
+            }
+        }
+    }
+
     private async Task PreloadImagesAsync(MarkdownDocument ast)
     {
         foreach (ParagraphBlock paragraph in ast.Descendants<ParagraphBlock>())
         {
-            if (GetStandaloneImages(paragraph) is not { } images)
+            if (GetStandaloneImages(paragraph) is { } images)
             {
-                continue;
+                foreach (LinkInline image in images)
+                {
+                    await PreloadImageUrlAsync(image.Url ?? string.Empty);
+                }
             }
 
-            foreach (LinkInline image in images)
+            if (GetStandaloneHtmlImages(paragraph) is { } htmlImages)
             {
-                string url = image.Url ?? string.Empty;
-                if (url.Length == 0 || _imageCache.ContainsKey(url))
+                foreach ((string src, _) in htmlImages)
                 {
-                    continue;
+                    await PreloadImageUrlAsync(src);
                 }
-
-                _imageCache[url] = await LoadImageBytesAsync(url);
             }
         }
+
+        foreach (HtmlBlock html in ast.Descendants<HtmlBlock>())
+        {
+            foreach ((string src, _) in ParseHtmlImages(html))
+            {
+                await PreloadImageUrlAsync(src);
+            }
+        }
+    }
+
+    private async Task PreloadImageUrlAsync(string url)
+    {
+        if (url.Length == 0 || _imageCache.ContainsKey(url))
+        {
+            return;
+        }
+
+        _imageCache[url] = await LoadImageBytesAsync(url);
     }
 
     private async Task<byte[]?> LoadImageBytesAsync(string url)

--- a/src/WinPrint.Core/ContentTypeEngines/MarkdownCte.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/MarkdownCte.cs
@@ -719,7 +719,10 @@ public class MarkdownCte : ContentTypeEngineBase
                && text.EndsWith("-->", StringComparison.Ordinal);
     }
 
-    private static string StripHtmlComments(string html) => s_htmlCommentRegex.Replace(html, string.Empty);
+    private static string StripHtmlComments(string html)
+    {
+        return s_htmlCommentRegex.Replace(html, string.Empty);
+    }
 
     private static IEnumerable<(string Src, string Alt)> ParseHtmlImgTags(string html)
     {

--- a/tests/WinPrint.Core.UnitTests/Cte/CteRenderingTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Cte/CteRenderingTests.cs
@@ -726,7 +726,7 @@ public class CteRenderingTests
         }
         finally
         {
-            Directory.Delete(tempDir, recursive: true);
+            Directory.Delete(tempDir, true);
         }
     }
 

--- a/tests/WinPrint.Core.UnitTests/Cte/CteRenderingTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Cte/CteRenderingTests.cs
@@ -613,6 +613,44 @@ public class CteRenderingTests
         Assert.Contains(paint.DrawnStrings, s => s.Text == "diagram");
     }
 
+    [Theory]
+    [InlineData("![spinner](octocat-spinner-32.gif)")]
+    [InlineData("<img src=\"octocat-spinner-32.gif\" alt=\"spinner\" />")]
+    [InlineData("<p><img src=\"octocat-spinner-32.gif\" alt=\"spinner\" /></p>")]
+    public async Task MarkdownCte_RendersImage_FromLocalGif_FirstFrame(string markdown)
+    {
+        string gifPath = FindTestFile("pull request_files/octocat-spinner-32.gif");
+        string gifDir = Path.GetDirectoryName(gifPath)!;
+
+        var measure = new RecordingGraphicsContext();
+        var cte = new MarkdownCte
+        {
+            ContentSettings = new ContentSettings
+            {
+                Font = new Font { Family = "Courier New", Size = 10 },
+                TabSpaces = 4
+            },
+            MeasurementContext = measure,
+            PageSize = new System.Drawing.SizeF(400, 4000),
+            SourceFileName = Path.Combine(gifDir, "readme.md")
+        };
+
+        Assert.True(await cte.SetDocumentAsync(markdown + "\n"));
+        int pages = await cte.RenderAsync(Dpi96, null);
+        Assert.True(pages >= 1);
+
+        var paint = new RecordingGraphicsContext();
+        for (int p = 1; p <= pages; p++)
+        {
+            cte.PaintPage(paint, p);
+        }
+
+        RecordedImage drawn = Assert.Single(paint.DrawnImages);
+        Assert.True(drawn.Width > 0);
+        Assert.True(drawn.Height > 0);
+        Assert.DoesNotContain(paint.DrawnStrings, s => s.Text.Contains("🖼", StringComparison.Ordinal));
+    }
+
     [Fact]
     public async Task MarkdownCte_CodeBlock_HonorsTabSpacesSetting()
     {

--- a/tests/WinPrint.Core.UnitTests/Cte/CteRenderingTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Cte/CteRenderingTests.cs
@@ -652,6 +652,85 @@ public class CteRenderingTests
     }
 
     [Fact]
+    public async Task MarkdownCte_HtmlCommentWithImg_DoesNotRenderCommentedImage()
+    {
+        string gifPath = FindTestFile("pull request_files/octocat-spinner-32.gif");
+        string gifDir = Path.GetDirectoryName(gifPath)!;
+
+        var measure = new RecordingGraphicsContext();
+        var cte = new MarkdownCte
+        {
+            ContentSettings = new ContentSettings
+            {
+                Font = new Font { Family = "Courier New", Size = 10 },
+                TabSpaces = 4
+            },
+            MeasurementContext = measure,
+            PageSize = new System.Drawing.SizeF(400, 4000),
+            SourceFileName = Path.Combine(gifDir, "readme.md")
+        };
+
+        const string md = "<!-- <img src=\"octocat-spinner-32.gif\" alt=\"hidden\" /> -->\n";
+
+        Assert.True(await cte.SetDocumentAsync(md));
+        int pages = await cte.RenderAsync(Dpi96, null);
+
+        var paint = new RecordingGraphicsContext();
+        for (int p = 1; p <= pages; p++)
+        {
+            cte.PaintPage(paint, p);
+        }
+
+        Assert.Empty(paint.DrawnImages);
+        Assert.DoesNotContain(paint.DrawnStrings, s => s.Text.Contains("hidden", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task MarkdownCte_HtmlImg_DecodesEntitiesInSrcAndAlt()
+    {
+        string gifPath = FindTestFile("pull request_files/octocat-spinner-32.gif");
+        string tempDir = Path.Combine(Path.GetTempPath(), "wp213-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            string encodedName = "a&b.gif";
+            File.Copy(gifPath, Path.Combine(tempDir, encodedName));
+
+            var measure = new RecordingGraphicsContext();
+            var cte = new MarkdownCte
+            {
+                ContentSettings = new ContentSettings
+                {
+                    Font = new Font { Family = "Courier New", Size = 10 },
+                    TabSpaces = 4
+                },
+                MeasurementContext = measure,
+                PageSize = new System.Drawing.SizeF(400, 4000),
+                SourceFileName = Path.Combine(tempDir, "readme.md")
+            };
+
+            const string md = "<img src=\"a&amp;b.gif\" alt=\"R&amp;D spinner\" />\n";
+
+            Assert.True(await cte.SetDocumentAsync(md));
+            int pages = await cte.RenderAsync(Dpi96, null);
+            Assert.True(pages >= 1);
+
+            var paint = new RecordingGraphicsContext();
+            for (int p = 1; p <= pages; p++)
+            {
+                cte.PaintPage(paint, p);
+            }
+
+            Assert.Single(paint.DrawnImages);
+            Assert.DoesNotContain(paint.DrawnStrings, s => s.Text.Contains("🖼", StringComparison.Ordinal));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task MarkdownCte_CodeBlock_HonorsTabSpacesSetting()
     {
         var measure = new RecordingGraphicsContext();


### PR DESCRIPTION
## Summary

Fixes #213: Markdown files that embed GIFs as HTML `<img>` tags (like `README.md`) now render when printing.

## Root cause

Hero GIFs in `README.md` use raw HTML `<img src="docs/hero-tui.gif">`, not Markdown `![alt](src)`. Markdig parses those as `HtmlBlock` nodes, and `MarkdownCte.WalkBlocks()` had no handler for them — images were silently dropped. GIF decode itself was fine (Skia/GDI+/ImageSharp all render the first frame).

## Fix

- Parse `<img src/alt>` from `HtmlBlock` and standalone `HtmlInline` paragraphs
- Preload those URLs alongside existing Markdown image preloading
- Add regression tests for local GIF via Markdown syntax, bare `<img>`, and `<p><img></p>` (matching `docs/index.md`)

## Test plan

- [x] `dotnet test --filter MarkdownCte_RendersImage` (6 passed)