### PR TITLE
docs: restore web edits to demo.md and users-guide.md clobbered by #243

### DIFF
--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -2,19 +2,18 @@
 
 ## Features
 
-* Prints source code in hundreds of programming languages with syntax highlighting and line numbering.
-* Prints HTML files.
-* Prints Markdown files as formatted documents (headings, lists, blockquotes, code blocks, and inline images).
-* Prints ANSI-encoded text and colorized console captures (`.ans`/`.ansi`), decoding ANSI escape sequences to color.
-* Prints "multiple-pages-up" on one piece of paper (saves trees!)
+* Beautifully Prints:
+  * Source code in hundreds of programming languages with syntax highlighting and line numbering.
+  * HTML files.
+  * Markdown files as formatted documents (headings, lists, blockquotes, code blocks, mermaid diagrams, and inline images).
+  * ANSI-encoded text and colorized console captures (`.ans`/`.ansi`), decoding ANSI escape sequences to color.
+* Saves trees printing "multiple-pages-up" on one piece of paper.
 * Complete control over page formatting options, including headers and footers, margins, fonts, page orientation, etc.
 * Headers and Footers support detailed file and print information macros with rich date/time formatting.
-* Simple and elegant graphical user interface with accurate print preview on Windows and macOS.
-* `wp` provides a terminal UI on Windows, macOS, and Linux.
-* `wp gui` launches the GUI on Windows and macOS.
 * Sheet Definitions make it easy to save settings for frequent print jobs.
+* Accurate print preview in the GUI *and* TUI.
+* `wp` provides a rich command line interface (CLI) on Windows, macOs, and Linux
 * Comprehensive logging.
-* Cross-platform TUI; Windows and macOS GUI; Linux GUI is deferred.
 
 ## Command Line Interface
 
@@ -29,12 +28,18 @@ wp [options] [file...]
 | Command | Description |
 |---------|-------------|
 | `wp file.cs` | Open a file in the TUI |
-| `wp` | Launch the TUI (terminal user interface) |
+| `wp` | Launch the TUI |
 | `wp print file.cs` | Print one or more files without opening the UI |
 | `wp gui` | Launch the graphical user interface on Windows/macOS |
 | `wp gui file.cs` | Launch the GUI with a file (and options) loaded |
 
 ### Examples
