### PR TITLE
fix(tui): park cursor below the prompt after headless wp commands

### DIFF
--- a/src/WinPrint.TUI/GuiCommand.cs
+++ b/src/WinPrint.TUI/GuiCommand.cs
@@ -50,16 +50,23 @@ public sealed class GuiCommand : ICliCommand
 
         try
         {
-            GuiLauncher.Launch(BuildArguments(options));
-            return Task.FromResult(new CommandResult(CommandStatus.Ok, "Opened WinPrint GUI.", null, null));
+            try
+            {
+                GuiLauncher.Launch(BuildArguments(options));
+                return Task.FromResult(new CommandResult(CommandStatus.Ok, "Opened WinPrint GUI.", null, null));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Task.FromResult(new CommandResult(CommandStatus.Error, null, ex.GetType().Name, ex.Message));
+            }
+            catch (Win32Exception ex)
+            {
+                return Task.FromResult(new CommandResult(CommandStatus.Error, null, ex.GetType().Name, ex.Message));
+            }
         }
-        catch (InvalidOperationException ex)
+        finally
         {
-            return Task.FromResult(new CommandResult(CommandStatus.Error, null, ex.GetType().Name, ex.Message));
-        }
-        catch (Win32Exception ex)
-        {
-            return Task.FromResult(new CommandResult(CommandStatus.Error, null, ex.GetType().Name, ex.Message));
+            HeadlessInlineTeardown.ReserveInlineRegion(app);
         }
     }
 

--- a/src/WinPrint.TUI/HeadlessInlineTeardown.cs
+++ b/src/WinPrint.TUI/HeadlessInlineTeardown.cs
@@ -1,0 +1,37 @@
+using System.Drawing;
+using Terminal.Gui.App;
+using Terminal.Gui.Drivers;
+
+namespace WinPrint.TUI;
+
+/// <summary>
+///     Helpers for <see cref="CommandKind.Input" /> commands that run without a TUI view tree.
+/// </summary>
+internal static class HeadlessInlineTeardown
+{
+    /// <summary>
+    ///     Reserves an inline screen region so Terminal.Gui teardown parks the cursor below the
+    ///     shell prompt instead of on it (#240).
+    /// </summary>
+    /// <remarks>
+    ///     <see cref="Terminal.Gui.Cli.CliHost" /> wraps every command in an inline
+    ///     <see cref="IApplication" /> session. Commands such as <c>wp print</c> never call
+    ///     <c>RunAsync</c> on a view, so <see cref="IApplication.Screen" /> height stays zero and
+    ///     <c>AnsiOutput.Dispose</c> leaves the cursor at <see cref="IDriver.InlinePosition" /> —
+    ///     the row where the prompt was. The host then writes the command result there, overwriting
+    ///     earlier terminal output. Claim one row at the inline anchor so dispose advances the
+    ///     cursor to the line below the prompt.
+    /// </remarks>
+    internal static void ReserveInlineRegion(IApplication? app, int rows = 1)
+    {
+        if (app is not { AppModel: AppModel.Inline } || app.Driver is not { } driver)
+        {
+            return;
+        }
+
+        int width = Math.Max(1, driver.Screen.Width);
+        int height = Math.Max(1, rows);
+        int startRow = Math.Max(0, driver.InlinePosition.Y);
+        app.Screen = new Rectangle(0, startRow, width, height);
+    }
+}

--- a/src/WinPrint.TUI/PrintCommand.cs
+++ b/src/WinPrint.TUI/PrintCommand.cs
@@ -52,32 +52,39 @@ public sealed class PrintCommand : ICliCommand
     {
         ArgumentNullException.ThrowIfNull(options);
 
-        if (options.Arguments.Count == 0)
-        {
-            return new CommandResult(CommandStatus.Error, null, "NoFiles",
-                "Specify at least one file to print, e.g. `wp print Program.cs`.");
-        }
-
-        bool whatIf = CommandOptionsBinder.GetFlag(options, "what-if");
-        var output = new StringBuilder();
-        int totalSheets = 0;
-
         try
         {
-            foreach (string file in options.Arguments)
+            if (options.Arguments.Count == 0)
             {
-                cancellationToken.ThrowIfCancellationRequested();
-                totalSheets += await PrintOneAsync(file, options, whatIf, output).ConfigureAwait(false);
+                return new CommandResult(CommandStatus.Error, null, "NoFiles",
+                    "Specify at least one file to print, e.g. `wp print Program.cs`.");
             }
-        }
-        catch (Exception ex) when (ex is InvalidOperationException or IOException or UnauthorizedAccessException)
-        {
-            return new CommandResult(CommandStatus.Error, output.ToString().TrimEnd(), ex.GetType().Name, ex.Message);
-        }
 
-        string verb = whatIf ? "would print" : "printed";
-        output.Append($"{options.Arguments.Count} file(s) {verb} {totalSheets} sheet(s).");
-        return new CommandResult(CommandStatus.Ok, output.ToString().TrimEnd(), null, null);
+            bool whatIf = CommandOptionsBinder.GetFlag(options, "what-if");
+            var output = new StringBuilder();
+            int totalSheets = 0;
+
+            try
+            {
+                foreach (string file in options.Arguments)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    totalSheets += await PrintOneAsync(file, options, whatIf, output).ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex) when (ex is InvalidOperationException or IOException or UnauthorizedAccessException)
+            {
+                return new CommandResult(CommandStatus.Error, output.ToString().TrimEnd(), ex.GetType().Name, ex.Message);
+            }
+
+            string verb = whatIf ? "would print" : "printed";
+            output.Append($"{options.Arguments.Count} file(s) {verb} {totalSheets} sheet(s).");
+            return new CommandResult(CommandStatus.Ok, output.ToString().TrimEnd(), null, null);
+        }
+        finally
+        {
+            HeadlessInlineTeardown.ReserveInlineRegion(app);
+        }
     }
 
     // Loads one file, applies the options, and either prints it or (for --what-if) counts its sheets.

