### PR TITLE
fix(tui): bump Terminal.Gui to 2.4.17 — fixes File dialog crash on Linux (#5544)

### DIFF
--- a/src/WinPrint.TUI/Program.cs
+++ b/src/WinPrint.TUI/Program.cs
@@ -34,7 +34,12 @@ VelopackApp.Build().Run();
 // standard .tui config locations (~/.tui/config.json, ./.tui/wp.config.json, TUI_CONFIG), so
 // users — and the hero-GIF recorder, which themes wp via ./.tui/wp.config.json — couldn't
 // restyle the app.
+// TG 2.4.16+ marks ConfigurationManager [Obsolete] (CS0618) ahead of removal in favor of
+// TuiConfigurationBuilder / Microsoft.Extensions.Configuration; it still works. Suppress the
+// deprecation warning for now — migrating to TuiConfigurationBuilder is tracked as follow-up.
+#pragma warning disable CS0618 // Type or member is obsolete
 ConfigurationManager.Enable(ConfigLocations.All);
+#pragma warning restore CS0618
 
 CliHost host = new(options =>
 {

--- a/src/WinPrint.TUI/WinPrint.TUI.csproj
+++ b/src/WinPrint.TUI/WinPrint.TUI.csproj
@@ -21,7 +21,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Terminal.Gui" Version="2.4.13" />
+        <PackageReference Include="Terminal.Gui" Version="2.4.17" />
         <PackageReference Include="Terminal.Gui.Cli" Version="0.3.0" />
         <PackageReference Include="Terminal.Gui.Editor" Version="2.5.5" />
         <PackageReference Include="Velopack" Version="1.1.1" />


### PR DESCRIPTION
## Problem
On Linux, **Alt-F (📁 File…) crashed the entire `wp` app.** On any host with snapd (Ubuntu, WSL), Terminal.Gui's file-dialog enumeration hit `/run/snapd/ns` — a root-only mount-namespace dir — threw an unhandled `UnauthorizedAccessException` (`Access to the path '/run/snapd/ns' is denied`), and the process died (exit 1). Discovered during first-ever Linux user-testing of `wp` (installed via the freshly-repaired brew bottle).

Root cause was upstream: Terminal.Gui [#5544](https://github.com/tui-cs/Terminal.Gui/issues/5544) — FileDialog mishandled an unreadable directory entry.

## Fix
Bump `Terminal.Gui` **2.4.13 → 2.4.17**, which carries both halves of the upstream fix:
- **#5548** (in 2.4.16) — stops the crash, but rendered the directory **empty** (one unreadable entry blanked the whole listing → dialog unusable).
- **#5569** (in 2.4.17) — completes it: the unreadable entry is skipped and the rest of the directory lists normally.

## Verified in a PTY on the snapd host that reproduced the crash
| TG version | Alt-F File dialog |
|---|---|
| 2.4.13 (was shipping) | 💥 crashes app, exit 1 |
| 2.4.16 | survives, but dialog renders **empty** |
| **2.4.17 (this PR)** | ✅ opens **populated** (dirs + files + sizes/dates), navigable, accepts typed paths, no crash, **clean stderr** |

Also spot-checked the rest of the TUI on Linux: renders correctly, zoom (`=`/`-`/`0`) and Landscape toggle reshape the preview, Print degrades gracefully (`No printers found… lpr/CUPS`), quit clean.

## Note on `ConfigurationManager`
TG 2.4.16+ marks `ConfigurationManager` `[Obsolete]` (CS0618) ahead of removal, in favor of `TuiConfigurationBuilder` — **it still works**. The call added in #224 is wrapped in a targeted `#pragma warning disable CS0618` with a comment; the build stays green under `TreatWarningsAsErrors`. Migrating to `TuiConfigurationBuilder` is **separate follow-up** (will file an issue).

Builds clean (0 errors, warnings-as-errors on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)