### PR TITLE
Only invoke win/mac runners when absolutely necessary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,21 @@
 name: CI
 
 on:
+  # push is scoped to the same branches as pull_request (not '**'): a push to a branch with
+  # an open PR fires both events on the same commit, double-running the windows-latest/macos-26
+  # jobs below for no extra coverage. Pushes to a WIP feature branch with no PR yet now build
+  # nothing until a PR is opened — direct pushes to main/develop/v2.1 still get their own run.
   push:
-    branches: ['**']
+    branches: [main, develop, v2.1]
   pull_request:
     branches: [main, develop, v2.1]
+
+# Cancel a still-running CI run for the same PR/branch when a new commit lands, instead of
+# letting superseded windows-latest/macos-26 jobs run to completion — those two runner classes
+# are what GitHub actually charges for.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,11 @@ on:
 
 # Cancel a still-running CI run for the same PR/branch when a new commit lands, instead of
 # letting superseded windows-latest/macos-26 jobs run to completion — those two runner classes
-# are what GitHub actually charges for.
+# are what GitHub actually charges for. Keyed by PR number (not head_ref): two different forks
+# can share a branch name (e.g. both named "fix"), and head_ref alone would let one contributor's
+# push cancel another contributor's unrelated run.
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,16 @@ on:
   # an open PR fires both events on the same commit, double-running the windows-latest/macos-26
   # jobs below for no extra coverage. Pushes to a WIP feature branch with no PR yet now build
   # nothing until a PR is opened — direct pushes to main/develop/v2.1 still get their own run.
+  # paths-ignore skips the whole workflow when every changed file is docs/README — those never
+  # affect the build/test matrix. (Only skips if ALL changed files match; a PR mixing docs with
+  # code still runs CI.) GitHub Pages serves /docs via the legacy Jekyll builder tied to repo
+  # settings, not an Actions workflow, so this doesn't affect the docs site build either.
   push:
     branches: [main, develop, v2.1]
+    paths-ignore: &docs-only ['docs/**', 'README.md']
   pull_request:
     branches: [main, develop, v2.1]
+    paths-ignore: *docs-only
 
 # Cancel a still-running CI run for the same PR/branch when a new commit lands, instead of
 # letting superseded windows-latest/macos-26 jobs run to completion — those two runner classes

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,8 +8,10 @@ name: CodeQL
 on:
   push:
     branches: [develop, main]
+    paths-ignore: ['docs/**', 'README.md']
   pull_request:
     branches: [develop, main]
+    paths-ignore: ['docs/**', 'README.md']
   schedule:
     - cron: '41 4 * * 1' # weekly, Monday 04:41 UTC
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,12 +39,14 @@ files, commit those changes — that *is* the fix; re-run until `git diff` is em
 solution gate over MAUI files is still verified by Windows CI. Code-style analyzers also enforce
 **one top-level type per file** (WPA0001) and **no nested types** (WPA0002).
 
-**CI mechanics & flakiness (don't mistake a flake for a real failure).** Every PR triggers
-CI **twice** (a `push` run and a `pull_request` run). `maui-ui-tests` (Appium) and the
-FlaUI / TUI-golden suites are **flaky**: the tell is the *same commit* passing in one of the
-two sibling runs and failing in the other. Before chasing such a failure, confirm it's not the
-flake; to clear it, `gh run rerun --failed <run-id>` — but you **can't** re-run a job while its
-sibling workflow is still in progress (it's rejected), so wait for both to settle first.
+**CI mechanics & flakiness (don't mistake a flake for a real failure).** CI's `push` trigger is
+scoped to `[main, develop, v2.1]` (not every branch), so a PR from a feature branch gets exactly
+**one** run per push (the `pull_request` event) — this used to be two (a `push` run plus a
+`pull_request` run on the same commit), which double-billed the `windows-latest`/`macos-26` jobs
+for no extra coverage; a `concurrency` group also cancels a run outright when a newer commit
+supersedes it. `maui-ui-tests` (Appium) and the FlaUI / TUI-golden suites are still **flaky** on
+their own — a red run can just mean re-run it (`gh run rerun --failed <run-id>`) before assuming a
+real regression.
 
 ## Remote (Claude Code on the web) environment
 Fresh Linux containers have no toolchain. `.claude/hooks/session-start.sh` (registered


### PR DESCRIPTION
## Summary
- GitHub charges tons for `windows-latest`/`macos-26` runners. `ci.yml`'s `push` trigger was `branches: ['**']`, so **every** push to **any** branch ran the full matrix (Windows build/test, mac Appium UI tests, win-arm64/x64 AOT publish) — including WIP commits with no PR yet.
- Worse: once a PR exists, `push` and `pull_request` both fire on the same commit, so every PR push ran the whole matrix **twice** (documented as a known quirk in `CLAUDE.md`).
- Scope `push` to `[main, develop, v2.1]` (matching `pull_request`) so a PR push gets exactly one run, and WIP branches don't run CI until a PR is opened. Direct pushes to protected branches still trigger their own run.
- Add a `concurrency` group with `cancel-in-progress: true` so a superseded run (e.g. rapid follow-up commits) is cancelled instead of letting the windows/mac jobs run to completion for a stale commit. Keyed by PR number (not `head_ref`) so two different forks sharing a branch name can't cancel each other's runs.
- Neither `ci.yml` nor `codeql.yml` had a `paths` filter, so a docs- or README-only change still ran the full matrix + CodeQL for no reason. Added `paths-ignore: ['docs/**', 'README.md']` to both — a PR mixing docs with code still runs everything, since `paths-ignore` only skips when *every* changed file matches. (GitHub Pages serves `/docs` via the legacy Jekyll builder tied to repo settings, not an Actions workflow, so this doesn't touch the docs site build.)
- Updated the `CLAUDE.md` CI-flakiness note, which described the old double-run behavior.

Beyond cost, this also speeds up feedback: no more waiting on a redundant second run of the same commit, docs-only PRs merge without waiting on an irrelevant Windows/macOS/CodeQL run, and a rapid string of pushes no longer queues each one behind the last instead of just running the latest.

## Test plan
- [ ] Validated `ci.yml`/`codeql.yml` parse as YAML (`yaml.safe_load`).
- [ ] Open this PR and confirm exactly one CI run fires per push (not two).
- [ ] Push a follow-up commit and confirm the prior in-progress run is cancelled.
- [ ] Confirm CI still runs on a direct push to `develop`/`main`.
- [ ] Push a docs-only commit and confirm CI/CodeQL don't run; push a docs+code commit and confirm they do.