--- a/src/WinPrint.TUI/PrintCommand.cs
+++ b/src/WinPrint.TUI/PrintCommand.cs
@@ -74,7 +74,8 @@ public sealed class PrintCommand : ICliCommand
             }
             catch (Exception ex) when (ex is InvalidOperationException or IOException or UnauthorizedAccessException)
             {
-                return new CommandResult(CommandStatus.Error, output.ToString().TrimEnd(), ex.GetType().Name, ex.Message);
+                return new CommandResult(CommandStatus.Error, output.ToString().TrimEnd(), ex.GetType().Name,
+                    ex.Message);
             }
 
             string verb = whatIf ? "would print" : "printed";

--- a/tests/WinPrint.TUI.UnitTests/HeadlessInlineTeardownTests.cs
+++ b/tests/WinPrint.TUI.UnitTests/HeadlessInlineTeardownTests.cs
@@ -1,0 +1,47 @@
+using System.Drawing;
+using Terminal.Gui.App;
+using Terminal.Gui.Drivers;
+using WinPrint.TUI;
+using Xunit;
+
+namespace WinPrint.TUI.UnitTests;
+
+/// <summary>
+///     Guards the inline teardown helper used by headless <c>wp</c> commands (#240).
+/// </summary>
+public class HeadlessInlineTeardownTests
+{
+    [Fact]
+    public void ReserveInlineRegion_NullApp_DoesNotThrow()
+    {
+        HeadlessInlineTeardown.ReserveInlineRegion(null);
+    }
+
+    [Fact]
+    public void ReserveInlineRegion_FullScreenApp_DoesNotThrow()
+    {
+        using IApplication app = Application.Create();
+        app.Init(DriverRegistry.Names.ANSI);
+        app.AppModel = AppModel.FullScreen;
+
+        HeadlessInlineTeardown.ReserveInlineRegion(app);
+    }
+
+    [Fact]
+    public void ReserveInlineRegion_InlineApp_SetsScreenFromInlineAnchor()
+    {
+        Environment.SetEnvironmentVariable("DisableRealDriverIO", "1");
+        using IApplication app = Application.Create();
+        app.Init(DriverRegistry.Names.ANSI);
+        app.AppModel = AppModel.Inline;
+        app.ForceInlinePosition = new Point(0, 4);
+        app.Driver!.InlinePosition = new Point(0, 4);
+        app.Driver.SetScreenSize(80, 24);
+
+        HeadlessInlineTeardown.ReserveInlineRegion(app);
+
+        Assert.Equal(4, app.Screen.Y);
+        Assert.Equal(1, app.Screen.Height);
+        Assert.Equal(80, app.Screen.Width);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #240.

After \wp print\ or \wp gui\ returned, the shell prompt and command output rendered at a stale row, overwriting earlier terminal content (e.g. prior \ls\ output) instead of continuing below it.

## Root cause

\Terminal.Gui.Cli\ wraps every \CommandKind.Input\ command in an inline Terminal.Gui session. Headless commands like \wp print\ never call \RunAsync\ on a view, so \IApplication.Screen.Height\ stays zero. On teardown, \AnsiOutput.Dispose\ parks the cursor at \Screen.Y\ — the shell-prompt row — and \ResultWriter\ then writes the summary there.

## Fix

Reserve a one-row inline region at teardown (\HeadlessInlineTeardown.ReserveInlineRegion\) so Terminal.Gui parks the cursor on the line below the prompt. Applied to \PrintCommand\ and \GuiCommand\.

## Testing

- Added \HeadlessInlineTeardownTests\ (null/fullscreen no-op, inline sets \Screen\ from anchor)
- Existing \PrintCommandTests\ still pass
- Repro: run \ls\, then \wp print <file> --what-if\ — summary should appear below prior output, not overwrite it