### PR TITLE
fix(brew): drop wp.dbg from wp formula + make the x86_64_linux bottle best-effort

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -619,13 +619,20 @@ jobs:
           #
           # This block is deliberately BEST-EFFORT and isolated in a subshell so a bottle failure
           # can NOT strand the tap. The tap update is what actually ships wp + the GUI cask to
-          # macOS/arm64 users; gating it behind the (fragile) x86_64_linux bottle once pinned every
-          # platform at an old version for four releases (v3.0.6–v3.0.9). If the bottle build or its
-          # pour-test fails, we publish a BOTTLE-LESS formula instead — x86_64 Linux then falls back
-          # to the source `url` (exactly the pre-#211 behavior: needs a compiler; no worse for anyone
-          # else) — and the tap still advances. We keep the declared bottle block ONLY when the
-          # bottle was built, uploaded, AND pour-tested: never declare a tag whose file is
-          # missing/mismatched (that hard-fails the platform with no source fallback).
+          # macOS/arm64 users; gating it behind the (fragile) x86_64_linux bottle deterministically
+          # crashed the v3.0.6/v3.0.8/v3.0.9 brew jobs (elftools choking on wp.dbg — re-running never
+          # helped) and pinned every platform at 3.0.5. If the bottle build or its pour-test fails,
+          # we publish a BOTTLE-LESS formula instead — x86_64 Linux then falls back to the source
+          # `url` (exactly the pre-#211 behavior: needs a compiler; no worse for anyone else) — and
+          # the tap still advances. We keep the declared bottle block ONLY when the bottle was
+          # built, uploaded, AND pour-tested: never declare a tag whose file is missing/mismatched
+          # (that hard-fails the platform with no source fallback).
+          #
+          # The `timeout` wrappers matter: elftools can HANG on a pathological ELF instead of
+          # crashing (observed locally on wp.dbg). A hang inside this subshell would ride out the
+          # 6-hour job timeout and strand the tap push anyway — a bounded kill turns it into just
+          # another best-effort failure. 15 min is generous: a healthy build/pour of this formula
+          # is seconds (it only extracts a ~40 MB tarball).
           rm -f /tmp/bottle_sha
           set +e
           (
@@ -638,7 +645,7 @@ jobs:
             echo "Validating (bottle-less) formula load under Homebrew…"
             brew info --formula kindel/winprint/wp > /dev/null
             echo "Building x86_64_linux bottle…"
-            brew install --build-bottle --verbose kindel/winprint/wp
+            timeout 900 brew install --build-bottle --verbose kindel/winprint/wp
             # --skip-relocation matches the formula's :any_skip_relocation DSL (the payload bakes in
             # no Cellar/prefix paths). --no-rebuild keeps the filename suffix-free for the first
             # bottle of this version.
@@ -663,7 +670,7 @@ jobs:
             git -C "$VTAP" -c user.email=ci@example.com -c user.name=ci commit -qm final
             brew info --formula kindel/winprint/wp > /dev/null
             echo "Pour-testing the uploaded bottle…"
-            brew install --verbose kindel/winprint/wp 2>&1 | tee /tmp/pour.log
+            timeout 900 brew install --verbose kindel/winprint/wp 2>&1 | tee /tmp/pour.log
             grep -q "Pouring" /tmp/pour.log
             wp --version
             brew uninstall --force wp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -608,57 +608,91 @@ jobs:
           fi
           export HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1
           VTAP="$(brew --repository)/Library/Taps/kindel/homebrew-winprint"
+          rm -rf "$VTAP"; mkdir -p "$VTAP/Formula"
+          git -C "$VTAP" init -q
+
+          # --- Build + publish the x86_64_linux bottle (issue #211) — BEST-EFFORT --------------
+          # `wp` compiles nothing (its "install" just extracts the prebuilt AOT tarball), but a
+          # bottle-less formula is treated as a source build that Homebrew refuses on compiler-less
+          # hosts — so we ship an x86_64_linux bottle they can POUR. ubuntu-latest has gcc, so the
+          # `--build-bottle` source install passes the compiler gate (no code is actually compiled).
+          #
+          # This block is deliberately BEST-EFFORT and isolated in a subshell so a bottle failure
+          # can NOT strand the tap. The tap update is what actually ships wp + the GUI cask to
+          # macOS/arm64 users; gating it behind the (fragile) x86_64_linux bottle once pinned every
+          # platform at an old version for four releases (v3.0.6–v3.0.9). If the bottle build or its
+          # pour-test fails, we publish a BOTTLE-LESS formula instead — x86_64 Linux then falls back
+          # to the source `url` (exactly the pre-#211 behavior: needs a compiler; no worse for anyone
+          # else) — and the tap still advances. We keep the declared bottle block ONLY when the
+          # bottle was built, uploaded, AND pour-tested: never declare a tag whose file is
+          # missing/mismatched (that hard-fails the platform with no source fallback).
+          rm -f /tmp/bottle_sha
+          set +e
+          (
+            set -e
+            # Strip the bottle block so the BUILD formula is bottle-less (its sha placeholder isn't
+            # a valid SHA yet), then load-validate + build the bottle from a source install.
+            sed '/# >>> winprint:bottle/,/# <<< winprint:bottle/d' /tmp/wp.rb > "$VTAP/Formula/wp.rb"
+            git -C "$VTAP" add -A
+            git -C "$VTAP" -c user.email=ci@example.com -c user.name=ci commit -qm build
+            echo "Validating (bottle-less) formula load under Homebrew…"
+            brew info --formula kindel/winprint/wp > /dev/null
+            echo "Building x86_64_linux bottle…"
+            brew install --build-bottle --verbose kindel/winprint/wp
+            # --skip-relocation matches the formula's :any_skip_relocation DSL (the payload bakes in
+            # no Cellar/prefix paths). --no-rebuild keeps the filename suffix-free for the first
+            # bottle of this version.
+            brew bottle --no-rebuild --skip-relocation --root-url="$base" kindel/winprint/wp
+            # `brew bottle` writes <name>--<version>.<tag>.bottle.tar.gz (double dash) into CWD; the
+            # download name Homebrew fetches is single-dash. Content (and thus SHA) is identical.
+            local_bottle="$(ls wp--"${version}".*.bottle.tar.gz)"
+            up_bottle="wp-${version}.x86_64_linux.bottle.tar.gz"
+            mv "$local_bottle" "$up_bottle"
+            sha256sum "$up_bottle" | awk '{print $1}' > /tmp/bottle_sha
+            echo "Uploading $up_bottle (sha256=$(cat /tmp/bottle_sha)) to release $TAG…"
+            gh release upload "$TAG" "$up_bottle" --clobber
+            brew uninstall --force wp
+
+            # Stage the FINAL formula (bottle block kept, sha filled) and POUR-TEST end to end.
+            # `brew info` can't catch a missing/mismatched bottle (it never fetches one), so actually
+            # install: it must POUR the uploaded bottle (no compiler) and run. Guard on "Pouring" so
+            # a silent fall-back to a source build is treated as a bottle failure (subshell exits
+            # non-zero -> we publish bottle-less below).
+            sed "s|{{sha_bottle_linux_x64}}|$(cat /tmp/bottle_sha)|" /tmp/wp.rb > "$VTAP/Formula/wp.rb"
+            git -C "$VTAP" add -A
+            git -C "$VTAP" -c user.email=ci@example.com -c user.name=ci commit -qm final
+            brew info --formula kindel/winprint/wp > /dev/null
+            echo "Pour-testing the uploaded bottle…"
+            brew install --verbose kindel/winprint/wp 2>&1 | tee /tmp/pour.log
+            grep -q "Pouring" /tmp/pour.log
+            wp --version
+            brew uninstall --force wp
+          )
+          bottle_rc=$?
+          set -e
+          rm -rf "$VTAP"
+
+          # Finalize the formula to PUSH: keep the bottle block only if the bottle fully succeeded;
+          # otherwise strip it so the tap ships a safe, bottle-less formula that still installs
+          # everywhere it did before #211.
+          if [ "$bottle_rc" -eq 0 ] && [ -s /tmp/bottle_sha ]; then
+            sed -i "s|{{sha_bottle_linux_x64}}|$(cat /tmp/bottle_sha)|" /tmp/wp.rb
+            echo "x86_64_linux bottle published (sha256=$(cat /tmp/bottle_sha))."
+          else
+            echo "::warning title=Homebrew bottle skipped::x86_64_linux bottle build/pour-test failed (rc=${bottle_rc}); publishing a BOTTLE-LESS formula so the tap still advances. x86_64 Linux source-builds (needs a compiler) until the bottle is fixed; all other platforms are unaffected."
+            sed -i '/# >>> winprint:bottle/,/# <<< winprint:bottle/d' /tmp/wp.rb
+          fi
+
+          # Load-validate EXACTLY what we're about to push (cask + final formula) before pushing.
           rm -rf "$VTAP"; mkdir -p "$VTAP/Casks" "$VTAP/Formula"
           git -C "$VTAP" init -q
           cp /tmp/winprint-cask.rb "$VTAP/Casks/winprint.rb"
-
-          # --- Build the x86_64_linux bottle (issue #211) --------------------------------------
-          # We build the bottle from a source install of the formula. `wp` compiles nothing (the
-          # "install" just extracts the prebuilt AOT tarball), but Homebrew classifies a bottle-less
-          # formula as a source build and needs a compiler present on THIS runner — ubuntu-latest
-          # ships gcc, so the gate passes (no code is actually compiled). End users then POUR this
-          # bottle and never need a toolchain. Strip the rendered bottle block via its sentinels so
-          # the build formula is bottle-less (its {{sha_bottle_linux_x64}} isn't a valid SHA yet).
-          sed '/# >>> winprint:bottle/,/# <<< winprint:bottle/d' /tmp/wp.rb > "$VTAP/Formula/wp.rb"
-          git -C "$VTAP" add -A
-          git -C "$VTAP" -c user.email=ci@example.com -c user.name=ci commit -qm build
-          echo "Validating cask + (bottle-less) formula load under Homebrew…"
-          brew info --cask kindel/winprint/winprint > /dev/null
-          brew info --formula kindel/winprint/wp > /dev/null
-          echo "Building x86_64_linux bottle…"
-          brew install --build-bottle --verbose kindel/winprint/wp
-          # --skip-relocation makes the built bottle match the formula's :any_skip_relocation DSL
-          # (correct: the payload bakes in no Cellar/prefix paths). --no-rebuild keeps the filename
-          # suffix-free (wp-<version>.<tag>.bottle.tar.gz) for the first bottle of this version.
-          brew bottle --no-rebuild --skip-relocation --root-url="$base" kindel/winprint/wp
-          # `brew bottle` writes <name>--<version>.<tag>.bottle.tar.gz (double dash) into CWD; the
-          # download name Homebrew fetches is single-dash. Content (and thus SHA) is identical.
-          local_bottle="$(ls wp--"${version}".*.bottle.tar.gz)"
-          up_bottle="wp-${version}.x86_64_linux.bottle.tar.gz"
-          mv "$local_bottle" "$up_bottle"
-          bottle_sha="$(sha256sum "$up_bottle" | awk '{print $1}')"
-          echo "Uploading $up_bottle (sha256=$bottle_sha) to release $TAG…"
-          gh release upload "$TAG" "$up_bottle" --clobber
-          brew uninstall --force wp
-
-          # Fill the freshly-built bottle's SHA into the final formula, then re-stage it.
-          sed -i "s|{{sha_bottle_linux_x64}}|${bottle_sha}|" /tmp/wp.rb
           cp /tmp/wp.rb "$VTAP/Formula/wp.rb"
           git -C "$VTAP" add -A
-          git -C "$VTAP" -c user.email=ci@example.com -c user.name=ci commit -qm final
-
-          # Validate the FINAL cask + formula LOAD, then POUR-TEST end to end. `brew info` alone
-          # can't catch a missing/mismatched bottle (it never fetches one), so actually install: it
-          # must POUR the bottle we just uploaded (no compiler) and run. Guard on "Pouring" so a
-          # silent fall-back to a source build fails this job instead of shipping a broken bottle.
-          echo "Validating final cask + formula load…"
+          git -C "$VTAP" -c user.email=ci@example.com -c user.name=ci commit -qm validate
+          echo "Validating final cask + formula load before push…"
           brew info --cask kindel/winprint/winprint > /dev/null
           brew info --formula kindel/winprint/wp > /dev/null
-          echo "Pour-testing the uploaded bottle…"
-          brew install --verbose kindel/winprint/wp 2>&1 | tee /tmp/pour.log
-          grep -q "Pouring" /tmp/pour.log || { echo "::error title=Bottle pour failed::wp installed without pouring its bottle — the x86_64_linux bottle is missing or mismatched."; exit 1; }
-          wp --version
-          brew uninstall --force wp
           rm -rf "$VTAP"
 
           git clone "https://x-access-token:${TAP_TOKEN}@github.com/kindel/homebrew-winprint.git" tap

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,15 @@ artifacts in the tap:
   the `url` blocks (macOS has Clang; arm64 Linux source-builds). **Never declare a bottle tag without
   publishing + pour-testing its file** — a declared-but-missing bottle hard-fails that platform with no
   source fallback. (arm64 Linux bottle = follow-up; needs bottling on an arm64 runner.)
+  **Two hard-won gotchas (they made v3.0.6–v3.0.9 ship no tap update — brew stuck at 3.0.5):**
+  (1) the formula's `install` **must drop `wp.dbg`** (`rm_f Dir["*.dbg"]`). Homebrew's Linux
+  install *and* pour scan every ELF in the keg (`load_tab` → `undeclared_runtime_dependencies`
+  → `LinkageChecker`), and the vendored `elftools` hangs/crashes on that 48 MB AOT debug file
+  (`undefined method 'header' for nil`) — the *actual* cause of the failed bottle job, not rpath
+  relocation. `wp` itself pours fine; the `.dbg` is useless to users anyway. (2) the bottle build
+  is now **best-effort**: it runs in an isolated subshell, and on any failure the job publishes a
+  **bottle-less** formula so the formula+cask tap push still lands. Never gate the tap update on
+  the (fragile) bottle again.
 - **Validate a cask by LOADING it, never `ruby -c`.** `ruby -c` checks Ruby *syntax* and happily
   passes invalid cask **DSL** (e.g. `conflicts_with formula:` — that key is cask-only-`cask:`), which
   once shipped a tap cask Homebrew couldn't parse and broke `brew install --cask` for everyone. The

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,15 +89,18 @@ artifacts in the tap:
   the `url` blocks (macOS has Clang; arm64 Linux source-builds). **Never declare a bottle tag without
   publishing + pour-testing its file** — a declared-but-missing bottle hard-fails that platform with no
   source fallback. (arm64 Linux bottle = follow-up; needs bottling on an arm64 runner.)
-  **Two hard-won gotchas (they made v3.0.6–v3.0.9 ship no tap update — brew stuck at 3.0.5):**
-  (1) the formula's `install` **must drop `wp.dbg`** (`rm_f Dir["*.dbg"]`). Homebrew's Linux
-  install *and* pour scan every ELF in the keg (`load_tab` → `undeclared_runtime_dependencies`
-  → `LinkageChecker`), and the vendored `elftools` hangs/crashes on that 48 MB AOT debug file
-  (`undefined method 'header' for nil`) — the *actual* cause of the failed bottle job, not rpath
-  relocation. `wp` itself pours fine; the `.dbg` is useless to users anyway. (2) the bottle build
-  is now **best-effort**: it runs in an isolated subshell, and on any failure the job publishes a
-  **bottle-less** formula so the formula+cask tap push still lands. Never gate the tap update on
-  the (fragile) bottle again.
+  **Two hard-won gotchas (they left the tap stuck at 3.0.5 while releases reached 3.0.9 —
+  the bottle step crashed the v3.0.6/v3.0.8/v3.0.9 brew jobs deterministically; v3.0.7's was
+  skipped for unrelated reasons):** (1) the formula's `install` **must drop `wp.dbg`**
+  (`rm_f Dir["*.dbg"]`). Homebrew's Linux install *and* pour scan every ELF in the keg
+  (`load_tab` → `undeclared_runtime_dependencies` → `LinkageChecker`), and the vendored
+  `elftools` crashes — or worse, **hangs** — on that 48 MB AOT debug file (`undefined method
+  'header' for nil`) — the *actual* cause of the failed bottle job, not rpath relocation.
+  `wp` itself pours fine; the `.dbg` is useless to users anyway. (2) the bottle build is now
+  **best-effort**: it runs in an isolated subshell with `timeout`-bounded brew calls (a hang
+  would otherwise outlive the job and strand the tap anyway), and on any failure the job
+  publishes a **bottle-less** formula so the formula+cask tap push still lands. Never gate
+  the tap update on the (fragile) bottle again.
 - **Validate a cask by LOADING it, never `ruby -c`.** `ruby -c` checks Ruby *syntax* and happily
   passes invalid cask **DSL** (e.g. `conflicts_with formula:` — that key is cask-only-`cask:`), which
   once shipped a tap cask Homebrew couldn't parse and broke `brew install --cask` for everyone. The

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,15 +102,18 @@ artifacts in the tap:
   the `url` blocks (macOS has Clang; arm64 Linux source-builds). **Never declare a bottle tag without
   publishing + pour-testing its file** — a declared-but-missing bottle hard-fails that platform with no
   source fallback. (arm64 Linux bottle = follow-up; needs bottling on an arm64 runner.)
-  **Two hard-won gotchas (they made v3.0.6–v3.0.9 ship no tap update — brew stuck at 3.0.5):**
-  (1) the formula's `install` **must drop `wp.dbg`** (`rm_f Dir["*.dbg"]`). Homebrew's Linux
-  install *and* pour scan every ELF in the keg (`load_tab` → `undeclared_runtime_dependencies`
-  → `LinkageChecker`), and the vendored `elftools` hangs/crashes on that 48 MB AOT debug file
-  (`undefined method 'header' for nil`) — the *actual* cause of the failed bottle job, not rpath
-  relocation. `wp` itself pours fine; the `.dbg` is useless to users anyway. (2) the bottle build
-  is now **best-effort**: it runs in an isolated subshell, and on any failure the job publishes a
-  **bottle-less** formula so the formula+cask tap push still lands. Never gate the tap update on
-  the (fragile) bottle again.
+  **Two hard-won gotchas (they left the tap stuck at 3.0.5 while releases reached 3.0.9 —
+  the bottle step crashed the v3.0.6/v3.0.8/v3.0.9 brew jobs deterministically; v3.0.7's was
+  skipped for unrelated reasons):** (1) the formula's `install` **must drop `wp.dbg`**
+  (`rm_f Dir["*.dbg"]`). Homebrew's Linux install *and* pour scan every ELF in the keg
+  (`load_tab` → `undeclared_runtime_dependencies` → `LinkageChecker`), and the vendored
+  `elftools` crashes — or worse, **hangs** — on that 48 MB AOT debug file (`undefined method
+  'header' for nil`) — the *actual* cause of the failed bottle job, not rpath relocation.
+  `wp` itself pours fine; the `.dbg` is useless to users anyway. (2) the bottle build is now
+  **best-effort**: it runs in an isolated subshell with `timeout`-bounded brew calls (a hang
+  would otherwise outlive the job and strand the tap anyway), and on any failure the job
+  publishes a **bottle-less** formula so the formula+cask tap push still lands. Never gate
+  the tap update on the (fragile) bottle again.
 - **Validate a cask by LOADING it, never `ruby -c`.** `ruby -c` checks Ruby *syntax* and happily
   passes invalid cask **DSL** (e.g. `conflicts_with formula:` — that key is cask-only-`cask:`), which
   once shipped a tap cask Homebrew couldn't parse and broke `brew install --cask` for everyone. The

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,15 @@ artifacts in the tap:
   the `url` blocks (macOS has Clang; arm64 Linux source-builds). **Never declare a bottle tag without
   publishing + pour-testing its file** — a declared-but-missing bottle hard-fails that platform with no
   source fallback. (arm64 Linux bottle = follow-up; needs bottling on an arm64 runner.)
+  **Two hard-won gotchas (they made v3.0.6–v3.0.9 ship no tap update — brew stuck at 3.0.5):**
+  (1) the formula's `install` **must drop `wp.dbg`** (`rm_f Dir["*.dbg"]`). Homebrew's Linux
+  install *and* pour scan every ELF in the keg (`load_tab` → `undeclared_runtime_dependencies`
+  → `LinkageChecker`), and the vendored `elftools` hangs/crashes on that 48 MB AOT debug file
+  (`undefined method 'header' for nil`) — the *actual* cause of the failed bottle job, not rpath
+  relocation. `wp` itself pours fine; the `.dbg` is useless to users anyway. (2) the bottle build
+  is now **best-effort**: it runs in an isolated subshell, and on any failure the job publishes a
+  **bottle-less** formula so the formula+cask tap push still lands. Never gate the tap update on
+  the (fragile) bottle again.
 - **Validate a cask by LOADING it, never `ruby -c`.** `ruby -c` checks Ruby *syntax* and happily
   passes invalid cask **DSL** (e.g. `conflicts_with formula:` — that key is cask-only-`cask:`), which
   once shipped a tap cask Homebrew couldn't parse and broke `brew install --cask` for everyone. The

--- a/packaging/homebrew/Formula/wp.rb
+++ b/packaging/homebrew/Formula/wp.rb
@@ -58,6 +58,13 @@ class Wp < Formula
   # <<< winprint:bottle
 
   def install
+    # Drop the separated debug-symbol file (wp.dbg) before installing. It is useless to end
+    # users and — critically — Homebrew's Linux install/pour path scans every ELF in the keg
+    # (load_tab -> undeclared_runtime_dependencies -> LinkageChecker), and the vendored
+    # elftools gem hangs/crashes parsing this AOT .dbg file ("undefined method 'header' for
+    # nil"). That crash is what kept the x86_64_linux bottle from ever pouring (issue #211).
+    # Removing it here keeps it out of both the poured bottle and the url/source install path.
+    rm_f Dir["*.dbg"]
     libexec.install Dir["*"]
     bin.install_symlink libexec/"wp"
   end


### PR DESCRIPTION
## TL;DR
Homebrew has been **stuck at 3.0.5** while GitHub releases + winget advanced to **3.0.9**. The `Update Homebrew tap` job crashed on **v3.0.6, v3.0.8, and v3.0.9** — deterministically, with the identical `NoMethodError: undefined method 'header' for nil` (v3.0.7's brew job was *skipped*: all `Package <rid>` jobs failed first for unrelated reasons). This fixes the real cause and makes sure a bottle failure — or hang — can never strand the tap again.

*(Root cause found here on Linux against real Homebrew; independently verified from the release-run side on macOS — see the comment below, which also supplied the v3.0.7 correction and the determinism evidence.)*

## Why brew was stuck
The `brew` job pushes the tap **at the very end**, *after* building the x86_64_linux bottle (the #211 feature, merged in `eda30fb` ~2h after the last good release v3.0.5 — v3.0.6 was simply the first release to *run* the bottle step). When the bottle build dies, the whole `run:` aborts under `set -euo pipefail` and the formula+cask push never happens — pinning **every** platform (macOS, arm64 Linux, the cask) at 3.0.5, not just x86_64-Linux bottle users. The failure is **deterministic** (a re-run of v3.0.8's job reproduced it exactly), so `gh run rerun --failed` could never recover the tap.

## Root cause (verified locally against real Homebrew, no compiler)
Not rpath / patchelf relocation (the initial hypothesis). The payload ships **`wp.dbg`** — a **48 MB DWARF debug ELF** — right next to `wp`. Homebrew's Linux **install *and* pour** both run a keg-wide dependency scan:

```
FormulaInstaller#pour
  -> Utils::Bottles.load_tab            # forces runtime_dependencies(read_from_tab: false)
    -> Formula#undeclared_runtime_dependencies
      -> LinkageChecker#check_dylibs    # walks EVERY ELF in the keg
        -> ELFShim#dynamically_linked_libraries -> PatchELF::Patcher#needed
          -> ELFTools::Dynamic ... str_offset  ==> undefined method 'header' for nil
```

`elftools 1.3.1` chokes on `wp.dbg`'s `.dynamic` — in CI it crashed; locally it **hung** (which is worse: a hang would ride out the 6-hour job timeout). Key facts confirmed with brew's own vendored gems:
- **`wp` itself parses and pours fine** (`needed = [libm, libc, ld-linux]`). It's `wp.dbg` that breaks the scanner.
- The scan runs on **`brew install --build-bottle`** (CI) *and* on a plain **`brew install` pour** — so the bottle #211 shipped would have been **unpourable by end users** even if CI had built it.
- Homebrew already carries a `skip_protodesc_cold` guard for exactly this "patchelf/elftools chokes on unusual ELF sections" class of bug (Go, protobuf); .NET AOT is another such case.

### Proof
Hand-built the x86_64_linux bottle from the real v3.0.9 tarball and poured it locally with **no compiler present**:
- Bottle **with** `wp.dbg` → `Error: undefined method 'header' for nil` (reproduces CI exactly).
- Bottle **without** `wp.dbg` → `==> Pouring wp-3.0.9.x86_64_linux.bottle.tar.gz` → `wp 3.0.9+…` runs, `rc=0`. ✅
- Edited formula (`rm_f Dir["*.dbg"]`) + no-dbg bottle → `brew info` loads, `brew install` pours, `wp --version` works. ✅

## Changes
1. **`packaging/homebrew/Formula/wp.rb`** — `rm_f Dir["*.dbg"]` before `libexec.install`. Keeps the debug file out of both the poured bottle and the `url`/source install path. (It's useless to end users and bloats the install.)
2. **`.github/workflows/release.yml` (`brew` job)** — the bottle build/upload/pour-test now runs in an **isolated best-effort subshell** with **`timeout 900`-bounded brew installs** (so an elftools *hang* becomes just another best-effort failure instead of eating the job; a healthy build/pour is seconds). On any failure the job publishes a **BOTTLE-LESS** formula (x86_64 Linux falls back to the source `url`, exactly as pre-#211 — no worse for anyone else) so the **formula+cask tap push always lands**. The declared `bottle do` block is kept **only** when the bottle was built, uploaded, *and* pour-tested — never a declared-but-missing tag. Final cask+formula load-validation still runs before push.
3. **`CLAUDE.md` / `AGENTS.md`** — record both gotchas and the accurate failure history.

## Scope / decisions
- Kept the existing `brew install --build-bottle` mechanism (it should now succeed with `wp.dbg` gone; can't be run locally without gcc). The best-effort wrapper + timeouts are the safety net if it still misbehaves in CI.
- **Tap catch-up:** by design this only takes effect on the **next release** (e.g. v3.0.10) — no manual push against the live tap (still at `version "3.0.5"`, last tap commit "winprint 3.0.5", Jul 3).
- Out of scope: the separate, known-experimental **win-arm64** package leg (`continue-on-error`), and the arm64-Linux bottle follow-up.

## Test plan
- [x] Repro + fix proven locally against real Homebrew 6.0.6 (pour with no compiler).
- [x] Root cause + determinism independently verified from the release-run side (macOS agent, comment below).
- [x] Edited formula loads (`brew info --formula`) and pours + runs.
- [x] `release.yml` YAML validates.
- [ ] Confirmed on the next real release run (tap advances; bottle pours or job falls back cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)