### PR TITLE
feat(mermaid): default to the builtin backend; Mermaider 0.9.0 (all diagram types)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,8 +163,9 @@ engine by `SupportedContentTypes` and applies the per-engine settings persisted 
 `ApplyPersistedEngineSettings`. This replaced the old reflection scan (`GetTypes()` +
 `Activator.CreateInstance`) and the per-engine static `Create()` factories. Engines:
 - `TextCte` (`text/plain`), `MarkdownCte` (`text/x-markdown`, subclasses `TextCte` and
-  flattens Markdown via Markdig; ```mermaid fences render in-process via Mermaider + Svg.Skia by
-  default, with `mermaidBackend: "service"` (mermaid.ink) or opt-in `builtin` via Mermaider), `TextMateCte` (syntax highlighting; the default),
+  flattens Markdown via Markdig; ```mermaid fences render in-process by default via Mermaider +
+  Svg.Skia — every diagram type except ZenUML as of Mermaider 0.9.0 — with opt-in
+  `mermaidBackend: "service"` for the remote mermaid.ink), `TextMateCte` (syntax highlighting; the default),
   `AnsiCte` (`text/ansi`; decodes ANSI escape sequences via the vendored managed `libvt100`)
   and `HtmlCte` (`text/html` plus `.mhtml`/`.mht`; lays out HTML/CSS via the managed HtmlRenderer,
   with `http(s)` assets gated behind `AllowRemoteResources`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,8 +184,9 @@ engine by `SupportedContentTypes` and applies the per-engine settings persisted 
 `ApplyPersistedEngineSettings`. This replaced the old reflection scan (`GetTypes()` +
 `Activator.CreateInstance`) and the per-engine static `Create()` factories. Engines:
 - `TextCte` (`text/plain`), `MarkdownCte` (`text/x-markdown`, subclasses `TextCte` and
-  flattens Markdown via Markdig; ```mermaid fences render in-process via Mermaider + Svg.Skia by
-  default, with `mermaidBackend: "service"` (mermaid.ink) or opt-in `builtin` via Mermaider), `TextMateCte` (syntax highlighting; the default),
+  flattens Markdown via Markdig; ```mermaid fences render in-process by default via Mermaider +
+  Svg.Skia — every diagram type except ZenUML as of Mermaider 0.9.0 — with opt-in
+  `mermaidBackend: "service"` for the remote mermaid.ink), `TextMateCte` (syntax highlighting; the default),
   `AnsiCte` (`text/ansi`; decodes ANSI escape sequences via the vendored managed `libvt100`)
   and `HtmlCte` (`text/html` plus `.mhtml`/`.mht`; lays out HTML/CSS via the managed HtmlRenderer,
   with `http(s)` assets gated behind `AllowRemoteResources`).

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Advanced source code, html, markdown, and text file printing for terminals (all 
 
 ## How to turn Markdown into a PDF
 
-One command, every platform. Markdown goes in; a formatted, paginated PDF comes out: headings, lists, tables, images, syntax-highlighted code, and ` ```mermaid ` fences rendered as real diagrams (via mermaid.ink by default, or fully in-process with the built-in renderer):
+One command, every platform. Markdown goes in; a formatted, paginated PDF comes out: headings, lists, tables, images, syntax-highlighted code, and ` ```mermaid ` fences rendered as real diagrams (fully in-process by default — no network — or via mermaid.ink with the opt-in `service` backend):
 
 ```powershell
 wp print mermaid.md --pdf mermaid.pdf --sheet "Proportional 1-Up"

--- a/docs/hero-gif-win.md
+++ b/docs/hero-gif-win.md
@@ -129,8 +129,8 @@ mcec's `hero-gif.md`. Two WinPrint-specific input rules:
 12. **Record the CLI showcase (`docs/cli.gif`).** Regenerate this **every time the Windows hero is
     regenerated** -- same controller session. It is the README's "How to turn Markdown into a PDF"
     beat: `wp print` turning `testfiles/mermaid.md` (every mermaid diagram type — flowchart,
-    sequence, class, ER, pie, gantt, … — as images via the default mermaid.ink backend; use
-    `mermaidBackend: "builtin"` only if you need the in-process path and its fallbacks) into a
+    sequence, class, ER, pie, gantt, … — as images via the default in-process builtin backend;
+    only the ZenUML fence falls back to a code block) into a
     PDF, from a real terminal. Needs a **`net10.0-windows`-TFM `wp`** on PATH (`dotnet build
     src/WinPrint.TUI/WinPrint.TUI.csproj -f net10.0-windows`; the portable `net10.0` build has no
     Windows print path and tries `lpr`).

--- a/docs/hero-gifs.md
+++ b/docs/hero-gifs.md
@@ -72,9 +72,9 @@ linger; the zoom/pan flourish stays fast.
 ## The Mermaid beat
 
 `demo.md` leads with its Mermaid fence (since #246), so page 1 of every hero opens on the
-rendered diagram. `renderMermaidDiagrams` defaults to `true` with the `service` backend
-(mermaid.ink unless `mermaidServiceUrl` says otherwise — the diagram source goes over the
-network, so recording needs connectivity). The gotcha is a **stale co-located
+rendered diagram. `renderMermaidDiagrams` defaults to `true` with the in-process `builtin`
+backend (Mermaider — no network needed; only the opt-in `service` backend sends the diagram
+to mermaid.ink and needs connectivity). The gotcha is a **stale co-located
 `WinPrint.config.json`** pinning `renderMermaidDiagrams: false` from an earlier version — then
 the fence prints as a code block and the Mermaid beats show code instead of a picture. On
 macOS/Linux winprint runs in **portable mode** — the config sits next to the executable, and

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ See [User's Guide](users-guide.md) for more details.
 
 ### Turn Markdown into a PDF
 
-One command, every platform. Markdown goes in; a formatted, paginated PDF comes out: headings, lists, tables, images, syntax-highlighted code, and ` ```mermaid ` fences rendered as real diagrams (via mermaid.ink by default, or fully in-process with the built-in renderer):
+One command, every platform. Markdown goes in; a formatted, paginated PDF comes out: headings, lists, tables, images, syntax-highlighted code, and ` ```mermaid ` fences rendered as real diagrams (fully in-process by default — no network — or via mermaid.ink with the opt-in `service` backend):
 
 ```powershell
 wp print mermaid.md --pdf mermaid.pdf --sheet "Proportional 1-Up"

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -244,14 +244,14 @@ This is the default CTE used for most text and source files. It uses bundled Tex
 
 ### `MarkdownCte`
 
-Renders Markdown files (`text/x-markdown`; e.g. `.md`) as formatted documents, including inline images. ` ```mermaid ` fenced code blocks are rendered as diagrams by default using the remote `mermaid.ink` service (diagram source is sent over the network; broadest compatibility). Unsupported diagram types, and diagrams that fail to render, print as regular code blocks.
+Renders Markdown files (`text/x-markdown`; e.g. `.md`) as formatted documents, including inline images. ` ```mermaid ` fenced code blocks are rendered as diagrams by default, entirely in-process via the Mermaider library — nothing is sent over the network, and every Mermaid diagram type except ZenUML is supported (as of Mermaider 0.9.0). Diagrams that fail to render print as regular code blocks.
 
-Options in the `markdownContentTypeEngineSettings` section of `WinPrint.config.json`: set `renderMermaidDiagrams` to `false` to always print fences as code, or set `mermaidBackend` to `"builtin"` for the private in-process Mermaider renderer (nothing is sent over the network, but it supports fewer diagram types and has some syntax restrictions). See the support matrix in `testfiles/mermaid.md`.
+Options in the `markdownContentTypeEngineSettings` section of `WinPrint.config.json`: set `renderMermaidDiagrams` to `false` to always print fences as code, or set `mermaidBackend` to `"service"` to render via the remote `mermaid.ink` service instead (full Mermaid.js fidelity, but the diagram source is sent over the network). See the support matrix in `testfiles/mermaid.md`.
 
    ```json
        "markdownContentTypeEngineSettings": {
          "renderMermaidDiagrams": true,
-         "mermaidBackend": "service",
+         "mermaidBackend": "builtin",
          "mermaidServiceUrl": "https://mermaid.ink"
        }
    ```

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -248,6 +248,8 @@ Renders Markdown files (`text/x-markdown`; e.g. `.md`) as formatted documents, i
 
 Options in the `markdownContentTypeEngineSettings` section of `WinPrint.config.json`: set `renderMermaidDiagrams` to `false` to always print fences as code, or set `mermaidBackend` to `"service"` to render via the remote `mermaid.ink` service instead (full Mermaid.js fidelity, but the diagram source is sent over the network). See the support matrix in `testfiles/mermaid.md`.
 
+Upgrading from 3.1.x: those versions wrote their then-default `"mermaidBackend": "service"` into the config file, so on first load WinPrint rewrites that leftover to `"builtin"` (and stamps the file with `schemaVersion`) — nothing is sent over the network unless you set `"service"` yourself afterwards, which then sticks.
+
    ```json
        "markdownContentTypeEngineSettings": {
          "renderMermaidDiagrams": true,

--- a/src/WinPrint.Core/ContentTypeEngines/MarkdownCte.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/MarkdownCte.cs
@@ -32,9 +32,9 @@ namespace WinPrint.Core.ContentTypeEngines;
 ///     URLs are supported. Anything that fails to load (and inline images mixed with text) falls back
 ///     to alt text. When <see cref="RenderMermaidDiagrams" /> is enabled (the default),
 ///     <c>```mermaid</c> fences are rendered to images via <see cref="MermaidRenderer" /> (by default
-///     the remote `service` at <see cref="MermaidServiceUrl" />); set <see cref="MermaidBackend" /> to
-///     <c>"builtin"</c> for the in-process Mermaider renderer. A diagram that fails to render falls back to a plain code
-///     block.
+///     the in-process Mermaider renderer); set <see cref="MermaidBackend" /> to <c>"service"</c> for
+///     the remote mermaid.ink-compatible service at <see cref="MermaidServiceUrl" />. A diagram that
+///     fails to render falls back to a plain code block.
 /// </summary>
 public class MarkdownCte : ContentTypeEngineBase
 {
@@ -111,23 +111,24 @@ public class MarkdownCte : ContentTypeEngineBase
     /// <summary>
     ///     When true (the default), each <c>```mermaid</c> fence is rendered to an image via
     ///     <see cref="MermaidRenderer" />; when false, fences render as plain code blocks.
-    ///     The default backend is the remote <c>service</c> (mermaid.ink-compatible), which
-    ///     sends the diagram source over the network (same privacy consideration as
-    ///     <see cref="HtmlCte.AllowRemoteResources" />). Set to <c>false</c> to opt out entirely,
-    ///     or switch <see cref="MermaidBackend"/> to <c>"builtin"</c> for fully in-process rendering.
+    ///     The default backend is the in-process <c>builtin</c> renderer (Mermaider), so nothing
+    ///     leaves the machine. Set to <c>false</c> to opt out entirely, or switch
+    ///     <see cref="MermaidBackend"/> to <c>"service"</c> for the remote mermaid.ink-compatible
+    ///     service (full Mermaid.js fidelity; sends diagram source over the network).
     /// </summary>
     public bool RenderMermaidDiagrams { get; set; } = true;
 
     /// <summary>
     ///     Selects the diagram backend when no <see cref="MermaidRenderer" /> is injected:
-    ///     <c>service</c> (the default) renders via the remote mermaid.ink-compatible service at
-    ///     <see cref="MermaidServiceUrl" /> (diagram source is sent; same privacy consideration as
-    ///     <see cref="HtmlCte.AllowRemoteResources" />); <c>builtin</c> renders in-process via
-    ///     <see cref="MermaiderRenderer" /> (private, but supports fewer types and some syntax
-    ///     variants are rejected). Unknown values safely fall back to <c>builtin</c> (never
-    ///     network). Failures from either backend fall back to a plain code block.
+    ///     <c>builtin</c> (the default) renders in-process via <see cref="MermaiderRenderer" />
+    ///     (private and fast; covers every Mermaid diagram type except ZenUML as of Mermaider
+    ///     0.9.0); <c>service</c> renders via the remote mermaid.ink-compatible service at
+    ///     <see cref="MermaidServiceUrl" /> (full Mermaid.js fidelity; diagram source is sent —
+    ///     same privacy consideration as <see cref="HtmlCte.AllowRemoteResources" />). Unknown
+    ///     values safely fall back to <c>builtin</c> (never network). Failures from either
+    ///     backend fall back to a plain code block.
     /// </summary>
-    public string MermaidBackend { get; set; } = "service";
+    public string MermaidBackend { get; set; } = "builtin";
 
     /// <summary>Base URL of the mermaid.ink-compatible service used when <see cref="MermaidBackend" /> is <c>service</c>.</summary>
     public string MermaidServiceUrl { get; set; } = "https://mermaid.ink";
@@ -926,9 +927,9 @@ public class MarkdownCte : ContentTypeEngineBase
 
     /// <summary>
     ///     The renderer the preload uses: an injected <see cref="MermaidRenderer" /> wins; otherwise
-    ///     <see cref="MermaidBackend" /> picks the remote <see cref="MermaidInkRenderer" />
-    ///     (<c>service</c>, the default) or the in-process <see cref="MermaiderRenderer" />
-    ///     (<c>builtin</c>). Unrecognized backend values fall back to builtin so a config typo
+    ///     <see cref="MermaidBackend" /> picks the in-process <see cref="MermaiderRenderer" />
+    ///     (<c>builtin</c>, the default) or the remote <see cref="MermaidInkRenderer" />
+    ///     (<c>service</c>). Unrecognized backend values fall back to builtin so a config typo
     ///     never causes network I/O.
     /// </summary>
     internal IMermaidRenderer ResolveMermaidRenderer()

--- a/src/WinPrint.Core/ContentTypeEngines/MermaidInkRenderer.cs
+++ b/src/WinPrint.Core/ContentTypeEngines/MermaidInkRenderer.cs
@@ -10,7 +10,7 @@ namespace WinPrint.Core.ContentTypeEngines;
 
 /// <summary>
 ///     The <c>service</c> <see cref="IMermaidRenderer" /> backend (see
-///     <see cref="MarkdownCte.MermaidBackend" />; the default): renders diagrams to PNG via a mermaid.ink-compatible HTTP
+///     <see cref="MarkdownCte.MermaidBackend" />; opt-in): renders diagrams to PNG via a mermaid.ink-compatible HTTP
 ///     service (<c>GET {service}/img/{url-safe-base64-of-source}?type=png</c>, the encoding documented
 ///     at https://mermaid.js.org/ecosystem/tutorials.html). Note the diagram source is sent to the
 ///     service; <see cref="MarkdownCte" /> only uses this renderer when the user opts into the

--- a/src/WinPrint.Core/Models/Settings.cs
+++ b/src/WinPrint.Core/Models/Settings.cs
@@ -93,6 +93,22 @@ public class Settings : ModelBase
         }
     }
 
+    /// <summary>
+    ///     The settings format this file was written by; bump when a load-time migration is added.
+    ///     2 = <c>mermaidBackend</c> defaults to <c>builtin</c> (files written by 3.1.2–3.1.4 persisted
+    ///     the then-default <c>service</c>).
+    /// </summary>
+    public const int CurrentSchemaVersion = 2;
+
+    /// <summary>
+    ///     Format stamp for <c>WinPrint.config.json</c>: lets the loader run migrations exactly once for
+    ///     files written by older versions, whose persisted values can record an old default rather than
+    ///     a user's choice (see <c>WinPrintJson.MigrateLegacySettings</c>). Files without the field
+    ///     predate 3.2.0.
+    /// </summary>
+    [SafeForTelemetry]
+    public int SchemaVersion { get; set; } = CurrentSchemaVersion;
+
     [SafeForTelemetry] public string DefaultContentType { get; set; } = "text/plain";
 
     [SafeForTelemetry] public string DefaultCteClassName { get; set; } = ContentTypeEngineBase.DefaultCteClassName;
@@ -614,6 +630,7 @@ public class Settings : ModelBase
             : new WindowLocation(src.Location.X, src.Location.Y);
         Size = src.Size is null ? null : new WindowSize(src.Size.Width, src.Size.Height);
         WindowState = src.WindowState;
+        SchemaVersion = src.SchemaVersion;
         DefaultSheet = src.DefaultSheet;
         DefaultSheetByContentType.Clear();
         if (src.DefaultSheetByContentType is not null)

--- a/src/WinPrint.Core/Serialization/WinPrintJson.cs
+++ b/src/WinPrint.Core/Serialization/WinPrintJson.cs
@@ -14,6 +14,18 @@ internal static class WinPrintJson
 
     public static Settings LoadSettingsWithDefaults(string json)
     {
+        return LoadSettingsWithDefaults(json, out _);
+    }
+
+    /// <summary>
+    ///     Parses <paramref name="json" /> over the current defaults. <paramref name="migrated" /> is
+    ///     true when the document predates <see cref="Settings.CurrentSchemaVersion" />; the caller
+    ///     should persist the returned settings so the file is stamped and migrations run exactly once
+    ///     (a value the user sets afterwards is then honored).
+    /// </summary>
+    public static Settings LoadSettingsWithDefaults(string json, out bool migrated)
+    {
+        migrated = false;
         var defaults = Settings.CreateDefaultSettings();
         if (string.IsNullOrWhiteSpace(json))
         {
@@ -26,6 +38,8 @@ internal static class WinPrintJson
             return DeserializeSettings(json) ?? defaults;
         }
 
+        migrated = MigrateLegacySettings(userObject);
+
         JsonNode? baseNode = JsonSerializer.SerializeToNode(defaults, WinPrintJsonSerializerContext.Default.Settings);
         if (baseNode is not JsonObject baseObject)
         {
@@ -34,6 +48,40 @@ internal static class WinPrintJson
 
         MergeObjects(baseObject, userObject);
         return DeserializeSettings(baseObject.ToJsonString()) ?? defaults;
+    }
+
+    /// <summary>
+    ///     One-shot fixups for settings documents written by versions before
+    ///     <see cref="Settings.CurrentSchemaVersion" /> (no <c>schemaVersion</c> field, or an older one).
+    ///     3.1.2–3.1.4 persisted the full settings document while <c>mermaidBackend</c> defaulted to
+    ///     <c>service</c>, so in such files that value records the old default, not a user opt-in
+    ///     (opting into the default wrote the same bytes); rewrite it to <c>builtin</c> so upgraded
+    ///     installs stop sending mermaid diagram source over the network (#265). Returns true for every
+    ///     pre-current document — even when nothing else changed — so the caller rewrites the file with
+    ///     the current stamp and a later hand-edit back to <c>service</c> sticks.
+    /// </summary>
+    private static bool MigrateLegacySettings(JsonObject userObject)
+    {
+        string? versionKey = FindPropertyKey(userObject, "schemaVersion");
+        if (versionKey is not null
+            && userObject[versionKey] is JsonValue versionValue
+            && versionValue.TryGetValue(out int schemaVersion)
+            && schemaVersion >= Settings.CurrentSchemaVersion)
+        {
+            return false;
+        }
+
+        if (FindPropertyKey(userObject, "markdownContentTypeEngineSettings") is { } markdownKey
+            && userObject[markdownKey] is JsonObject markdown
+            && FindPropertyKey(markdown, "mermaidBackend") is { } backendKey
+            && markdown[backendKey] is JsonValue backendValue
+            && backendValue.TryGetValue(out string? backend)
+            && string.Equals(backend, "service", StringComparison.OrdinalIgnoreCase))
+        {
+            markdown[backendKey] = "builtin";
+        }
+
+        return true;
     }
 
     public static Settings? DeserializeSettings(string json)

--- a/src/WinPrint.Core/Services/SettingsService.cs
+++ b/src/WinPrint.Core/Services/SettingsService.cs
@@ -142,7 +142,17 @@ public class SettingsService
     private Settings LoadSettings()
     {
         string json = File.ReadAllText(SettingsFileName);
-        return WinPrintJson.LoadSettingsWithDefaults(json);
+        Settings settings = WinPrintJson.LoadSettingsWithDefaults(json, out bool migrated);
+        if (migrated)
+        {
+            Log.Information(
+                "Settings file predates schema {schemaVersion}; migrating and rewriting {settingsFileName}.",
+                Settings.CurrentSchemaVersion, SettingsFileName);
+            // Preserve the watcher: SaveSettings with watchChanges=false would tear down an armed one.
+            SaveSettings(settings, watchChanges: _watcher is not null);
+        }
+
+        return settings;
     }
 
     /// <summary>

--- a/src/WinPrint.Core/WinPrint.Core.csproj
+++ b/src/WinPrint.Core/WinPrint.Core.csproj
@@ -85,7 +85,7 @@
              publishes the TUI and GUI into one directory; if the GUI publishes an older Markdig.dll
              after the TUI, `wp` fails during Terminal.Gui configuration startup. -->
         <PackageReference Include="Markdig" Version="1.3.2" />
-        <PackageReference Include="Mermaider" Version="0.8.0" />
+        <PackageReference Include="Mermaider" Version="0.9.0" />
         <PackageReference Include="Svg.Skia" Version="5.1.1" />
         <PackageReference Include="HtmlRenderer.Core.NetStandard2" Version="1.5.1.3" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />

--- a/testfiles/demo.md
+++ b/testfiles/demo.md
@@ -30,7 +30,7 @@ Here is a footnote, because BobAtk, the inventor of COM and my mentor, taught me
 
 ## Mermaid Diagrams
 
-The fenced block below prints as an actual diagram using the default `mermaid.ink` service (or the in-process `builtin` backend if configured); set `renderMermaidDiagrams` to `false` if you liked the code better. The promissory note, paid:
+The fenced block below prints as an actual diagram, rendered entirely in-process by default (or by the remote `mermaid.ink` service if you opt into the `service` backend); set `renderMermaidDiagrams` to `false` if you liked the code better. The promissory note, paid:
 
 ```mermaid
 graph LR

--- a/testfiles/mermaid.md
+++ b/testfiles/mermaid.md
@@ -2,26 +2,24 @@
 
 `demo.md` shows one diagram and calls it a day. This file is the **grand tour + stress test** for Mermaid rendering in WinPrint:
 
-*   Complex examples of **every diagram type the built-in renderer (Mermaider 0.8.0 + Svg.Skia) supports**.
+*   Complex examples of **every diagram type the built-in renderer (Mermaider 0.9.0 + Svg.Skia) supports** — which, as of 0.9.0, is every Mermaid diagram type except ZenUML, plus the Mermaider-only TreeView.
 *   Additional complexities, subgraphs, notes, styling, and edge cases for supported types.
-*   **Unsupported types** and syntax variants that the builtin cannot handle (they deliberately fall back to plain code blocks).
-*   Syntax that works in the full Mermaid spec but triggers parse limitations in Mermaider (e.g. `pie title ...` on the header line).
+*   Syntax variants that older Mermaider releases rejected (e.g. `pie title ...` on the header line) — kept as regression stress cases now that they parse.
+*   One deliberately **unsupported type** (ZenUML) that falls back to a plain code block.
 
 **Purpose**: stress the parsing/rendering pipeline, serve as a living benchmark (image count + visual output changes with Mermaider upgrades), and prove that the fallback chain *always* works cleanly. A fence that should render as an image produces exactly one `DrawnImage`; everything else produces source text in the output.
 
-The default backend is the remote `mermaid.ink` service (full Mermaid.js fidelity, sends diagram source). All valid fences should render as images by default.
-
-To use the private in-process renderer instead (no data leaves the machine, but fewer types + some syntax restrictions):
+The default backend is the private in-process `builtin` renderer (Mermaider): no data leaves the machine. To use the remote `mermaid.ink` service instead (full Mermaid.js fidelity, sends diagram source):
 
 ```json
 "markdownContentTypeEngineSettings": {
-    "mermaidBackend": "builtin"
+    "mermaidBackend": "service"
 }
 ```
 
 (You can also set `renderMermaidDiagrams: false` to disable Mermaid rendering entirely and always show source code blocks.)
 
-If a section below prints as source instead of a picture under the default backend, that is the documented fallback doing its job (or a deliberate syntax stress case). Know which before filing a bug.
+If a section below prints as source instead of a picture under the default backend, that is the documented fallback doing its job (or a deliberate stress case). Know which before filing a bug.
 
 ## Supported by builtin (Mermaider)
 
@@ -64,7 +62,7 @@ sequenceDiagram
     opt when using service backend
         R-->>W: PNG (full Mermaid.js via mermaid.ink)
     end
-    Note over W,R: builtin = private + fast<br/>service = broadest compatibility
+    Note over W,R: builtin = private + fast<br/>service = full Mermaid.js
     W-->>U: pages
 ```
 
@@ -173,8 +171,6 @@ quadrantChart
 
 ### Pie (header on its own line)
 
-The builtin renderer is particular about pie headers. Use this form for builtin.
-
 ```mermaid
 pie
     title Where the ink goes
@@ -217,42 +213,7 @@ venn-beta
     union TUI,GUI["WinPrint"]
 ```
 
-## Syntax stress cases (builtin limitations even on "supported" types)
-
-These use valid Mermaid syntax that the service backend (and official mermaid.js) accepts, but that the current Mermaider detector + parsers reject. They prove that fallback works even for types the library claims to support.
-
-### Pie with title on the same line as the keyword (very common form)
-
-```mermaid
-pie title Where the ink goes (compact header form)
-    "Diagrams" : 30
-    "Code blocks" : 45
-    "Regret" : 25
-```
-
-### Quadrant with title on header line
-
-```mermaid
-quadrantChart title Features by effort (compact)
-    x-axis Low effort --> High effort
-    y-axis Low glory --> High glory
-    quadrant-1 Do
-    Mermaid: [0.8, 0.9]
-```
-
-### Timeline with title on header line
-
-```mermaid
-timeline title The long road (compact)
-    1998 : WinSpit ships
-    2026 : Mermaid too
-```
-
-## Unsupported diagram types + advanced features (fallback with builtin)
-
-The following diagram types (or rich examples of them) are not implemented in Mermaider 0.8.0. With `mermaidBackend: "builtin"` they render as source code blocks. They are excellent for proving the fallback path and for comparing output between the two backends. (With the default service backend they should all render as images.)
-
-### Gantt (classic unsupported)
+### Gantt
 
 ```mermaid
 gantt
@@ -377,47 +338,115 @@ architecture-beta
     api:B --> disk:T
 ```
 
+### TreeView (beta, Mermaider extension)
+
+Not a Mermaid.js type (the service backend falls back for this one); Mermaider renders
+file-system-style trees from indentation or box-drawing characters.
+
+```mermaid
+treeView-beta
+    winprint/
+        src/
+            WinPrint.Core/
+            WinPrint.TUI/
+        testfiles/
+            mermaid.md
+        README.md
+```
+
+## Syntax stress cases (former builtin limitations, now regression guards)
+
+Mermaider releases before 0.9.0 rejected these very common header forms even though official
+mermaid.js accepts them; they used to prove the fallback path. As of 0.9.0 they parse and render.
+They stay here so a regression in title-on-header-line parsing shows up as a changed image count.
+
+### Pie with title on the same line as the keyword (very common form)
+
+```mermaid
+pie title Where the ink goes (compact header form)
+    "Diagrams" : 30
+    "Code blocks" : 45
+    "Regret" : 25
+```
+
+### Quadrant with title on header line
+
+```mermaid
+quadrantChart title Features by effort (compact)
+    x-axis Low effort --> High effort
+    y-axis Low glory --> High glory
+    quadrant-1 Do
+    Mermaid: [0.8, 0.9]
+```
+
+### Timeline with title on header line
+
+```mermaid
+timeline title The long road (compact)
+    1998 : WinSpit ships
+    2026 : Mermaid too
+```
+
+## Unsupported diagram types (fallback with builtin)
+
+As of Mermaider 0.9.0 exactly one Mermaid.js diagram type is not implemented: ZenUML. With
+`mermaidBackend: "builtin"` it renders as a source code block — the proof that the fallback
+chain still works. (mermaid.ink needs a ZenUML plugin server-side, so even the service backend
+may fall back on this one.)
+
+### ZenUML
+
+```mermaid
+zenuml
+    title Order Service
+    @Actor Client
+    Client->OrderService.create() {
+        return ok
+    }
+```
+
 ---
 
 **End of file.** The exact number of images you see depends on the active backend:
 
-*   Default (see code): service backend → all fences that are valid Mermaid should produce images.
-*   `mermaidBackend: "builtin"` → only the 13 types listed under "Supported by builtin", using compatible syntax.
+*   Default (`builtin`, Mermaider): 27 images — every fence above except ZenUML.
+*   `mermaidBackend: "service"` (mermaid.ink / full Mermaid.js): everything except TreeView (not a Mermaid.js type) and possibly ZenUML (plugin-dependent).
 
-The unit test `MermaiderRendererTests.MermaidShowcase_RendersSupportedTypes_FallsBackForTheRest` asserts 13 images when forcing the builtin path.
+The unit test `MermaiderRendererTests.MermaidShowcase_RendersSupportedTypes_FallsBackForTheRest` asserts 27 images on the builtin path.
 
 ## Mermaid Backend Support Matrix
 
-| Diagram Type          | Keyword(s)                          | Builtin (Mermaider 0.8.0)                          | Service (mermaid.ink / full Mermaid.js) | Notes / Caveats |
-|-----------------------|-------------------------------------|----------------------------------------------------|-----------------------------------------|-----------------|
-| Flowchart             | `flowchart` / `graph` (+ LR/TB/...) | Yes (incl. subgraphs, many shapes)                | Yes (full)                             | Best supported in builtin. |
-| Sequence              | `sequenceDiagram`                   | Yes (alt, opt, notes, participants, etc.)         | Yes (full)                             | Good coverage. |
-| State                 | `stateDiagram` / `stateDiagram-v2`  | Yes                                               | Yes                                    | — |
-| Class                 | `classDiagram`                      | Yes                                               | Yes                                    | — |
-| ER / Entity-Rel       | `erDiagram`                         | Yes                                               | Yes                                    | — |
-| Git Graph             | `gitGraph`                          | Yes                                               | Yes                                    | — |
-| Mindmap               | `mindmap`                           | Yes                                               | Yes                                    | — |
-| Pie                   | `pie` (+ optional `showData`)       | Yes **only if header on own line** (`pie\n title ...`) | Yes (full, including `pie title Foo` on same line) | Major syntax caveat in builtin. Common form falls back. |
-| Quadrant Chart        | `quadrantChart`                     | Yes **only if header on own line**                | Yes (full)                             | Same title-on-header limitation as pie. |
-| Timeline              | `timeline`                          | Yes **only if header on own line**                | Yes                                    | Same limitation. |
-| Radar                 | `radar` / `radar-beta`              | Yes                                               | Yes                                    | — |
-| Treemap               | `treemap` / `treemap-beta`          | Yes                                               | Yes                                    | — |
-| Venn                  | `venn` / `venn-beta`                | Yes                                               | Yes                                    | — |
-| Gantt                 | `gantt`                             | No                                                | Yes                                    | Classic fallback example. |
-| XY Chart              | `xychart` / `xychart-beta`          | No                                                | Yes                                    | — |
-| Sankey                | `sankey` / `sankey-beta`            | No                                                | Yes                                    | — |
-| User Journey          | `journey`                           | No                                                | Yes                                    | — |
-| Requirement           | `requirementDiagram` / `requirement`| No                                                | Yes                                    | — |
-| C4                    | `C4Context`, `C4Container`, ...     | No                                                | Yes                                    | — |
-| Kanban                | `kanban`                            | No                                                | Yes                                    | — |
-| Block                 | `block-beta`                        | No                                                | Yes                                    | — |
-| Packet                | `packet-beta`                       | No                                                | Yes                                    | — |
-| Architecture          | `architecture-beta`                 | No                                                | Yes (newer)                            | — |
-| Others (Wardley, etc.)| various                             | No                                                | Yes (when Mermaid.js supports)         | — |
+| Diagram Type          | Keyword(s)                          | Builtin (Mermaider 0.9.0)                | Service (mermaid.ink / full Mermaid.js) | Notes / Caveats |
+|-----------------------|-------------------------------------|------------------------------------------|-----------------------------------------|-----------------|
+| Flowchart             | `flowchart` / `graph` (+ LR/TB/...) | Yes (incl. subgraphs, many shapes)       | Yes (full)                             | — |
+| Sequence              | `sequenceDiagram`                   | Yes (alt, opt, notes, participants, etc.)| Yes (full)                             | — |
+| State                 | `stateDiagram` / `stateDiagram-v2`  | Yes                                      | Yes                                    | — |
+| Class                 | `classDiagram`                      | Yes                                      | Yes                                    | — |
+| ER / Entity-Rel       | `erDiagram`                         | Yes                                      | Yes                                    | — |
+| Git Graph             | `gitGraph`                          | Yes                                      | Yes                                    | — |
+| Mindmap               | `mindmap`                           | Yes                                      | Yes                                    | — |
+| Pie                   | `pie` (+ optional `showData`)       | Yes (incl. `pie title Foo` on one line)  | Yes                                    | Title-on-header-line parsed since 0.9.0. |
+| Quadrant Chart        | `quadrantChart`                     | Yes (incl. title on header line)         | Yes                                    | — |
+| Timeline              | `timeline`                          | Yes (incl. title on header line)         | Yes                                    | — |
+| Radar                 | `radar` / `radar-beta`              | Yes                                      | Yes                                    | — |
+| Treemap               | `treemap` / `treemap-beta`          | Yes                                      | Yes                                    | — |
+| Venn                  | `venn` / `venn-beta`                | Yes                                      | Yes                                    | — |
+| Gantt                 | `gantt`                             | Yes (since 0.9.0)                        | Yes                                    | — |
+| XY Chart              | `xychart` / `xychart-beta`          | Yes (since 0.9.0)                        | Yes                                    | — |
+| Sankey                | `sankey` / `sankey-beta`            | Yes (since 0.9.0)                        | Yes                                    | — |
+| User Journey          | `journey`                           | Yes (since 0.9.0)                        | Yes                                    | — |
+| Requirement           | `requirementDiagram` / `requirement`| Yes (since 0.9.0)                        | Yes                                    | — |
+| C4                    | `C4Context`, `C4Container`, ...     | Yes (since 0.9.0)                        | Yes                                    | — |
+| Kanban                | `kanban`                            | Yes (since 0.9.0)                        | Yes                                    | — |
+| Block                 | `block-beta`                        | Yes (since 0.9.0)                        | Yes                                    | — |
+| Packet                | `packet-beta`                       | Yes (since 0.9.0)                        | Yes                                    | — |
+| Architecture          | `architecture-beta`                 | Yes (since 0.9.0)                        | Yes (newer)                            | — |
+| TreeView              | `treeView-beta`                     | Yes (Mermaider extension)                | No (not a Mermaid.js type)             | Builtin-only. |
+| ZenUML                | `zenuml`                            | No                                       | Plugin-dependent                       | The one remaining fallback example. |
 
 **Key takeaways:**
-- Builtin currently implements the 13 types in Mermaider's `DiagramType` enum.
-- Even for supported types there are syntax limitations (title placement for pie/quadrant/timeline).
-- Service backend = (near) full fidelity to current Mermaid.js.
+- Builtin implements the 23 types in Mermaider's `DiagramType` enum — every Mermaid.js type except ZenUML, plus TreeView.
+- The old title-placement limitations for pie/quadrant/timeline are gone as of 0.9.0.
+- Service backend = (near) full fidelity to current Mermaid.js, at the cost of sending diagram source over the network.
 - WinPrint always falls back to a plain code block on any failure from either renderer. A typo in `mermaidBackend` safely falls back to builtin (never accidentally sends data).
 - `mermaid.md` + its unit test act as the living spec, benchmark, and proof that fallback works.

--- a/tests/WinPrint.Core.UnitTests/Cte/MarkdownMermaidRenderingTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Cte/MarkdownMermaidRenderingTests.cs
@@ -246,16 +246,16 @@ public class MarkdownMermaidRenderingTests
     }
 
     [Fact]
-    public void Defaults_RenderOn_ServiceBackend()
+    public void Defaults_RenderOn_BuiltinBackend()
     {
-        // The shipped defaults: fences render using the remote mermaid.ink service.
-        // (A typo/unknown value in MermaidBackend safely falls back to the builtin renderer
-        // instead of sending data over the network.)
+        // The shipped defaults: fences render in-process via Mermaider; nothing leaves the
+        // machine unless the user opts into the service backend. (A typo/unknown value in
+        // MermaidBackend also safely falls back to the builtin renderer.)
         var cte = new MarkdownCte();
 
         Assert.True(cte.RenderMermaidDiagrams);
-        Assert.Equal("service", cte.MermaidBackend);
-        Assert.IsType<MermaidInkRenderer>(cte.ResolveMermaidRenderer());
+        Assert.Equal("builtin", cte.MermaidBackend);
+        Assert.IsType<MermaiderRenderer>(cte.ResolveMermaidRenderer());
     }
 
     [Theory]
@@ -285,11 +285,10 @@ public class MarkdownMermaidRenderingTests
     [Fact]
     public async Task DefaultPipeline_RendersFenceViaBuiltinRenderer()
     {
-        // End to end using the builtin backend explicitly (Mermaider parse/layout ->
+        // End to end on the shipped defaults (builtin backend: Mermaider parse/layout ->
         // CSS-var inlining -> Svg.Skia raster). This exercises the in-process path and is
-        // safe for offline CI. (The shipped default backend is the remote service.)
+        // safe for offline CI.
         MarkdownCte cte = MakeCte(new RecordingGraphicsContext());
-        cte.MermaidBackend = "builtin";
 
         RecordingGraphicsContext paint = await RenderAndPaintAsync(cte, MermaidDoc);
 

--- a/tests/WinPrint.Core.UnitTests/Cte/MermaiderRendererTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Cte/MermaiderRendererTests.cs
@@ -56,10 +56,11 @@ public class MermaiderRendererTests
     [Fact]
     public async Task MermaidShowcase_RendersSupportedTypes_FallsBackForTheRest()
     {
-        // testfiles/mermaid.md is the grand tour + stress test. This run forces the
-        // `builtin` backend to exercise Mermaider + the fallback logic (13 images for
-        // supported types, code blocks for the rest). Useful as a benchmark for Mermaider
-        // upgrades and to prove fallback. (The application default backend is now "service".)
+        // testfiles/mermaid.md is the grand tour + stress test: every diagram type Mermaider
+        // 0.9.0 supports (all of Mermaid.js except ZenUML, plus TreeView) renders as an image
+        // on the builtin backend (the shipped default); the deliberately unsupported ZenUML
+        // fence falls back to a code block. Useful as a benchmark for Mermaider upgrades and
+        // to prove fallback.
         string path = FindTestFile("mermaid.md");
         var cte = new MarkdownCte
         {
@@ -70,8 +71,7 @@ public class MermaiderRendererTests
             },
             MeasurementContext = new RecordingGraphicsContext(),
             PageSize = new System.Drawing.SizeF(600, 3000),
-            SourceFileName = path,
-            MermaidBackend = "builtin" // Force the Mermaider path for this builtin-specific test
+            SourceFileName = path
         };
 
         Assert.True(await cte.SetDocumentAsync(await File.ReadAllTextAsync(path)));
@@ -84,11 +84,14 @@ public class MermaiderRendererTests
             cte.PaintPage(paint, p);
         }
 
-        Assert.Equal(13, paint.DrawnImages.Count);
-        // Multiple unsupported fences (and syntax variants) must have fallen back to source text.
-        Assert.Contains(paint.DrawnStrings, s => s.Text.Contains("gantt", StringComparison.Ordinal));
-        Assert.Contains(paint.DrawnStrings, s => s.Text.Contains("xychart", StringComparison.OrdinalIgnoreCase));
-        Assert.Contains(paint.DrawnStrings, s => s.Text.Contains("sankey", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(27, paint.DrawnImages.Count);
+        // The one unsupported fence (ZenUML) must have fallen back to source text — and the
+        // formerly-unsupported types must NOT appear as source. (Match on strings that only
+        // exist inside fence bodies — the prose and the support-matrix table repeat the
+        // diagram keywords, so keyword matches would false-positive.)
+        Assert.Contains(paint.DrawnStrings, s => s.Text.Contains("OrderService.create()", StringComparison.Ordinal));
+        Assert.DoesNotContain(paint.DrawnStrings, s => s.Text.Contains("bar [500,", StringComparison.Ordinal));
+        Assert.DoesNotContain(paint.DrawnStrings, s => s.Text.Contains("A, B, 10", StringComparison.Ordinal));
     }
 
     private static string FindTestFile(string name)

--- a/tests/WinPrint.Core.UnitTests/Serialization/WinPrintJsonMigrationTests.cs
+++ b/tests/WinPrint.Core.UnitTests/Serialization/WinPrintJsonMigrationTests.cs
@@ -1,0 +1,138 @@
+using WinPrint.Core.Models;
+using WinPrint.Core.Services;
+using Xunit;
+
+namespace WinPrint.Core.UnitTests.Serialization;
+
+/// <summary>
+///     Tests for the one-shot settings migration (issue #265 review feedback): configs written by
+///     3.1.2–3.1.4 persisted the then-default <c>mermaidBackend: "service"</c>, which must not keep
+///     upgraded installs on the network backend — while a <c>service</c> the user chooses on a
+///     current (stamped) config must be honored.
+/// </summary>
+public class WinPrintJsonMigrationTests
+{
+    [Fact]
+    public void ReadSettings_LegacyServiceBackend_MigratesToBuiltinAndStampsFile()
+    {
+        string settingsFileName = $"WinPrint.{GetType().Name}.LegacyService.json";
+        File.WriteAllText(settingsFileName, """
+                                            {
+                                              "markdownContentTypeEngineSettings": {
+                                                "mermaidBackend": "service"
+                                              }
+                                            }
+                                            """);
+
+        try
+        {
+            var settingsService = new SettingsService { SettingsFileName = settingsFileName };
+
+            Settings? settings = settingsService.ReadSettings();
+
+            Assert.NotNull(settings);
+            Assert.Equal("builtin", settings.MarkdownContentTypeEngineSettings.MermaidBackend);
+
+            // The file was rewritten with the current stamp and the migrated value, so the
+            // migration runs exactly once.
+            string rewritten = File.ReadAllText(settingsFileName);
+            Assert.Contains($"\"schemaVersion\": {Settings.CurrentSchemaVersion}", rewritten);
+            Assert.DoesNotContain("\"service\"", rewritten);
+        }
+        finally
+        {
+            File.Delete(settingsFileName);
+        }
+    }
+
+    [Fact]
+    public void ReadSettings_StampedServiceBackend_IsHonored()
+    {
+        string settingsFileName = $"WinPrint.{GetType().Name}.StampedService.json";
+        string original = $$"""
+                            {
+                              "schemaVersion": {{Settings.CurrentSchemaVersion}},
+                              "markdownContentTypeEngineSettings": {
+                                "mermaidBackend": "service"
+                              }
+                            }
+                            """;
+        File.WriteAllText(settingsFileName, original);
+
+        try
+        {
+            var settingsService = new SettingsService { SettingsFileName = settingsFileName };
+
+            Settings? settings = settingsService.ReadSettings();
+
+            Assert.NotNull(settings);
+            Assert.Equal("service", settings.MarkdownContentTypeEngineSettings.MermaidBackend);
+            // A current-schema file is a deliberate configuration: it is not rewritten.
+            Assert.Equal(original, File.ReadAllText(settingsFileName));
+        }
+        finally
+        {
+            File.Delete(settingsFileName);
+        }
+    }
+
+    [Fact]
+    public void ReadSettings_LegacyBuiltinBackend_KeptButFileStamped()
+    {
+        // A legacy opt-in to builtin is preserved — and the file still gets stamped, so a later
+        // hand-edit to "service" is honored instead of re-migrated.
+        string settingsFileName = $"WinPrint.{GetType().Name}.LegacyBuiltin.json";
+        File.WriteAllText(settingsFileName, """
+                                            {
+                                              "markdownContentTypeEngineSettings": {
+                                                "mermaidBackend": "builtin"
+                                              }
+                                            }
+                                            """);
+
+        try
+        {
+            var settingsService = new SettingsService { SettingsFileName = settingsFileName };
+
+            Settings? settings = settingsService.ReadSettings();
+
+            Assert.NotNull(settings);
+            Assert.Equal("builtin", settings.MarkdownContentTypeEngineSettings.MermaidBackend);
+            Assert.Contains($"\"schemaVersion\": {Settings.CurrentSchemaVersion}",
+                File.ReadAllText(settingsFileName));
+        }
+        finally
+        {
+            File.Delete(settingsFileName);
+        }
+    }
+
+    [Fact]
+    public void ReadSettings_LegacyPascalCaseServiceBackend_Migrates()
+    {
+        // 3.1.x accepted hand-edited PascalCase keys (the merge is case-insensitive); the
+        // migration must match them the same way.
+        string settingsFileName = $"WinPrint.{GetType().Name}.PascalCase.json";
+        File.WriteAllText(settingsFileName, """
+                                            {
+                                              "MarkdownContentTypeEngineSettings": {
+                                                "MermaidBackend": "SERVICE"
+                                              }
+                                            }
+                                            """);
+
+        try
+        {
+            var settingsService = new SettingsService { SettingsFileName = settingsFileName };
+
+            Settings? settings = settingsService.ReadSettings();
+
+            Assert.NotNull(settings);
+            Assert.Equal("builtin", settings.MarkdownContentTypeEngineSettings.MermaidBackend);
+        }
+        finally
+        {
+            File.Delete(settingsFileName);
+        }
+    }
+}


### PR DESCRIPTION
Closes #265.

## What

Upstream [nullean/mermaider](https://github.com/nullean/mermaider) adopted the PRs adding every remaining diagram type (integration PR nullean/mermaider#36, architecture-beta #38, treeView-beta #39, and the `pie title ...` header-line fix #15). Mermaider now covers **every Mermaid diagram type except ZenUML**, plus a Mermaider-only TreeView. With full coverage, the reason #239 flipped the default to the remote service is gone, so:

- **`Mermaider` 0.8.0 → 0.9.0** in `WinPrint.Core`.
- **`mermaidBackend` defaults to `builtin`** again (in-process, nothing leaves the machine); `service` (mermaid.ink) stays as opt-in. Re-lands the in-process-by-default decision from #238.
- **`testfiles/mermaid.md`** reorganized: the ten formerly-unsupported types move under "Supported by builtin"; the pie/quadrant/timeline title-on-header stress cases stay as regression guards (they render now); new **TreeView** section (builtin-only) and a **ZenUML** section (the one remaining unsupported type) keep the fallback path proven. Support matrix rewritten.
- Showcase test now asserts **27 images** on the builtin default, with ZenUML falling back to a code block; default-backend unit tests flipped.
- Docs updated: README, docs/index, users-guide, hero-gif docs, demo.md, AGENTS.md/CLAUDE.md.

## Release status

This PR was opened as a draft because Mermaider 0.9.0 was not yet on nuget.org. **Upstream has since tagged and published 0.9.0** (`Mermaider` and `Sugiyama` both indexed), so the PR is now ready:

- The locally built shadow packages were purged from the NuGet cache and everything was re-verified against the **real nuget.org 0.9.0** (release commit `5d271e4`, which added strict-mode validation and a MonoFont option beyond the `58dfdc0` snapshot originally tested).
- CI was re-run after the release and is green across all jobs (build-and-test, all five AOT publish legs, MAUI UI tests, CodeQL).

## Verification

Against the published `Mermaider 0.9.0` (and earlier against a package built from upstream main):

- All **27 fences** in `mermaid.md` (26 pre-existing + TreeView) render through the real `MermaiderRenderer` path (Mermaider parse/layout → CSS-var inlining → Svg.Skia raster → PNG); ZenUML fails with `MermaidParseException` and falls back cleanly to a code block.
- All **22 mermaid unit tests pass**; the full suite's failure set is **byte-identical** to unmodified `develop` on this Mac (131 pre-existing `libgdiplus` environment failures — the GDI+ path is covered by Windows CI).
- `scripts/verify-style.sh` clean on both touched projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZRHmBWDSuArRQ4S9LJLR6
