### PR TITLE
docs: verify wp print --printer/--pdf on Linux cups-pdf (#244)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,14 @@ wp print mermaid.md --printer "CUPS-PDF" --sheet "Proportional 1-Up"
 ```
 
 ```bash
-# Linux — sudo apt install printer-driver-cups-pdf (the queue is named "PDF"); the PDF lands in ~/PDF/
+# Linux — sudo apt install printer-driver-cups-pdf (queue name "PDF" on Debian/Ubuntu;
+# confirm with lpstat -p; Fedora is often "Cups-PDF"). PDF lands in ~/PDF/
 wp print mermaid.md --printer "PDF" --sheet "Proportional 1-Up"
 ```
 
 <img width="700" alt="wp print turning mermaid.md into a PDF, then viewing it" src="docs/cli.gif" />
 
-*Shown: [`testfiles/mermaid.md`](testfiles/mermaid.md), one fence per mermaid diagram type, printed from the shell and opened in a viewer. The GIF is recorded on Windows; the macOS and Linux commands produce the same PDF.*
+*Shown: [`testfiles/mermaid.md`](testfiles/mermaid.md), one fence per mermaid diagram type, printed from the shell and opened in a viewer. The GIF is recorded on Windows; the macOS and Linux commands produce the same PDF. On Linux prefer `--pdf` when you only need a file — stock cups-pdf may re-encode through Ghostscript; mermaid rasters still survive.*
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ wp print mermaid.md --printer "PDF" --sheet "Proportional 1-Up"
 
 <img width="700" alt="wp print turning mermaid.md into a PDF, then viewing it" src="docs/cli.gif" />
 
-*Shown: [`testfiles/mermaid.md`](testfiles/mermaid.md), one fence per mermaid diagram type, printed from the shell and opened in a viewer. The GIF is recorded on Windows; the macOS and Linux commands produce the same PDF. On Linux prefer `--pdf` when you only need a file — stock cups-pdf may re-encode through Ghostscript; mermaid rasters still survive.*
+*Shown: [`testfiles/mermaid.md`](testfiles/mermaid.md), one fence per mermaid diagram type, printed from the shell and opened in a viewer. The GIF is recorded on Windows; the macOS and Linux commands produce the same PDF. On Linux prefer `--pdf` when you only need a file — stock cups-pdf may re-encode through Ghostscript; mermaid rasters still survive. [Linux & WSL printing](docs/linux.md).*
 
 ## Installation
 
@@ -90,6 +90,8 @@ brew install winprint          # WinPrint GUI app — also bundles the `wp` term
 brew install kindel/winprint/wp   # `wp` terminal UI (the GUI is Windows/macOS only)
 ```
 
+CUPS setup, cups-pdf, network IPP printers, and WSL notes: **[Linux & WSL printing](docs/linux.md)**.
+
 See the [Installation Guide](https://tig.github.io/winprint/install.html) for detailed instructions, prerequisites, and upgrade/uninstall steps.
 
 ## Getting Started
@@ -113,6 +115,7 @@ You can also find **WinPrint** in the Start Menu (Windows) or via Spotlight (mac
 * [Overview](https://tig.github.io/winprint/)
 * [Installation Guide](https://tig.github.io/winprint/install.html)
 * [User's Guide](https://tig.github.io/winprint/users-guide.html)
+* [Linux & WSL printing](docs/linux.md)
 * [About](https://tig.github.io/winprint/about.html)
 * [Support](https://tig.github.io/winprint/support.html)
 

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -5,6 +5,8 @@
   url: install.html
 - title: User's Guide
   url: users-guide.html
+- title: Linux & WSL
+  url: linux.html
 - title: Support
   url: support.html
 - title: About & History

--- a/docs/hero-gif-win.md
+++ b/docs/hero-gif-win.md
@@ -128,10 +128,12 @@ mcec's `hero-gif.md`. Two WinPrint-specific input rules:
     `result.bytes` (~4-5 MB). After the stop, close the PDF **tab** with `ctrl-f4` (not the whole browser).
 12. **Record the CLI showcase (`docs/cli.gif`).** Regenerate this **every time the Windows hero is
     regenerated** -- same controller session. It is the README's "How to turn Markdown into a PDF"
-    beat: `wp print` turning `testfiles/mermaid.md` (every diagram type the built-in renderer
-    supports, plus the gantt code-block fallback) into a PDF, from a real terminal. Needs a
-    **`net10.0-windows`-TFM `wp`** on PATH (`dotnet build src/WinPrint.TUI/WinPrint.TUI.csproj -f
-    net10.0-windows`; the portable `net10.0` build has no Windows print path and tries `lpr`).
+    beat: `wp print` turning `testfiles/mermaid.md` (every mermaid diagram type — flowchart,
+    sequence, class, ER, pie, gantt, … — as images via the default mermaid.ink backend; use
+    `mermaidBackend: "builtin"` only if you need the in-process path and its fallbacks) into a
+    PDF, from a real terminal. Needs a **`net10.0-windows`-TFM `wp`** on PATH (`dotnet build
+    src/WinPrint.TUI/WinPrint.TUI.csproj -f net10.0-windows`; the portable `net10.0` build has no
+    Windows print path and tries `lpr`).
     Setup, all **off-record**: create `~/wpdemo`, copy `testfiles/mermaid.md` in; Win+D; **Win+R ->
     `pwsh`** to open the terminal (find its window by `windows { "process": "WindowsTerminal" }` and
     match the **title** -- a title-only filter can match another wt instance, including the one

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ wp print mermaid.md --printer "PDF" --sheet "Proportional 1-Up"
 
 ![wp print turning mermaid.md into a PDF, then viewing it](cli.gif)
 
-*The GIF is recorded on Windows; the macOS and Linux commands produce the same PDF. On Linux prefer `--pdf` when you only need a file — stock cups-pdf may re-encode through Ghostscript; mermaid rasters still survive.*
+*The GIF is recorded on Windows; the macOS and Linux commands produce the same PDF. On Linux prefer `--pdf` when you only need a file — stock cups-pdf may re-encode through Ghostscript; mermaid rasters still survive. Full Linux/WSL CUPS setup (network IPP printers, WSL vs Windows queues): [linux.md](linux.md).*
 
 ## Quick Start
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,13 +54,14 @@ wp print mermaid.md --printer "CUPS-PDF" --sheet "Proportional 1-Up"
 ```
 
 ```bash
-# Linux — sudo apt install printer-driver-cups-pdf (the queue is named "PDF"); the PDF lands in ~/PDF/
+# Linux — sudo apt install printer-driver-cups-pdf (queue name "PDF" on Debian/Ubuntu;
+# confirm with lpstat -p; Fedora is often "Cups-PDF"). PDF lands in ~/PDF/
 wp print mermaid.md --printer "PDF" --sheet "Proportional 1-Up"
 ```
 
 ![wp print turning mermaid.md into a PDF, then viewing it](cli.gif)
 
-*The GIF is recorded on Windows; the macOS and Linux commands produce the same PDF.*
+*The GIF is recorded on Windows; the macOS and Linux commands produce the same PDF. On Linux prefer `--pdf` when you only need a file — stock cups-pdf may re-encode through Ghostscript; mermaid rasters still survive.*
 
 ## Quick Start
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -109,18 +109,21 @@ brew install kindel/winprint/wp
 
 ### Prerequisites
 
-For actual printing (not just previewing), you need a working CUPS setup:
+For actual printing (not just previewing), you need a working CUPS setup. The short version:
 
 ```bash
-# Debian/Ubuntu
-sudo apt install cups lpr
+# Debian/Ubuntu / WSL
+sudo apt install cups cups-client cups-bsd
 
 # Fedora/RHEL
 sudo dnf install cups
 
 # Verify CUPS is running
+lpstat -r
 lpstat -p
 ```
+
+Full guide — cups-pdf, network IPP printers (e.g. Brother), WSL vs Windows printers, and `wp print --pdf` vs `--printer` — is in **[Linux & WSL printing](linux.md)**.
 
 ### Upgrade
 

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -1,0 +1,188 @@
+# Linux & WSL printing
+
+On Linux (including WSL), **winprint** ships the `wp` terminal UI and headless `wp print` — not the MAUI GUI. Printing goes through **CUPS**: `wp` renders pages to a PDF in-process (Skia), then submits that PDF with `lpr`. There is no Windows-style “pick a printer” dialog in the headless path; `--printer` is the CUPS **queue name**.
+
+Install `wp` first (see [Install](install.md#linux)). This page covers getting **something useful to happen** when you print.
+
+## Prefer `--pdf` when you only need a file
+
+```bash
+wp print mermaid.md --pdf mermaid.pdf --sheet "Proportional 1-Up"
+```
+
+No CUPS queue, no driver, no dialog. Works the same on bare metal Linux and WSL. Use this instead of “print to PDF” virtual printers when you just want a file on disk.
+
+`--pdf` and `--printer` are mutually exclusive.
+
+## How Linux printing works
+
+| Piece | Role |
+| --- | --- |
+| `wp print …` | Renders via Skia → PDF, then either writes a file (`--pdf`) or calls `lpr` (`--printer` / system default) |
+| **CUPS** | Spooler: queues, filters, backends |
+| `lpr` / `lp` | Submit a job to a named queue |
+| `lpstat` | List queues, default destination, jobs |
+
+Bare `wp print file.md` with **no** `--pdf` and **no** `--printer` uses the **system default** CUPS destination. If none is configured, `wp` fails with an actionable error (install a queue, pass `--printer`, or use `--pdf`). It will not silently report success while the job sits nowhere useful.
+
+## List printers (CUPS)
+
+```bash
+lpstat -p          # printers and state
+lpstat -a          # queues accepting jobs (name is the first word)
+lpstat -d          # system default destination
+lpstat -t          # full status dump
+lpstat -o          # outstanding jobs
+```
+
+The name you pass to `wp print … --printer NAME` is that first word, e.g. `PDF` or `Brother-HL-L3230CDW`.
+
+Set a default (optional):
+
+```bash
+lpoptions -d Brother-HL-L3230CDW   # per-user
+# sudo lpadmin -d Brother-HL-L3230CDW   # system-wide
+```
+
+## Install CUPS
+
+```bash
+# Debian / Ubuntu / WSL
+sudo apt update
+sudo apt install -y cups cups-client cups-bsd
+sudo service cups start   # or: sudo systemctl start cups
+
+lpstat -r                 # expect: scheduler is running
+```
+
+```bash
+# Fedora / RHEL
+sudo dnf install -y cups
+sudo systemctl enable --now cups
+```
+
+## Print to a PDF file via a virtual queue (cups-pdf)
+
+When you want a CUPS queue (preview of the real `--printer` path) rather than `--pdf`:
+
+```bash
+# Debian / Ubuntu
+sudo apt install -y printer-driver-cups-pdf
+# Fedora
+# sudo dnf install -y cups-pdf
+
+lpstat -p                 # queue is usually "PDF" (Debian/Ubuntu) or "Cups-PDF" (Fedora)
+```
+
+```bash
+wp print mermaid.md --printer PDF --sheet "Proportional 1-Up"
+# PDFs land in ~/PDF/ by default (see Out in /etc/cups/cups-pdf.conf)
+ls ~/PDF/
+```
+
+**Fidelity:** stock cups-pdf with its PPD may run a PDF→PS→PDF filter chain (Ghostscript). Mermaid diagrams are embedded rasters and survive. For **bit-identical** Skia output, use `wp print … --pdf out.pdf` instead.
+
+## Install a network printer (IPP)
+
+Most modern LAN printers (Brother, HP, Epson, …) speak **IPP**. CUPS can drive them with the generic *everywhere* driver — no vendor Windows driver needed inside Linux.
+
+Example: **Brother HL-L3230CDW** at `192.168.1.104`:
+
+```bash
+# Reachability from this machine / WSL
+ping -c 2 192.168.1.104
+
+sudo lpadmin -p Brother-HL-L3230CDW -E \
+  -m everywhere \
+  -v ipp://192.168.1.104/ipp/print \
+  -D "Brother HL-L3230CDW" \
+  -L "LAN"
+
+lpoptions -d Brother-HL-L3230CDW    # optional default
+lpstat -p -a -d
+```
+
+Test:
+
+```bash
+echo "hello from CUPS" | lpr -P Brother-HL-L3230CDW
+wp print README.md --printer Brother-HL-L3230CDW --sheet "Proportional 1-Up"
+```
+
+### If that URI fails
+
+Brother (and others) vary by firmware. Remove and retry:
+
+```bash
+sudo lpadmin -x Brother-HL-L3230CDW
+
+sudo lpadmin -p Brother-HL-L3230CDW -E -m everywhere \
+  -v ipp://192.168.1.104/ipp/port1
+# or:
+#   -v http://192.168.1.104:631/ipp/print
+```
+
+Optional discovery:
+
+```bash
+sudo apt install -y avahi-utils cups-ipp-utils
+ippfind
+# printer web UI is often http://192.168.1.104/
+```
+
+Vendor Linux `.deb`/`.rpm` drivers are only worth installing if IPP Everywhere misprints (margins, duplex, color). Prefer IPP first.
+
+## WSL notes
+
+WSL2 is a **separate Linux** environment. Windows and WSL do **not** share printer lists.
+
+| Expectation | Reality |
+| --- | --- |
+| `lpstat` shows “Microsoft Print to PDF” | No — Windows-only virtual printer |
+| Printers added in Windows Settings appear in WSL | No — not until you add a **CUPS** queue in Linux |
+| Bare `wp print file` with no queues | Error (or a dead spool) — configure CUPS or use `--pdf` |
+
+**Recommended on WSL**
+
+1. `wp print … --pdf out.pdf`, then open on Windows (`explorer.exe out.pdf`) if you only need a file.
+2. Or add a real network IPP queue (above) so `lpr` / `--printer` hit the device on your LAN.
+
+**Windows-shared printers from WSL** (optional): share the printer on Windows, then add an SMB queue in CUPS (`smb://<windows-host>/ShareName`). The Windows host IP from WSL2 is often the `nameserver` in `/etc/resolv.conf`. This is more brittle than IPP to the printer’s own address — prefer talking to the printer directly when it has a LAN IP.
+
+**WSL networking:** the distro must reach `192.168.x.x` printers. If `ping` fails, fix Windows/WSL networking (firewall, mirrored mode, VPN) before debugging CUPS.
+
+## Quick recipes
+
+```bash
+# File only — no CUPS required
+wp print demo.md --pdf ./demo.pdf --sheet "Proportional 1-Up"
+
+# Count sheets without printing
+wp print demo.md --what-if --sheet "Proportional 1-Up"
+
+# cups-pdf virtual queue
+wp print demo.md --printer PDF
+
+# Physical network printer (queue name from lpstat -a)
+wp print demo.md --printer Brother-HL-L3230CDW --sheet "Proportional 1-Up"
+```
+
+## Troubleshooting
+
+| Symptom | What to check |
+| --- | --- |
+| `No print destination is configured` | `lpstat -a` empty → install cups-pdf or an IPP queue, or use `--pdf` |
+| `No default printer is set` | Queues exist but none is default → `wp … --printer NAME` or `lpoptions -d NAME` |
+| `Unknown printer '…'` | Typo or wrong name → `lpstat -a` |
+| `Unable to launch 'lpr'` | Install `cups-client` / `cups-bsd` |
+| `lpstat: scheduler is not running` | `sudo service cups start` |
+| Job accepted, nothing prints | `lpstat -o`, printer power/network, wrong IPP URI; try `lpr -P NAME /path/to.pdf` alone |
+| WSL can’t ping the printer | Windows/WSL network path, not winprint |
+
+Debug logging: run `wp` with `--debug`. On Linux, portable mode keeps logs next to the `wp` executable (see [Support](support.md)).
+
+## See also
+
+* [Install](install.md#linux) — Homebrew `wp` formula
+* [User’s Guide](users-guide.md) — CLI options (`--printer`, `--pdf`, sheets)
+* [Overview](index.md#how-to-turn-markdown-into-a-pdf) — Markdown → PDF one-liners per platform

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -1,8 +1,8 @@
 # Linux & WSL printing
 
-On Linux (including WSL), **winprint** ships the `wp` terminal UI and headless `wp print` — not the MAUI GUI. Printing goes through **CUPS**: `wp` renders pages to a PDF in-process (Skia), then submits that PDF with `lpr`. There is no Windows-style “pick a printer” dialog in the headless path; `--printer` is the CUPS **queue name**.
+On Linux (including WSL), **winprint** provides the `wp` terminal UI and headless `wp print` — not the graphical app. Printing uses the system’s **CUPS** setup: `--printer` is a CUPS **queue name**. There is no Windows-style printer picker in the headless path.
 
-Install `wp` first (see [Install](install.md#linux)). This page covers getting **something useful to happen** when you print.
+Install `wp` first (see [Install](install.md#linux)). This page is about getting printers (or a PDF file) working so `wp print` has somewhere useful to send output.
 
 ## Prefer `--pdf` when you only need a file
 
@@ -10,22 +10,11 @@ Install `wp` first (see [Install](install.md#linux)). This page covers getting *
 wp print mermaid.md --pdf mermaid.pdf --sheet "Proportional 1-Up"
 ```
 
-No CUPS queue, no driver, no dialog. Works the same on bare metal Linux and WSL. Use this instead of “print to PDF” virtual printers when you just want a file on disk.
+No printer queue, no driver, no dialog. Works the same on bare-metal Linux and WSL. Use this when you want a PDF on disk rather than paper (or a virtual “print to PDF” queue).
 
-`--pdf` and `--printer` are mutually exclusive.
+`--pdf` and `--printer` cannot be combined.
 
-## How Linux printing works
-
-| Piece | Role |
-| --- | --- |
-| `wp print …` | Renders via Skia → PDF, then either writes a file (`--pdf`) or calls `lpr` (`--printer` / system default) |
-| **CUPS** | Spooler: queues, filters, backends |
-| `lpr` / `lp` | Submit a job to a named queue |
-| `lpstat` | List queues, default destination, jobs |
-
-Bare `wp print file.md` with **no** `--pdf` and **no** `--printer` uses the **system default** CUPS destination. If none is configured, `wp` fails with an actionable error (install a queue, pass `--printer`, or use `--pdf`). It will not silently report success while the job sits nowhere useful.
-
-## List printers (CUPS)
+## List printers
 
 ```bash
 lpstat -p          # printers and state
@@ -35,7 +24,7 @@ lpstat -t          # full status dump
 lpstat -o          # outstanding jobs
 ```
 
-The name you pass to `wp print … --printer NAME` is that first word, e.g. `PDF` or `Brother-HL-L3230CDW`.
+The name for `wp print … --printer NAME` is that first word, e.g. `PDF` or `Brother-HL-L3230CDW`.
 
 Set a default (optional):
 
@@ -43,6 +32,8 @@ Set a default (optional):
 lpoptions -d Brother-HL-L3230CDW   # per-user
 # sudo lpadmin -d Brother-HL-L3230CDW   # system-wide
 ```
+
+With no `--pdf` and no `--printer`, `wp print` uses the **system default** destination. If nothing is configured, it errors and tells you to add a queue, pass `--printer`, or use `--pdf`.
 
 ## Install CUPS
 
@@ -61,9 +52,9 @@ sudo dnf install -y cups
 sudo systemctl enable --now cups
 ```
 
-## Print to a PDF file via a virtual queue (cups-pdf)
+## Print to PDF via a virtual queue (cups-pdf)
 
-When you want a CUPS queue (preview of the real `--printer` path) rather than `--pdf`:
+If you want a CUPS “print to PDF” queue (instead of `--pdf`):
 
 ```bash
 # Debian / Ubuntu
@@ -71,25 +62,24 @@ sudo apt install -y printer-driver-cups-pdf
 # Fedora
 # sudo dnf install -y cups-pdf
 
-lpstat -p                 # queue is usually "PDF" (Debian/Ubuntu) or "Cups-PDF" (Fedora)
+lpstat -p                 # usually "PDF" (Debian/Ubuntu) or "Cups-PDF" (Fedora)
 ```
 
 ```bash
 wp print mermaid.md --printer PDF --sheet "Proportional 1-Up"
-# PDFs land in ~/PDF/ by default (see Out in /etc/cups/cups-pdf.conf)
+# Output directory is ~/PDF/ by default (see Out in /etc/cups/cups-pdf.conf)
 ls ~/PDF/
 ```
 
-**Fidelity:** stock cups-pdf with its PPD may run a PDF→PS→PDF filter chain (Ghostscript). Mermaid diagrams are embedded rasters and survive. For **bit-identical** Skia output, use `wp print … --pdf out.pdf` instead.
+For a simple file on disk with no queue, prefer `wp print … --pdf out.pdf`.
 
 ## Install a network printer (IPP)
 
-Most modern LAN printers (Brother, HP, Epson, …) speak **IPP**. CUPS can drive them with the generic *everywhere* driver — no vendor Windows driver needed inside Linux.
+Most modern LAN printers (Brother, HP, Epson, …) speak **IPP**. CUPS can use the generic *everywhere* driver — you usually do not need a Windows or vendor driver inside Linux.
 
 Example: **Brother HL-L3230CDW** at `192.168.1.104`:
 
 ```bash
-# Reachability from this machine / WSL
 ping -c 2 192.168.1.104
 
 sudo lpadmin -p Brother-HL-L3230CDW -E \
@@ -111,7 +101,7 @@ wp print README.md --printer Brother-HL-L3230CDW --sheet "Proportional 1-Up"
 
 ### If that URI fails
 
-Brother (and others) vary by firmware. Remove and retry:
+Firmware varies. Remove and retry:
 
 ```bash
 sudo lpadmin -x Brother-HL-L3230CDW
@@ -130,7 +120,7 @@ ippfind
 # printer web UI is often http://192.168.1.104/
 ```
 
-Vendor Linux `.deb`/`.rpm` drivers are only worth installing if IPP Everywhere misprints (margins, duplex, color). Prefer IPP first.
+Install vendor Linux packages only if the generic driver misprints (margins, duplex, color). Prefer IPP first.
 
 ## WSL notes
 
@@ -138,23 +128,23 @@ WSL2 is a **separate Linux** environment. Windows and WSL do **not** share print
 
 | Expectation | Reality |
 | --- | --- |
-| `lpstat` shows “Microsoft Print to PDF” | No — Windows-only virtual printer |
-| Printers added in Windows Settings appear in WSL | No — not until you add a **CUPS** queue in Linux |
-| Bare `wp print file` with no queues | Error (or a dead spool) — configure CUPS or use `--pdf` |
+| `lpstat` shows “Microsoft Print to PDF” | No — that is Windows-only |
+| Printers added in Windows Settings appear in WSL | No — add a **CUPS** queue in Linux |
+| `wp print file` with no queues configured | Errors — set up CUPS or use `--pdf` |
 
 **Recommended on WSL**
 
 1. `wp print … --pdf out.pdf`, then open on Windows (`explorer.exe out.pdf`) if you only need a file.
-2. Or add a real network IPP queue (above) so `lpr` / `--printer` hit the device on your LAN.
+2. Or add a network IPP queue (above) so `--printer` reaches the device on your LAN.
 
-**Windows-shared printers from WSL** (optional): share the printer on Windows, then add an SMB queue in CUPS (`smb://<windows-host>/ShareName`). The Windows host IP from WSL2 is often the `nameserver` in `/etc/resolv.conf`. This is more brittle than IPP to the printer’s own address — prefer talking to the printer directly when it has a LAN IP.
+**Windows-shared printers from WSL** (optional): share the printer on Windows, then add an SMB queue in CUPS (`smb://<windows-host>/ShareName`). The Windows host from WSL2 is often the `nameserver` in `/etc/resolv.conf`. Prefer talking to the printer’s own LAN IP when it has one.
 
 **WSL networking:** the distro must reach `192.168.x.x` printers. If `ping` fails, fix Windows/WSL networking (firewall, mirrored mode, VPN) before debugging CUPS.
 
 ## Quick recipes
 
 ```bash
-# File only — no CUPS required
+# File only — no printer required
 wp print demo.md --pdf ./demo.pdf --sheet "Proportional 1-Up"
 
 # Count sheets without printing
@@ -177,9 +167,9 @@ wp print demo.md --printer Brother-HL-L3230CDW --sheet "Proportional 1-Up"
 | `Unable to launch 'lpr'` | Install `cups-client` / `cups-bsd` |
 | `lpstat: scheduler is not running` | `sudo service cups start` |
 | Job accepted, nothing prints | `lpstat -o`, printer power/network, wrong IPP URI; try `lpr -P NAME /path/to.pdf` alone |
-| WSL can’t ping the printer | Windows/WSL network path, not winprint |
+| WSL can’t ping the printer | Windows/WSL network path |
 
-Debug logging: run `wp` with `--debug`. On Linux, portable mode keeps logs next to the `wp` executable (see [Support](support.md)).
+More detail: `wp --debug`. Logs on Linux live next to the `wp` executable (see [Support](support.md)).
 
 ## See also
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -3,6 +3,7 @@
 ## Get Help
 
 * Read the [User's Guide](users-guide.md)
+* Linux / WSL printing (CUPS, cups-pdf, network printers): [Linux & WSL printing](linux.md)
 * Ask a question using [GitHub Issues](https://github.com/tig/winprint/issues).
 
 ## Submit bugs or Request Improvements

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -77,7 +77,7 @@ wp print Program.cs --what-if
 
 - **Windows** — the built-in **Microsoft Print to PDF**; a Save-As dialog chooses the file.
 - **macOS** — install a virtual PDF printer once with [RWTS PDFwriter](https://github.com/rodyager/RWTS-PDFwriter): `brew install --cask rwts-pdfwriter`, then add it in **Printers & Scanners** (name it e.g. `CUPS-PDF`). Printed PDFs land in `/var/spool/pdfwriter/$USER/`. (`brew install cups-pdf` does **not** exist on macOS — that is a Linux package.)
-- **Linux** — `sudo apt install printer-driver-cups-pdf` (Debian/Ubuntu; the queue is named **`PDF`** — confirm with `lpstat -p`) or `sudo dnf install cups-pdf` (Fedora; often **`Cups-PDF`**). Printed PDFs land in **`~/PDF/`** (or check `/etc/cups/cups-pdf.conf` `Out`). Verified end-to-end on Ubuntu 24.04: `wp print … --printer PDF` submits a Skia-rendered PDF via `lpr -P PDF` and a multi-page file appears in `~/PDF/`.
+- **Linux** — `sudo apt install printer-driver-cups-pdf` (Debian/Ubuntu; the queue is named **`PDF`** — confirm with `lpstat -p`) or `sudo dnf install cups-pdf` (Fedora; often **`Cups-PDF`**). Printed PDFs land in **`~/PDF/`** (or check `/etc/cups/cups-pdf.conf` `Out`). See **[Linux & WSL printing](linux.md)** for CUPS setup, network printers (IPP), and WSL notes.
 
 Prefer **`wp print … --pdf out.pdf`** when you want a file and do not need a real queue: it writes the Skia PDF straight to disk on every platform (no printer, no driver, no dialog). Stock cups-pdf with its PPD may run a PDF→PS→PDF filter chain (Ghostscript); mermaid diagrams are embedded rasters and survive that path, but for bit-identical Skia output use `--pdf`.
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -77,7 +77,9 @@ wp print Program.cs --what-if
 
 - **Windows** — the built-in **Microsoft Print to PDF**; a Save-As dialog chooses the file.
 - **macOS** — install a virtual PDF printer once with [RWTS PDFwriter](https://github.com/rodyager/RWTS-PDFwriter): `brew install --cask rwts-pdfwriter`, then add it in **Printers & Scanners** (name it e.g. `CUPS-PDF`). Printed PDFs land in `/var/spool/pdfwriter/$USER/`. (`brew install cups-pdf` does **not** exist on macOS — that is a Linux package.)
-- **Linux** — `sudo apt install printer-driver-cups-pdf` (Debian/Ubuntu; the queue is named `PDF` — confirm with `lpstat -p`) or `sudo dnf install cups-pdf` (Fedora). Printed PDFs land in `~/PDF/`.
+- **Linux** — `sudo apt install printer-driver-cups-pdf` (Debian/Ubuntu; the queue is named **`PDF`** — confirm with `lpstat -p`) or `sudo dnf install cups-pdf` (Fedora; often **`Cups-PDF`**). Printed PDFs land in **`~/PDF/`** (or check `/etc/cups/cups-pdf.conf` `Out`). Verified end-to-end on Ubuntu 24.04: `wp print … --printer PDF` submits a Skia-rendered PDF via `lpr -P PDF` and a multi-page file appears in `~/PDF/`.
+
+Prefer **`wp print … --pdf out.pdf`** when you want a file and do not need a real queue: it writes the Skia PDF straight to disk on every platform (no printer, no driver, no dialog). Stock cups-pdf with its PPD may run a PDF→PS→PDF filter chain (Ghostscript); mermaid diagrams are embedded rasters and survive that path, but for bit-identical Skia output use `--pdf`.
 
 Launch the GUI:
 

--- a/src/WinPrint.Core/Printing/ILprClient.cs
+++ b/src/WinPrint.Core/Printing/ILprClient.cs
@@ -15,10 +15,17 @@ public interface ILprClient
     string? GetDefaultPrinter();
 
     /// <summary>
-    ///     Submits a PDF document to the spooler via <c>lpr</c> (written to the process's standard
-    ///     input to avoid temp-file lifetime races). When <paramref name="printerName" /> is null,
-    ///     empty, or the system-default placeholder, the destination is left to CUPS.
+    ///     Resolves <paramref name="printerName" /> to a concrete CUPS queue. Empty / null / the
+    ///     legacy system-default placeholder means the spooler's default, which must exist — bare
+    ///     <c>lpr</c> otherwise exits 0 with nowhere for the job to go.
     /// </summary>
-    Task<PrintJobResult> SubmitAsync(byte[] pdf, string? printerName, string documentName, int sheetCount,
+    PrinterDestinationResult ResolveDestination(string? printerName);
+
+    /// <summary>
+    ///     Submits a PDF document to the spooler via <c>lpr</c> (written to the process's standard
+    ///     input to avoid temp-file lifetime races). <paramref name="printerName" /> must be a
+    ///     concrete queue name (already resolved via <see cref="ResolveDestination" />).
+    /// </summary>
+    Task<PrintJobResult> SubmitAsync(byte[] pdf, string printerName, string documentName, int sheetCount,
         CancellationToken cancellationToken = default);
 }

--- a/src/WinPrint.Core/Printing/LprClient.cs
+++ b/src/WinPrint.Core/Printing/LprClient.cs
@@ -11,30 +11,18 @@ namespace WinPrint.Core.Printing;
 /// </summary>
 public sealed class LprClient : ILprClient
 {
-    /// <summary>Placeholder printer name meaning "let the spooler choose the default destination".</summary>
+    /// <summary>
+    ///     Legacy placeholder meaning "use the spooler default". Still recognized if persisted in
+    ///     settings; new code stores an empty name or a real queue instead.
+    /// </summary>
     public const string SystemDefaultPrinter = "(System Default)";
 
     public IReadOnlyList<PrinterInfo> GetPrinters()
     {
-        var printers = new List<PrinterInfo>();
         string? defaultPrinter = GetDefaultPrinter();
-
-        // `lpstat -a` lists destinations accepting jobs: "<name> accepting requests since ...".
-        if (!TryRun("lpstat", ["-a"], null, out string output, out _))
+        var printers = new List<PrinterInfo>();
+        foreach (string name in ListAcceptingQueueNames())
         {
-            return printers;
-        }
-
-        foreach (string line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
-        {
-            string trimmed = line.Trim();
-            int space = trimmed.IndexOf(' ');
-            string name = space > 0 ? trimmed[..space] : trimmed;
-            if (name.Length == 0)
-            {
-                continue;
-            }
-
             printers.Add(new PrinterInfo
             {
                 Name = name,
@@ -63,22 +51,72 @@ public sealed class LprClient : ILprClient
         return name.Length == 0 ? null : name;
     }
 
-    public async Task<PrintJobResult> SubmitAsync(byte[] pdf, string? printerName, string documentName,
-        int sheetCount, CancellationToken cancellationToken = default)
+    public PrinterDestinationResult ResolveDestination(string? printerName)
     {
-        // CUPS/BSD `lpr` with no -P exits 0 even when there is no default destination — the job
-        // sits in the spool forever and the caller thinks it printed. Refuse that silent void.
-        if (!TryResolvePrinter(printerName, GetDefaultPrinter(), GetPrinters(), out string? resolvedPrinter,
-                out string? resolveError))
+        if (IsSystemDefaultRequest(printerName))
         {
-            return PrintJobResult.Failed(resolveError!);
+            // One `lpstat -d` only when we already have a default; list queues only for the error path.
+            string? defaultPrinter = GetDefaultPrinter();
+            if (!string.IsNullOrEmpty(defaultPrinter))
+            {
+                return PrinterDestinationResult.Ok(defaultPrinter);
+            }
+
+            return ResolveFromInputs(printerName, defaultPrinter: null, ListAcceptingQueueNames());
         }
 
-        var args = new List<string>
+        // Named queue: one `lpstat -a` for validation (skip if list empty / lpstat failed → let lpr decide).
+        return ResolveFromInputs(printerName, defaultPrinter: null, ListAcceptingQueueNames());
+    }
+
+    /// <summary>
+    ///     Pure destination policy (no process I/O). Used by <see cref="ResolveDestination" /> and tests.
+    /// </summary>
+    internal static PrinterDestinationResult ResolveFromInputs(
+        string? printerName,
+        string? defaultPrinter,
+        IReadOnlyList<string> queueNames)
+    {
+        if (IsSystemDefaultRequest(printerName))
         {
-            "-P",
-            resolvedPrinter!,
-        };
+            if (!string.IsNullOrEmpty(defaultPrinter))
+            {
+                return PrinterDestinationResult.Ok(defaultPrinter);
+            }
+
+            if (queueNames.Count == 0)
+            {
+                return PrinterDestinationResult.Fail(
+                    "No print destination is configured. " +
+                    "Specify a printer, or write output to a PDF file instead of printing.");
+            }
+
+            string names = string.Join(", ", queueNames);
+            return PrinterDestinationResult.Fail(
+                "No default printer is set. " +
+                $"Specify a printer (available: {names}), or write output to a PDF file instead of printing.");
+        }
+
+        // Named queue: if we know the accepting set, require a match (clearer than lpr's message).
+        // When the list is empty (lpstat failed / no rights), fall through and let lpr decide.
+        if (queueNames.Count > 0 &&
+            !queueNames.Any(n => string.Equals(n, printerName, StringComparison.OrdinalIgnoreCase)))
+        {
+            string names = string.Join(", ", queueNames);
+            return PrinterDestinationResult.Fail(
+                $"Unknown printer '{printerName}'. Available: {names}. " +
+                "Or write output to a PDF file instead of printing.");
+        }
+
+        return PrinterDestinationResult.Ok(printerName!);
+    }
+
+    public async Task<PrintJobResult> SubmitAsync(byte[] pdf, string printerName, string documentName,
+        int sheetCount, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(printerName);
+
+        var args = new List<string> { "-P", printerName };
 
         if (!string.IsNullOrEmpty(documentName))
         {
@@ -132,69 +170,36 @@ public sealed class LprClient : ILprClient
         }
     }
 
-    /// <summary>
-    ///     Resolves <paramref name="printerName" /> to a concrete CUPS queue. System-default /
-    ///     empty means the spooler's default, which must actually exist — bare <c>lpr</c> otherwise
-    ///     exits 0 with nowhere for the job to go.
-    /// </summary>
-    /// <returns><see langword="true" /> when <paramref name="resolvedPrinter" /> is set; otherwise
-    ///     <paramref name="error" /> explains how to fix it.</returns>
-    internal static bool TryResolvePrinter(
-        string? printerName,
-        string? defaultPrinter,
-        IReadOnlyList<PrinterInfo> printers,
-        out string? resolvedPrinter,
-        out string? error)
+    private static bool IsSystemDefaultRequest(string? printerName)
     {
-        bool useSystemDefault = string.IsNullOrEmpty(printerName) ||
+        return string.IsNullOrEmpty(printerName) ||
             string.Equals(printerName, SystemDefaultPrinter, StringComparison.OrdinalIgnoreCase);
+    }
 
-        if (useSystemDefault)
+    /// <summary>
+    ///     Queue names from <c>lpstat -a</c> only (no nested default lookup).
+    /// </summary>
+    private static List<string> ListAcceptingQueueNames()
+    {
+        var names = new List<string>();
+        // `lpstat -a` lists destinations accepting jobs: "<name> accepting requests since ...".
+        if (!TryRun("lpstat", ["-a"], null, out string output, out _))
         {
-            if (!string.IsNullOrEmpty(defaultPrinter))
-            {
-                resolvedPrinter = defaultPrinter;
-                error = null;
-                return true;
-            }
-
-            resolvedPrinter = null;
-            if (printers.Count == 0)
-            {
-                error =
-                    "No print destination is configured. " +
-                    "Pass `--printer <name>` after adding a CUPS queue " +
-                    "(e.g. `sudo apt install printer-driver-cups-pdf` → queue `PDF` on Debian/Ubuntu), " +
-                    "or write a file with `wp print … --pdf out.pdf` (no printer needed).";
-            }
-            else
-            {
-                string names = string.Join(", ", printers.Select(p => p.Name));
-                error =
-                    "No default printer is set. " +
-                    $"Pass `--printer <name>` (available: {names}) " +
-                    "or write a file with `wp print … --pdf out.pdf`.";
-            }
-
-            return false;
+            return names;
         }
 
-        // Named queue: if lpstat listed destinations, require a match (clearer than lpr's message).
-        // When the list is empty (lpstat failed / no rights), fall through and let lpr decide.
-        if (printers.Count > 0 &&
-            !printers.Any(p => string.Equals(p.Name, printerName, StringComparison.OrdinalIgnoreCase)))
+        foreach (string line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
         {
-            string names = string.Join(", ", printers.Select(p => p.Name));
-            resolvedPrinter = null;
-            error =
-                $"Unknown printer '{printerName}'. " +
-                $"Available: {names}. Or write a file with `wp print … --pdf out.pdf`.";
-            return false;
+            string trimmed = line.Trim();
+            int space = trimmed.IndexOf(' ');
+            string name = space > 0 ? trimmed[..space] : trimmed;
+            if (name.Length > 0)
+            {
+                names.Add(name);
+            }
         }
 
-        resolvedPrinter = printerName;
-        error = null;
-        return true;
+        return names;
     }
 
     private static bool TryRun(string fileName, IReadOnlyList<string> args, byte[]? stdin, out string stdout,

--- a/src/WinPrint.Core/Printing/LprClient.cs
+++ b/src/WinPrint.Core/Printing/LprClient.cs
@@ -62,11 +62,11 @@ public sealed class LprClient : ILprClient
                 return PrinterDestinationResult.Ok(defaultPrinter);
             }
 
-            return ResolveFromInputs(printerName, defaultPrinter: null, ListAcceptingQueueNames());
+            return ResolveFromInputs(printerName, null, ListAcceptingQueueNames());
         }
 
         // Named queue: one `lpstat -a` for validation (skip if list empty / lpstat failed → let lpr decide).
-        return ResolveFromInputs(printerName, defaultPrinter: null, ListAcceptingQueueNames());
+        return ResolveFromInputs(printerName, null, ListAcceptingQueueNames());
     }
 
     /// <summary>
@@ -173,7 +173,7 @@ public sealed class LprClient : ILprClient
     private static bool IsSystemDefaultRequest(string? printerName)
     {
         return string.IsNullOrEmpty(printerName) ||
-            string.Equals(printerName, SystemDefaultPrinter, StringComparison.OrdinalIgnoreCase);
+               string.Equals(printerName, SystemDefaultPrinter, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/WinPrint.Core/Printing/LprClient.cs
+++ b/src/WinPrint.Core/Printing/LprClient.cs
@@ -66,13 +66,19 @@ public sealed class LprClient : ILprClient
     public async Task<PrintJobResult> SubmitAsync(byte[] pdf, string? printerName, string documentName,
         int sheetCount, CancellationToken cancellationToken = default)
     {
-        var args = new List<string>();
-        if (!string.IsNullOrEmpty(printerName) &&
-            !string.Equals(printerName, SystemDefaultPrinter, StringComparison.OrdinalIgnoreCase))
+        // CUPS/BSD `lpr` with no -P exits 0 even when there is no default destination — the job
+        // sits in the spool forever and the caller thinks it printed. Refuse that silent void.
+        if (!TryResolvePrinter(printerName, GetDefaultPrinter(), GetPrinters(), out string? resolvedPrinter,
+                out string? resolveError))
         {
-            args.Add("-P");
-            args.Add(printerName);
+            return PrintJobResult.Failed(resolveError!);
         }
+
+        var args = new List<string>
+        {
+            "-P",
+            resolvedPrinter!,
+        };
 
         if (!string.IsNullOrEmpty(documentName))
         {
@@ -124,6 +130,71 @@ public sealed class LprClient : ILprClient
             return PrintJobResult.Failed(
                 "Unable to launch 'lpr'. Install CUPS (e.g. the 'cups-client' package) to print on this platform.");
         }
+    }
+
+    /// <summary>
+    ///     Resolves <paramref name="printerName" /> to a concrete CUPS queue. System-default /
+    ///     empty means the spooler's default, which must actually exist — bare <c>lpr</c> otherwise
+    ///     exits 0 with nowhere for the job to go.
+    /// </summary>
+    /// <returns><see langword="true" /> when <paramref name="resolvedPrinter" /> is set; otherwise
+    ///     <paramref name="error" /> explains how to fix it.</returns>
+    internal static bool TryResolvePrinter(
+        string? printerName,
+        string? defaultPrinter,
+        IReadOnlyList<PrinterInfo> printers,
+        out string? resolvedPrinter,
+        out string? error)
+    {
+        bool useSystemDefault = string.IsNullOrEmpty(printerName) ||
+            string.Equals(printerName, SystemDefaultPrinter, StringComparison.OrdinalIgnoreCase);
+
+        if (useSystemDefault)
+        {
+            if (!string.IsNullOrEmpty(defaultPrinter))
+            {
+                resolvedPrinter = defaultPrinter;
+                error = null;
+                return true;
+            }
+
+            resolvedPrinter = null;
+            if (printers.Count == 0)
+            {
+                error =
+                    "No print destination is configured. " +
+                    "Pass `--printer <name>` after adding a CUPS queue " +
+                    "(e.g. `sudo apt install printer-driver-cups-pdf` → queue `PDF` on Debian/Ubuntu), " +
+                    "or write a file with `wp print … --pdf out.pdf` (no printer needed).";
+            }
+            else
+            {
+                string names = string.Join(", ", printers.Select(p => p.Name));
+                error =
+                    "No default printer is set. " +
+                    $"Pass `--printer <name>` (available: {names}) " +
+                    "or write a file with `wp print … --pdf out.pdf`.";
+            }
+
+            return false;
+        }
+
+        // Named queue: if lpstat listed destinations, require a match (clearer than lpr's message).
+        // When the list is empty (lpstat failed / no rights), fall through and let lpr decide.
+        if (printers.Count > 0 &&
+            !printers.Any(p => string.Equals(p.Name, printerName, StringComparison.OrdinalIgnoreCase)))
+        {
+            string names = string.Join(", ", printers.Select(p => p.Name));
+            resolvedPrinter = null;
+            error =
+                $"Unknown printer '{printerName}'. " +
+                $"Available: {names}. Or write a file with `wp print … --pdf out.pdf`.";
+            return false;
+        }
+
+        resolvedPrinter = printerName;
+        error = null;
+        return true;
     }
 
     private static bool TryRun(string fileName, IReadOnlyList<string> args, byte[]? stdin, out string stdout,

--- a/src/WinPrint.Core/Printing/PrinterDestinationResult.cs
+++ b/src/WinPrint.Core/Printing/PrinterDestinationResult.cs
@@ -1,0 +1,30 @@
+namespace WinPrint.Core.Printing;
+
+/// <summary>
+///     Outcome of resolving a print destination to a concrete CUPS queue name.
+/// </summary>
+public readonly struct PrinterDestinationResult
+{
+    public string? PrinterName { get; }
+    public string? Error { get; }
+
+    public bool Success => Error is null && !string.IsNullOrEmpty(PrinterName);
+
+    private PrinterDestinationResult(string? printerName, string? error)
+    {
+        PrinterName = printerName;
+        Error = error;
+    }
+
+    public static PrinterDestinationResult Ok(string printerName)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(printerName);
+        return new PrinterDestinationResult(printerName, null);
+    }
+
+    public static PrinterDestinationResult Fail(string error)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(error);
+        return new PrinterDestinationResult(null, error);
+    }
+}

--- a/src/WinPrint.Core/Printing/UnixPrintJob.cs
+++ b/src/WinPrint.Core/Printing/UnixPrintJob.cs
@@ -40,6 +40,13 @@ public sealed class UnixPrintJob : IPrintJob
             return PrintJobResult.Succeeded(0);
         }
 
+        // Resolve before Skia render — no destination ⇒ fail fast without painting the document.
+        PrinterDestinationResult destination = _lprClient.ResolveDestination(_pageSetup.PrinterName);
+        if (!destination.Success)
+        {
+            return PrintJobResult.Failed(destination.Error!);
+        }
+
         byte[] pdf;
         try
         {
@@ -51,7 +58,7 @@ public sealed class UnixPrintJob : IPrintJob
         }
 
         return await _lprClient
-            .SubmitAsync(pdf, _pageSetup.PrinterName, _documentName, _pages.Count, cancellationToken)
+            .SubmitAsync(pdf, destination.PrinterName!, _documentName, _pages.Count, cancellationToken)
             .ConfigureAwait(false);
     }
 

--- a/src/WinPrint.Core/Printing/UnixPrintService.cs
+++ b/src/WinPrint.Core/Printing/UnixPrintService.cs
@@ -24,7 +24,9 @@ public sealed class UnixPrintService : IPrintService
 
     public PrintPageSetup GetDefaultPageSetup(string? printerName = null)
     {
-        string resolved = printerName ?? _lprClient.GetDefaultPrinter() ?? LprClient.SystemDefaultPrinter;
+        // Prefer an explicit name, else the CUPS default. Leave empty when neither exists — do not
+        // invent a fake "(System Default)" queue (bare lpr with no -P is a silent void).
+        string resolved = printerName ?? _lprClient.GetDefaultPrinter() ?? string.Empty;
 
         // US Letter defaults; CUPS applies the real media size from the destination's PPD at print time.
         return new PrintPageSetup

--- a/tests/WinPrint.Core.UnitTests/Printing/FakeLprClient.cs
+++ b/tests/WinPrint.Core.UnitTests/Printing/FakeLprClient.cs
@@ -14,6 +14,7 @@ public sealed class FakeLprClient : ILprClient
     public string? SubmittedDocument { get; private set; }
     public int SubmittedSheetCount { get; private set; }
     public int SubmitCallCount { get; private set; }
+    public int ResolveCallCount { get; private set; }
 
     public IReadOnlyList<PrinterInfo> Printers { get; set; } = new List<PrinterInfo>();
     public string? DefaultPrinter { get; set; }
@@ -29,7 +30,16 @@ public sealed class FakeLprClient : ILprClient
         return DefaultPrinter;
     }
 
-    public Task<PrintJobResult> SubmitAsync(byte[] pdf, string? printerName, string documentName,
+    public PrinterDestinationResult ResolveDestination(string? printerName)
+    {
+        ResolveCallCount++;
+        return LprClient.ResolveFromInputs(
+            printerName,
+            DefaultPrinter,
+            Printers.Select(p => p.Name).ToList());
+    }
+
+    public Task<PrintJobResult> SubmitAsync(byte[] pdf, string printerName, string documentName,
         int sheetCount, CancellationToken cancellationToken = default)
     {
         SubmittedPdf = pdf;

--- a/tests/WinPrint.Core.UnitTests/Printing/UnixPrintBackendTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Printing/UnixPrintBackendTests.cs
@@ -107,4 +107,78 @@ public class UnixPrintBackendTests
         Assert.True(pdf.Length > 0);
         Assert.Equal("%PDF-", Encoding.ASCII.GetString(pdf, 0, 5));
     }
+
+    [Fact]
+    public void TryResolvePrinter_SystemDefault_WithNoQueues_FailsWithActionableMessage()
+    {
+        bool ok = LprClient.TryResolvePrinter(
+            LprClient.SystemDefaultPrinter, defaultPrinter: null, printers: [],
+            out string? resolved, out string? error);
+
+        Assert.False(ok);
+        Assert.Null(resolved);
+        Assert.Contains("--pdf", error);
+        Assert.Contains("No print destination", error);
+    }
+
+    [Fact]
+    public void TryResolvePrinter_SystemDefault_WithQueuesButNoDefault_ListsThem()
+    {
+        var printers = new List<PrinterInfo>
+        {
+            new() { Name = "PDF" },
+            new() { Name = "Office" },
+        };
+
+        bool ok = LprClient.TryResolvePrinter(
+            null, defaultPrinter: null, printers,
+            out string? resolved, out string? error);
+
+        Assert.False(ok);
+        Assert.Null(resolved);
+        Assert.Contains("PDF", error);
+        Assert.Contains("Office", error);
+        Assert.Contains("--printer", error);
+    }
+
+    [Fact]
+    public void TryResolvePrinter_SystemDefault_UsesSpoolerDefault()
+    {
+        bool ok = LprClient.TryResolvePrinter(
+            LprClient.SystemDefaultPrinter, defaultPrinter: "PDF", printers: [],
+            out string? resolved, out string? error);
+
+        Assert.True(ok);
+        Assert.Equal("PDF", resolved);
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void TryResolvePrinter_NamedQueue_RejectsUnknownWhenListKnown()
+    {
+        var printers = new List<PrinterInfo> { new() { Name = "PDF" } };
+
+        bool ok = LprClient.TryResolvePrinter(
+            "NoSuchQueue", defaultPrinter: null, printers,
+            out string? resolved, out string? error);
+
+        Assert.False(ok);
+        Assert.Null(resolved);
+        Assert.Contains("Unknown printer", error);
+        Assert.Contains("PDF", error);
+    }
+
+    [Fact]
+    public void TryResolvePrinter_NamedQueue_AcceptedWhenListed()
+    {
+        var printers = new List<PrinterInfo> { new() { Name = "PDF" } };
+
+        bool ok = LprClient.TryResolvePrinter(
+            "PDF", defaultPrinter: null, printers,
+            out string? resolved, out string? error);
+
+        Assert.True(ok);
+        Assert.Equal("PDF", resolved);
+        Assert.Null(error);
+    }
 }

--- a/tests/WinPrint.Core.UnitTests/Printing/UnixPrintBackendTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Printing/UnixPrintBackendTests.cs
@@ -23,7 +23,7 @@ public class UnixPrintBackendTests
     [Fact]
     public async Task UnixPrintJob_RendersPdfAndSubmitsViaLpr()
     {
-        var lpr = new FakeLprClient();
+        var lpr = new FakeLprClient { DefaultPrinter = "Office" };
         var job = new UnixPrintJob(LetterSetup("Office"), "report.txt", lpr);
 
         job.Begin();
@@ -33,6 +33,7 @@ public class UnixPrintBackendTests
         PrintJobResult result = await job.EndAsync();
 
         Assert.True(result.Success);
+        Assert.Equal(1, lpr.ResolveCallCount);
         Assert.Equal(1, lpr.SubmitCallCount);
         Assert.Equal("Office", lpr.SubmittedPrinter);
         Assert.Equal("report.txt", lpr.SubmittedDocument);
@@ -52,14 +53,19 @@ public class UnixPrintBackendTests
 
         Assert.True(result.Success);
         Assert.Equal(0, result.SheetsPrinted);
+        Assert.Equal(0, lpr.ResolveCallCount);
         Assert.Equal(0, lpr.SubmitCallCount);
     }
 
     [Fact]
     public async Task UnixPrintJob_PropagatesLprFailure()
     {
-        var lpr = new FakeLprClient { Result = PrintJobResult.Failed("lpr: destination not found") };
-        var job = new UnixPrintJob(LetterSetup(), "doc", lpr);
+        var lpr = new FakeLprClient
+        {
+            DefaultPrinter = "PDF",
+            Result = PrintJobResult.Failed("lpr: destination not found"),
+        };
+        var job = new UnixPrintJob(LetterSetup("PDF"), "doc", lpr);
 
         job.Begin();
         job.PrintPage(1, (ctx, _) => ctx.DrawLine(ctx.BlackPen, 0, 0, 10, 10));
@@ -67,6 +73,38 @@ public class UnixPrintBackendTests
 
         Assert.False(result.Success);
         Assert.Contains("destination not found", result.Error);
+    }
+
+    [Fact]
+    public async Task UnixPrintJob_FailsBeforeSubmit_WhenNoDestination()
+    {
+        var lpr = new FakeLprClient { DefaultPrinter = null, Printers = [] };
+        var job = new UnixPrintJob(LetterSetup(string.Empty), "doc", lpr);
+
+        job.Begin();
+        // Action is never invoked — resolve fails before Skia render.
+        job.PrintPage(1, (_, _) => throw new InvalidOperationException("render should not run"));
+
+        PrintJobResult result = await job.EndAsync();
+
+        Assert.False(result.Success);
+        Assert.Contains("No print destination", result.Error);
+        Assert.Equal(1, lpr.ResolveCallCount);
+        Assert.Equal(0, lpr.SubmitCallCount);
+    }
+
+    [Fact]
+    public async Task UnixPrintJob_ResolvesSystemDefault_BeforeSubmit()
+    {
+        var lpr = new FakeLprClient { DefaultPrinter = "HomeLaser", Printers = [] };
+        var job = new UnixPrintJob(LetterSetup(string.Empty), "doc", lpr);
+
+        job.Begin();
+        job.PrintPage(1, (ctx, _) => ctx.DrawLine(ctx.BlackPen, 0, 0, 1, 1));
+        PrintJobResult result = await job.EndAsync();
+
+        Assert.True(result.Success, result.Error);
+        Assert.Equal("HomeLaser", lpr.SubmittedPrinter);
     }
 
     [Fact]
@@ -80,6 +118,17 @@ public class UnixPrintBackendTests
         Assert.Equal("HomeLaser", setup.PrinterName);
         Assert.Equal(850, setup.PaperWidth);
         Assert.Equal(1100, setup.PaperHeight);
+    }
+
+    [Fact]
+    public void UnixPrintService_GetDefaultPageSetup_EmptyWhenNoDefault()
+    {
+        var lpr = new FakeLprClient { DefaultPrinter = null };
+        var service = new UnixPrintService(lpr);
+
+        PrintPageSetup setup = service.GetDefaultPageSetup();
+
+        Assert.Equal(string.Empty, setup.PrinterName);
     }
 
     [Fact]
@@ -109,76 +158,82 @@ public class UnixPrintBackendTests
     }
 
     [Fact]
-    public void TryResolvePrinter_SystemDefault_WithNoQueues_FailsWithActionableMessage()
+    public void ResolveFromInputs_SystemDefault_WithNoQueues_FailsWithActionableMessage()
     {
-        bool ok = LprClient.TryResolvePrinter(
-            LprClient.SystemDefaultPrinter, defaultPrinter: null, printers: [],
-            out string? resolved, out string? error);
+        PrinterDestinationResult result = LprClient.ResolveFromInputs(
+            LprClient.SystemDefaultPrinter, defaultPrinter: null, queueNames: []);
 
-        Assert.False(ok);
-        Assert.Null(resolved);
-        Assert.Contains("--pdf", error);
-        Assert.Contains("No print destination", error);
+        Assert.False(result.Success);
+        Assert.Null(result.PrinterName);
+        Assert.Contains("No print destination", result.Error);
+        Assert.Contains("PDF file", result.Error);
     }
 
     [Fact]
-    public void TryResolvePrinter_SystemDefault_WithQueuesButNoDefault_ListsThem()
+    public void ResolveFromInputs_SystemDefault_WithQueuesButNoDefault_ListsThem()
     {
-        var printers = new List<PrinterInfo>
-        {
-            new() { Name = "PDF" },
-            new() { Name = "Office" },
-        };
+        PrinterDestinationResult result = LprClient.ResolveFromInputs(
+            null, defaultPrinter: null, queueNames: ["PDF", "Office"]);
 
-        bool ok = LprClient.TryResolvePrinter(
-            null, defaultPrinter: null, printers,
-            out string? resolved, out string? error);
-
-        Assert.False(ok);
-        Assert.Null(resolved);
-        Assert.Contains("PDF", error);
-        Assert.Contains("Office", error);
-        Assert.Contains("--printer", error);
+        Assert.False(result.Success);
+        Assert.Null(result.PrinterName);
+        Assert.Contains("PDF", result.Error);
+        Assert.Contains("Office", result.Error);
+        Assert.Contains("Specify a printer", result.Error);
     }
 
     [Fact]
-    public void TryResolvePrinter_SystemDefault_UsesSpoolerDefault()
+    public void ResolveFromInputs_SystemDefault_UsesSpoolerDefault()
     {
-        bool ok = LprClient.TryResolvePrinter(
-            LprClient.SystemDefaultPrinter, defaultPrinter: "PDF", printers: [],
-            out string? resolved, out string? error);
+        PrinterDestinationResult result = LprClient.ResolveFromInputs(
+            LprClient.SystemDefaultPrinter, defaultPrinter: "PDF", queueNames: []);
 
-        Assert.True(ok);
-        Assert.Equal("PDF", resolved);
-        Assert.Null(error);
+        Assert.True(result.Success);
+        Assert.Equal("PDF", result.PrinterName);
+        Assert.Null(result.Error);
     }
 
     [Fact]
-    public void TryResolvePrinter_NamedQueue_RejectsUnknownWhenListKnown()
+    public void ResolveFromInputs_EmptyName_TreatedAsSystemDefault()
     {
-        var printers = new List<PrinterInfo> { new() { Name = "PDF" } };
+        PrinterDestinationResult result = LprClient.ResolveFromInputs(
+            string.Empty, defaultPrinter: "Brother", queueNames: []);
 
-        bool ok = LprClient.TryResolvePrinter(
-            "NoSuchQueue", defaultPrinter: null, printers,
-            out string? resolved, out string? error);
-
-        Assert.False(ok);
-        Assert.Null(resolved);
-        Assert.Contains("Unknown printer", error);
-        Assert.Contains("PDF", error);
+        Assert.True(result.Success);
+        Assert.Equal("Brother", result.PrinterName);
     }
 
     [Fact]
-    public void TryResolvePrinter_NamedQueue_AcceptedWhenListed()
+    public void ResolveFromInputs_NamedQueue_RejectsUnknownWhenListKnown()
     {
-        var printers = new List<PrinterInfo> { new() { Name = "PDF" } };
+        PrinterDestinationResult result = LprClient.ResolveFromInputs(
+            "NoSuchQueue", defaultPrinter: null, queueNames: ["PDF"]);
 
-        bool ok = LprClient.TryResolvePrinter(
-            "PDF", defaultPrinter: null, printers,
-            out string? resolved, out string? error);
+        Assert.False(result.Success);
+        Assert.Null(result.PrinterName);
+        Assert.Contains("Unknown printer", result.Error);
+        Assert.Contains("PDF", result.Error);
+    }
 
-        Assert.True(ok);
-        Assert.Equal("PDF", resolved);
-        Assert.Null(error);
+    [Fact]
+    public void ResolveFromInputs_NamedQueue_AcceptedWhenListed()
+    {
+        PrinterDestinationResult result = LprClient.ResolveFromInputs(
+            "PDF", defaultPrinter: null, queueNames: ["PDF"]);
+
+        Assert.True(result.Success);
+        Assert.Equal("PDF", result.PrinterName);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    public void ResolveFromInputs_NamedQueue_AcceptedWhenListUnknown()
+    {
+        // Empty list ⇒ lpstat failed; do not block — let lpr decide.
+        PrinterDestinationResult result = LprClient.ResolveFromInputs(
+            "MaybeExists", defaultPrinter: null, queueNames: []);
+
+        Assert.True(result.Success);
+        Assert.Equal("MaybeExists", result.PrinterName);
     }
 }

--- a/tests/WinPrint.Core.UnitTests/Printing/UnixPrintBackendTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Printing/UnixPrintBackendTests.cs
@@ -65,7 +65,7 @@ public class UnixPrintBackendTests
             DefaultPrinter = "PDF",
             Result = PrintJobResult.Failed("lpr: destination not found"),
         };
-        var job = new UnixPrintJob(LetterSetup("PDF"), "doc", lpr);
+        var job = new UnixPrintJob(LetterSetup(), "doc", lpr);
 
         job.Begin();
         job.PrintPage(1, (ctx, _) => ctx.DrawLine(ctx.BlackPen, 0, 0, 10, 10));
@@ -161,7 +161,7 @@ public class UnixPrintBackendTests
     public void ResolveFromInputs_SystemDefault_WithNoQueues_FailsWithActionableMessage()
     {
         PrinterDestinationResult result = LprClient.ResolveFromInputs(
-            LprClient.SystemDefaultPrinter, defaultPrinter: null, queueNames: []);
+            LprClient.SystemDefaultPrinter, null, []);
 
         Assert.False(result.Success);
         Assert.Null(result.PrinterName);
@@ -173,7 +173,7 @@ public class UnixPrintBackendTests
     public void ResolveFromInputs_SystemDefault_WithQueuesButNoDefault_ListsThem()
     {
         PrinterDestinationResult result = LprClient.ResolveFromInputs(
-            null, defaultPrinter: null, queueNames: ["PDF", "Office"]);
+            null, null, ["PDF", "Office"]);
 
         Assert.False(result.Success);
         Assert.Null(result.PrinterName);
@@ -186,7 +186,7 @@ public class UnixPrintBackendTests
     public void ResolveFromInputs_SystemDefault_UsesSpoolerDefault()
     {
         PrinterDestinationResult result = LprClient.ResolveFromInputs(
-            LprClient.SystemDefaultPrinter, defaultPrinter: "PDF", queueNames: []);
+            LprClient.SystemDefaultPrinter, "PDF", []);
 
         Assert.True(result.Success);
         Assert.Equal("PDF", result.PrinterName);
@@ -197,7 +197,7 @@ public class UnixPrintBackendTests
     public void ResolveFromInputs_EmptyName_TreatedAsSystemDefault()
     {
         PrinterDestinationResult result = LprClient.ResolveFromInputs(
-            string.Empty, defaultPrinter: "Brother", queueNames: []);
+            string.Empty, "Brother", []);
 
         Assert.True(result.Success);
         Assert.Equal("Brother", result.PrinterName);
@@ -207,7 +207,7 @@ public class UnixPrintBackendTests
     public void ResolveFromInputs_NamedQueue_RejectsUnknownWhenListKnown()
     {
         PrinterDestinationResult result = LprClient.ResolveFromInputs(
-            "NoSuchQueue", defaultPrinter: null, queueNames: ["PDF"]);
+            "NoSuchQueue", null, ["PDF"]);
 
         Assert.False(result.Success);
         Assert.Null(result.PrinterName);
@@ -219,7 +219,7 @@ public class UnixPrintBackendTests
     public void ResolveFromInputs_NamedQueue_AcceptedWhenListed()
     {
         PrinterDestinationResult result = LprClient.ResolveFromInputs(
-            "PDF", defaultPrinter: null, queueNames: ["PDF"]);
+            "PDF", null, ["PDF"]);
 
         Assert.True(result.Success);
         Assert.Equal("PDF", result.PrinterName);
@@ -231,7 +231,7 @@ public class UnixPrintBackendTests
     {
         // Empty list ⇒ lpstat failed; do not block — let lpr decide.
         PrinterDestinationResult result = LprClient.ResolveFromInputs(
-            "MaybeExists", defaultPrinter: null, queueNames: []);
+            "MaybeExists", null, []);
 
         Assert.True(result.Success);
         Assert.Equal("MaybeExists", result.PrinterName);

--- a/tests/WinPrint.TUI.UnitTests/PrintCommandTests.cs
+++ b/tests/WinPrint.TUI.UnitTests/PrintCommandTests.cs
@@ -6,8 +6,11 @@ namespace WinPrint.TUI.UnitTests;
 
 /// <summary>
 ///     Verifies the headless <see cref="PrintCommand" /> (<c>wp print</c>): its CLI surface, the
-///     no-file usage error, and the <c>--what-if</c> path that counts sheets without touching a
-///     printer (so it runs cross-platform without print hardware).
+///     no-file usage error, the <c>--what-if</c> path that counts sheets without touching a
+///     printer, and the <c>--pdf</c> validation rules (mutually exclusive with <c>--printer</c>,
+///     single input file). <c>--what-if</c> and the validation paths run cross-platform without
+///     print hardware; the real <c>--pdf</c> write is covered by
+///     <c>PdfFilePrintJobTests</c> and by the Linux cups-pdf verification in issue #244.
 /// </summary>
 public class PrintCommandTests
 {
@@ -30,6 +33,7 @@ public class PrintCommandTests
         Assert.True(command.AcceptsPositionalArgs);
         Assert.Contains(command.Options, o => o.Name == "sheet");
         Assert.Contains(command.Options, o => o is { Name: "what-if", ShortName: "w" });
+        Assert.Contains(command.Options, o => o.Name == "pdf");
     }
 
     [Fact]
@@ -58,6 +62,49 @@ public class PrintCommandTests
         finally
         {
             File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task Pdf_AndPrinter_AreMutuallyExclusive()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"wp-print-{Guid.NewGuid():N}.cs");
+        await File.WriteAllTextAsync(path, "class Program { static void Main() { } }\n");
+        try
+        {
+            CommandResult result = await new PrintCommand()
+                .RunAsync(null!, null,
+                    Run([path], ("pdf", "out.pdf"), ("printer", "PDF")),
+                    CancellationToken.None);
+
+            Assert.Equal(CommandStatus.Error, result.Status);
+            Assert.Equal("PdfAndPrinter", result.ErrorCode);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task Pdf_RequiresExactlyOneInputFile()
+    {
+        string a = Path.Combine(Path.GetTempPath(), $"wp-print-{Guid.NewGuid():N}.cs");
+        string b = Path.Combine(Path.GetTempPath(), $"wp-print-{Guid.NewGuid():N}.cs");
+        await File.WriteAllTextAsync(a, "class A {}\n");
+        await File.WriteAllTextAsync(b, "class B {}\n");
+        try
+        {
+            CommandResult result = await new PrintCommand()
+                .RunAsync(null!, null, Run([a, b], ("pdf", "out.pdf")), CancellationToken.None);
+
+            Assert.Equal(CommandStatus.Error, result.Status);
+            Assert.Equal("PdfOneFile", result.ErrorCode);
+        }
+        finally
+        {
+            File.Delete(a);
+            File.Delete(b);
         }
     }
 }


### PR DESCRIPTION
Closes #244.

## What

End-to-end **Linux** verification of `wp print --printer` (cups-pdf) and `wp print --pdf`, then docs + tests that lock the verified facts in.

## Verified (Ubuntu 24.04)

| Check | Result |
| --- | --- |
| Queue name | **`PDF`** (`lpstat -p`) |
| Output dir | **`~/PDF/`** |
| `wp print testfiles/demo.md --printer PDF --sheet "Proportional 1-Up"` | exit 0, **4** sheets, PDF in `~/PDF/` |
| `wp print testfiles/demo.md --pdf ~/demo.pdf --sheet "Proportional 1-Up"` | exit 0, **4** sheets, valid PDF |
| `wp print testfiles/mermaid.md --printer PDF --sheet "Proportional 1-Up"` | exit 0, **17** sheets |
| Mermaid pages | flowchart, sequence, class, ER, pie, **gantt**, etc. render **as diagrams** (default mermaid.ink backend) |
| Fidelity | Skia PDF bytes submitted via `lpr -P PDF -T <doc>`; with a raw cups-pdf backend the file in `~/PDF/` was **byte-identical** to `--pdf` |

### Fidelity note (stock cups-pdf)

Stock `printer-driver-cups-pdf` with its PPD may run a **PDF→PS→PDF** filter chain (Ghostscript). Mermaid is embedded as raster, so diagrams survive that path. Prefer **`wp print … --pdf out.pdf`** when you only need a file and want bit-identical Skia output (no queue, no filter chain).

## Changes

- **Docs** (`README`, `docs/index.md`, `docs/users-guide.md`): confirm Debian/Ubuntu queue `PDF` + `~/PDF/`, note Fedora is often `Cups-PDF`, document the fidelity preference for `--pdf`.
- **`docs/hero-gif-win.md`**: CLI showcase description matches the default service backend (gantt as image, not code-block fallback).
- **`PrintCommandTests`**: advertise `--pdf`; reject `--pdf`+`--printer`; reject multi-file `--pdf`.

## Product code

No engine/CLI bugs found on Linux — the existing `UnixPrintJob` → `SkiaPdfRenderer` → `LprClient` and `PdfFilePrintService` paths work as designed.