+
+Turn Markdown into a PDF (the classic move; see [the overview](index.md#how-to-turn-markdown-into-a-pdf) for it in action). Markdown prints as a formatted document, with images, tables, syntax-highlighted code, and mermaid fences rendered as diagrams:
+
+```bash
+wp print README.md --printer "Microsoft Print to PDF" --sheet "Proportional 1-Up"
+```
 
 Check the installed version:
 
@@ -219,9 +224,15 @@ The **winprint** GUI can be used to change many Sheet Definition settings. All s
 
 **winprint** supports five types of files. Support for each is provided by a **winprint** Content Type Engine (CTE):
 
-1. **`TextMateCte`** - This is the default CTE used for most text and source files. It uses bundled TextMate grammars for syntax highlighting.
+### `TextMateCte`
 
-2. **`MarkdownCte`** - Renders Markdown files (`text/x-markdown`; e.g. `.md`) as formatted documents, including inline images. ` ```mermaid ` fenced code blocks are rendered as diagrams by default using the remote `mermaid.ink` service (diagram source is sent over the network; broadest compatibility). Unsupported types or render failures fall back to code blocks. Set `mermaidBackend: "builtin"` for the private in-process Mermaider renderer (supports fewer diagram types and has some syntax restrictions). See the support matrix in `testfiles/mermaid.md`.
+This is the default CTE used for most text and source files. It uses bundled TextMate grammars for syntax highlighting.
+
+### `MarkdownCte`
+
+Renders Markdown files (`text/x-markdown`; e.g. `.md`) as formatted documents, including inline images. ` ```mermaid ` fenced code blocks are rendered as diagrams by default using the remote `mermaid.ink` service (diagram source is sent over the network; broadest compatibility). Unsupported diagram types, and diagrams that fail to render, print as regular code blocks.
+
+Options in the `markdownContentTypeEngineSettings` section of `WinPrint.config.json`: set `renderMermaidDiagrams` to `false` to always print fences as code, or set `mermaidBackend` to `"builtin"` for the private in-process Mermaider renderer (nothing is sent over the network, but it supports fewer diagram types and has some syntax restrictions). See the support matrix in `testfiles/mermaid.md`.
 
    ```json
        "markdownContentTypeEngineSettings": {
@@ -231,11 +242,19 @@ The **winprint** GUI can be used to change many Sheet Definition settings. All s
        }
    ```
 
-3. **`AnsiCte`** - Decodes files containing `ANSI Escape Sequences` (`text/ansi`; e.g. `.ans`/`.ansi` ANSI-art and colorized console captures), reflowing them for the page.
+### `AnsiCte`
 
-4. **`TextCte`** - This CTE knows only how to print raw `text/plain` files. The format of the printed text can be changed (e.g. to turn off line numbers or use a different font). Lines that are too long for a page are wrapped at character boundaries. `\f` (form feed) characters can be made to cause following text to print on the next page (this is off by default). Settings for `text/plain` can be changed by editing the `textContentTypeEngineSettings` section or a Sheet Definition in `WinPrint.config.json`.
+Decodes files containing `ANSI Escape Sequences` (`text/ansi`; e.g. `.ans`/`.ansi` ANSI-art and colorized console captures), reflowing them for the page.
 
-5. **`HtmlCte`** - Renders HTML files (`text/html`; e.g. `.html`/`.htm`, as well as `.mhtml`/`.mht` web archives) by laying out the HTML/CSS. Any CSS specified inline in the HTML file will be honored. Local (document-relative) files, `data:` URIs, and MHTML-embedded resources always load; `http(s)` resources are only fetched when `AllowRemoteResources` is enabled. `text/html` does not support line numbers.
+### `TextCte`
+
+This CTE knows only how to print raw `text/plain` files. The format of the printed text can be changed (e.g. to turn off line numbers or use a different font). Lines that are too long for a page are wrapped at character boundaries. `\f` (form feed) characters can be made to cause following text to print on the next page (this is off by default). Settings for `text/plain` can be changed by editing the `textContentTypeEngineSettings` section or a Sheet Definition in `WinPrint.config.json`.
+
+### `HtmlCte`
+
+Renders HTML files (`text/html`; e.g. `.html`/`.htm`, as well as `.mhtml`/`.mht` web archives) by laying out the HTML/CSS. Any CSS specified inline in the HTML file will be honored. Local (document-relative) files, `data:` URIs, and MHTML-embedded resources always load; `http(s)` resources are only fetched when `AllowRemoteResources` is enabled. `text/html` does not support line numbers.
+
+### Overriding Default CTE selection
 
 When using **winprint** from the command line, the `--content-type` (`-e`) option can be used to specify the content type / CTE to use.
 

--- a/testfiles/demo.md
+++ b/testfiles/demo.md
@@ -22,37 +22,57 @@ strongly about), ***both at once*** (for the parts I felt strongly about AND nob
 `inline code` (for the parts that actually matter), and ~~strikethrough~~ (for the features I
 swore I would ship in 1994).
 
-Here is a footnote, because a printing app absolutely needs footnotes.[^1]
+Here is a footnote, because BobAtk, the inventor of COM and my mentor, taught me to use them effectively.[^1]
 
 [^1]: I added footnote support at 2am. Nobody asked. This is the whole story of WinPrint.
 
-## Lists, ordered and otherwise
+## Mermaid Diagrams
 
-Unordered, nested, mildly judgmental:
+The fenced block below prints as an actual diagram using the default `mermaid.ink` service (or the in-process `builtin` backend if configured); set `renderMermaidDiagrams` to `false` if you liked the code better. The promissory note, paid:
+
+```mermaid
+graph LR
+    A[Have idea] --> B{Over-engineer it?}
+    B -->|Always| C[Add a feature]
+    C --> D[Nobody uses it]
+    D --> A
+    B -->|Never| E[Ship on time]
+    E -.->|has never happened| A
+```
+
+## Lists, ordered (IMO, all lists are ordered)
+
+Not numbered, nested, mildly judgmental:
 
 - Reasons to print source code
   - To read it on paper (romantic)
   - To spot the bug you could not see on screen (it works, annoyingly)
-  - To feel something
+  - To put in a box so the paper yellows over time (I still have the OG WinPrint source in a box somewhere)
 - Reasons not to
   - It is 2026
   - Trees
-  - Your color laser is out of cyan again
+  - Printers suck.
 
 Ordered, because sequence matters:
 
-1. Write a printing app.
-2. Over-engineer it.
+1. Write a printing app when printing matters (1989).
+2. Decided to rewrite it when printing still sorta matters (1993), but didn't finish.
+3. Really decide to rewrite it when printing no longer matters (2020).
+4. Over-engineer 2.0.
    1. Add a GUI with live print preview.
    2. Add headers and footers. With **macros**.
    3. Add a print preview *in the terminal*, because obviously.
-3. Ship it to the fourteen people who will love it.
+   4. Observe how only 14 people on the planet use it.
+5. Over-engineer 3.0 to prove 3 things in 2026.
+   1. Terminal.Gui kicks ass, espeically it's sixel/kitty graphics terminal support.
+   2. AI coding is the future.
+   3. People still don't print.
 
 A task list of my remaining life goals:
 
 - [x] Write WinPrint (1988)
 - [x] Rewrite WinPrint (2020)
-- [x] Rewrite it *again* as a TUI (do not ask)
+- [x] Rewrite it *again* as a TUI using AI (2026)
 - [ ] Learn my lesson
 
 ## A table nobody asked for
@@ -104,8 +124,7 @@ A little JSON, for the config file you will never open:
 
 ## A picture worth 154 versions
 
-Here is WinPrint 1.54, shareware, $25 by check, mailed from strangers who trusted the postal
-service more than the internet:
+Here is WinPrint 1.54, shareware, $25 by check, mailed from strangers who trusted the postal service more than the Internet:
 
 ![WinPrint 1.54, in all its Windows 3.1 glory](WinPrint154.png)
 
@@ -194,21 +213,6 @@ A: Because I know C# well and it is awesome, and because no other modern languag
 can even SPELL "print". I tried Electron and Flutter. Both suck at printing. This is the one
 technical decision I will die on.
 
-## Mermaid, which WinPrint supported Real Soon Now (tm) and now just supports
-
-The fenced block below prints as an actual diagram using the default `mermaid.ink` service (or the in-process `builtin` backend if configured); set `renderMermaidDiagrams` to `false` to show source code instead. The promissory
-note, paid:
-
-```mermaid
-graph LR
-    A[Have idea] --> B{Over-engineer it?}
-    B -->|Always| C[Add a feature]
-    C --> D[Nobody uses it]
-    D --> A
-    B -->|Never| E[Ship on time]
-    E -.->|has never happened| A
-```
-
 ## A very long list of fixed-pitch fonts I have loved
 
 Because a printing app is really just a font-appreciation society with extra steps:
@@ -238,5 +242,4 @@ Autolink, no ceremony: <https://tig.github.io/mcec/>
 
 ***
 
-That is the tour. If any of it printed nicely, thank the fixed-pitch fonts. If it did not,
-that is a bug, and I will fix it at 2am for an audience of no one. Enjoy WinPrint 3.0!
+That is the tour. If any of it printed nicely, thank the fixed-pitch fonts. If it did not, that is a bug, and I will fix it at 2am for an audience of no one. Enjoy WinPrint 3.0!


### PR DESCRIPTION
## What happened

@tig made three GitHub-web edits today (~8:30–9:00 AM MDT):

| Commit | File | Fate |
|---|---|---|
| `94c1f65e6` Revise README | `README.md` | ✅ survived |
| `14f973df9` Enhance documentation | `docs/index.md` | ✅ survived |
| `063a52f3b` Revise user guide | `docs/users-guide.md` | ❌ clobbered |
| `7f206d35d` Update demo.md (mermaid near top, voice rewrites) | `testfiles/demo.md` | ❌ clobbered |

An hour later, `ed44b7b7d` (PR #243, "revert mermaid default to service") rewrote `demo.md` and `users-guide.md` from a checkout that predated those edits, silently reverting them.

## What this PR does

Restores both edits via per-file 3-way merge (base = pre-edit, ours = web edit, theirs = develop tip), **keeping #243's factual changes**:

- `demo.md`: mermaid section back near the top (line 33), BobAtk footnote and section-title rewrites restored; the mermaid paragraph now describes the `mermaid.ink` service default (with `builtin` as the configured alternative).
- `users-guide.md`: "Beautifully Prints" Features restructure and `###`-per-CTE sections restored; `MarkdownCte` text states service-by-default with `builtin` as the private in-process opt-in; config example keeps `"mermaidBackend": "service"`. The "Turn Markdown into a PDF" example (also deleted by the stale rewrite) is restored with the stale "in-process" clause dropped.

Only drift from the web-edit versions is that backend-fact reconciliation — verified by diffing against `7f206d35d`/`063a52f3b` directly.

## Note

`docs/hero-tui.gif` was recorded before these edits (from demo.md with mermaid on the last page), so it doesn't reflect the new layout — happy to re-record it as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)